### PR TITLE
Make WH adverbs ADV/advmod in questions, but SCONJ/mark as subordinators

### DIFF
--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -279,7 +279,7 @@
 9	against	against	ADP	IN	_	11	case	11:case	_
 10	US	US	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	troops	troops	NOUN	NN	Number=Sing	7	obl	7:obl:against	_
-12	when	when	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
+12	when	when	SCONJ	WRB	_	15	mark	15:mark	_
 13	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 14	briefly	briefly	ADV	RB	_	15	advmod	15:advmod	_
 15	arrested	arrest	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
@@ -2598,7 +2598,7 @@
 3	of	of	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	lab	lab	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
-6	were	where	SCONJ	WRB	Mood=Ind|Tense=Past|Typo=Yes|VerbForm=Fin	10	mark	10:mark	_
+6	were	where	SCONJ	WRB	PronType=Rel|Typo=Yes	10	mark	10:mark	_
 7	uranium	uranium	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	being	be	AUX	VBG	VerbForm=Ger	10	aux:pass	10:aux:pass	_
@@ -6231,7 +6231,7 @@
 13	who	who	PRON	WP	PronType=Int	18	parataxis	18:parataxis	_
 14	when	when	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	where	where	ADV	WRB	PronType=Int	14	conj	14:conj:and|20:mark	_
+16	where	where	SCONJ	WRB	PronType=Int	14	conj	14:conj:and|20:mark	_
 17	direct	direct	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	access	access	NOUN	NN	Number=Sing	20	nsubj	20:nsubj	_
 19	can	can	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
@@ -8012,7 +8012,7 @@
 2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	SpaceAfter=No
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	realize	realize	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
+5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
 6	much	much	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
 8	stuff	stuff	NOUN	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -279,7 +279,7 @@
 9	against	against	ADP	IN	_	11	case	11:case	_
 10	US	US	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	troops	troops	NOUN	NN	Number=Sing	7	obl	7:obl:against	_
-12	when	when	ADV	WRB	PronType=Int	15	mark	15:mark	_
+12	when	when	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
 13	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 14	briefly	briefly	ADV	RB	_	15	advmod	15:advmod	_
 15	arrested	arrest	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
@@ -452,7 +452,7 @@
 8	all	all	ADV	RB	_	2	obl	2:obl:after	SpaceAfter=No
 9	,	,	PUNCT	,	_	2	punct	2:punct	_
 10	so	so	ADV	RB	_	28	advmod	28:advmod	_
-11	when	when	ADV	WRB	PronType=Int	13	mark	13:mark	_
+11	when	when	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 13	hear	hear	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	28	advcl	28:advcl:when	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
@@ -1323,7 +1323,7 @@
 6	money	money	NOUN	NN	Number=Sing	5	obj	5:obj	_
 7	branching	branch	VERB	VBG	VerbForm=Ger	5	advcl	5:advcl	_
 8	out	out	ADP	RP	_	7	compound:prt	7:compound:prt	_
-9	when	when	ADV	WRB	PronType=Int	15	mark	15:mark	_
+9	when	when	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
 10	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	appeal	appeal	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
@@ -1415,7 +1415,7 @@
 # newpar id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-p0001
 # text = Remember when a whole lot of people had to die because a Swedish newspaper printed those cartoons of the Prophet Mohammed?
 1	Remember	remember	VERB	VB	VerbForm=Inf	0	root	0:root	_
-2	when	when	ADV	WRB	PronType=Int	8	mark	8:mark	_
+2	when	when	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	whole	whole	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|10:nsubj:xsubj	_
@@ -1723,7 +1723,7 @@
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	prove	prove	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	just	just	ADV	RB	_	12	advmod	12:advmod	_
-11	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
+11	how	how	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 12	fanatic	fanatic	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 14	extremist	extremist	NOUN	NN	Number=Sing	15	compound	15:compound	_
@@ -1733,7 +1733,7 @@
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0013
 # text = When they saw a cartoon of their prophet, people had to die.
-1	When	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 3	saw	see	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:when	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
@@ -1750,7 +1750,7 @@
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0014
 # text = When their precious cartoons are released I highly doubt it will look like the end of the world.
-1	When	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 2	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 3	precious	precious	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	cartoons	cartoon	NOUN	NNS	Number=Plur	6	nsubj:pass	6:nsubj:pass	_
@@ -2598,7 +2598,7 @@
 3	of	of	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	lab	lab	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
-6	were	where	ADV	WRB	Mood=Ind|Tense=Past|Typo=Yes|VerbForm=Fin	10	advmod	10:advmod	_
+6	were	where	SCONJ	WRB	Mood=Ind|Tense=Past|Typo=Yes|VerbForm=Fin	10	mark	10:mark	_
 7	uranium	uranium	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	being	be	AUX	VBG	VerbForm=Ger	10	aux:pass	10:aux:pass	_
@@ -2832,7 +2832,7 @@
 7	year	year	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	_
 8	in	in	ADP	IN	_	9	case	9:case	_
 9	Asia	Asia	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
-10	when	when	ADV	WRB	PronType=Rel	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Rel	12	mark	12:mark	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	evacuated	evacuate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 13	U.S.	U.S.	PROPN	NNP	Number=Sing	14	compound	14:compound	_
@@ -3250,7 +3250,7 @@
 5	of	of	SCONJ	IN	_	6	case	6:case	_
 6	what	what	PRON	WP	PronType=Int	4	nmod	4:nmod:of	_
 7	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
-8	when	when	ADV	WRB	PronType=Int	10	mark	10:mark	_
+8	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	Bush	Bush	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
 10	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -4865,7 +4865,7 @@
 7	Defense	Defense	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
 8	only	only	ADV	RB	_	9	advmod	9:advmod	_
 9	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-10	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
+10	how	how	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	blow	blow	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
 13	things	thing	NOUN	NNS	Number=Plur	12	obj	12:obj	_
@@ -5229,7 +5229,7 @@
 4	of	of	ADV	RB	_	13	advmod	13:advmod	_
 5	course	course	ADV	RB	_	4	fixed	4:fixed	SpaceAfter=No
 6	,	,	PUNCT	,	_	13	punct	13:punct	_
-7	when	when	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
+7	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	Z	z	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
 9	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	csubj	13:csubj	_
 10	after	after	ADP	IN	_	11	case	11:case	_
@@ -5812,7 +5812,7 @@
 6	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 7	remarking	remark	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 8	on	on	SCONJ	IN	_	10	mark	10:mark	_
-9	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
+9	how	how	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 10	agreeable	agreeable	ADJ	JJ	Degree=Pos	7	advcl	7:advcl:on	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 12	all	all	DET	DT	_	11	det	11:det	_
@@ -6185,7 +6185,7 @@
 16	having	have	VERB	VBG	VerbForm=Ger	14	acl	14:acl:of	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	justify	justify	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
-19	why	why	ADV	WRB	PronType=Int	27	advmod	27:advmod	_
+19	why	why	SCONJ	WRB	PronType=Int	27	mark	27:mark	_
 20	each	each	DET	DT	_	23	compound	23:compound	_
 21	and	and	CCONJ	CC	_	22	cc	22:cc	_
 22	every	every	DET	DT	_	20	conj	20:conj:and|23:compound	_
@@ -6204,7 +6204,7 @@
 35	general	general	ADJ	JJ	Degree=Pos	36	amod	36:amod	_
 36	rule	rule	NOUN	NN	Number=Sing	33	obj	33:obj	_
 37	concerning	concern	VERB	VBG	VerbForm=Ger	42	mark	42:mark	_
-38	how	how	ADV	WRB	PronType=Int	42	advmod	42:advmod	_
+38	how	how	SCONJ	WRB	PronType=Int	42	mark	42:mark	_
 39	direct	direct	ADJ	JJ	Degree=Pos	40	amod	40:amod	_
 40	access	access	NOUN	NN	Number=Sing	42	nsubj	42:nsubj	_
 41	should	should	AUX	MD	VerbForm=Fin	42	aux	42:aux	_
@@ -6229,7 +6229,7 @@
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	control	control	VERB	VB	VerbForm=Inf	10	acl	10:acl:to	_
 13	who	who	PRON	WP	PronType=Int	18	parataxis	18:parataxis	_
-14	when	when	ADV	WRB	PronType=Int	20	mark	20:mark	_
+14	when	when	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	where	where	ADV	WRB	PronType=Int	14	conj	14:conj:and|20:mark	_
 17	direct	direct	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
@@ -6251,7 +6251,7 @@
 # text = Power be where power lies.
 1	Power	power	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
 2	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
-3	where	where	ADV	WRB	PronType=Int	5	mark	5:mark	_
+3	where	where	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	power	power	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 5	lies	lie	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:where	SpaceAfter=No
 6	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -6501,7 +6501,7 @@
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
 2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	_
-4	when	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 6	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:when	_
 7	over	over	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
@@ -8012,7 +8012,7 @@
 2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	SpaceAfter=No
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	realize	realize	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 6	much	much	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
 8	stuff	stuff	NOUN	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No
@@ -8398,7 +8398,7 @@
 # sent_id = email-enronsent01_01-0022
 # newpar id = email-enronsent01_01-p0009
 # text = How to Pledge:
-1	How	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	How	how	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	to	to	PART	TO	_	3	mark	3:mark	_
 3	Pledge	pledge	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 4	:	:	PUNCT	:	_	3	punct	3:punct	_
@@ -8832,7 +8832,7 @@
 20	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	16	ccomp	16:ccomp	_
 21	back	back	ADV	RB	_	20	advmod	20:advmod	_
 22	but	but	CCONJ	CC	_	27	cc	27:cc	_
-23	when	when	ADV	WRB	PronType=Int	25	mark	25:mark	_
+23	when	when	SCONJ	WRB	PronType=Int	25	mark	25:mark	_
 24	opportunity	opportunity	NOUN	NN	Number=Sing	25	nsubj	25:nsubj	_
 25	knocks	knock	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	advcl	27:advcl:when	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
@@ -10562,7 +10562,7 @@
 2	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj|4:nsubj:xsubj	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
 8	like	like	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
@@ -11497,7 +11497,7 @@
 
 # sent_id = email-enronsent19_02-0033
 # text = When we start the summer process, we will interview the candidate and slot him for your group.
-1	When	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 3	start	start	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:when	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -12285,7 +12285,7 @@
 16	value	value	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	calculate	calculate	VERB	VB	VerbForm=Inf	14	conj	12:xcomp|14:conj:and	_
-19	how	how	ADV	WRB	PronType=Int	20	advmod	20:advmod	_
+19	how	how	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 20	many	many	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	shares	share	NOUN	NNS	Number=Plur	18	obj	18:obj	SpaceAfter=No
 22	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -12393,7 +12393,7 @@
 1	Let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj|3:nsubj:xsubj	_
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
-4	when	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 6	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
@@ -13642,7 +13642,7 @@
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 22	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	conj	18:conj	_
-23	how	how	ADV	WRB	PronType=Int	24	advmod	24:advmod	_
+23	how	how	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 24	hard	hard	ADJ	JJ	Degree=Pos	22	ccomp	22:ccomp	_
 25	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	expl	24:expl	_
 26	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
@@ -13708,7 +13708,7 @@
 9	to	to	ADP	IN	_	11	case	11:case	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	site	site	NOUN	NN	Number=Sing	8	obl	8:obl:to	_
-12	where	where	ADV	WRB	PronType=Rel	15	advmod	15:advmod	_
+12	where	where	SCONJ	WRB	PronType=Rel	15	mark	15:mark	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
 14	can	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 15	hear	hear	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
@@ -14012,7 +14012,7 @@
 5	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	play	play	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
-8	when	when	ADV	WRB	PronType=Int	10	mark	10:mark	_
+8	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 10	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 11	to	to	PART	TO	_	10	xcomp	10:xcomp	SpaceAfter=No
@@ -14210,7 +14210,7 @@
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	protest	protest	NOUN	NN	Number=Sing	8	obl	8:obl:in	_
 17	at	at	SCONJ	IN	_	23	mark	23:mark	_
-18	how	how	ADV	WRB	PronType=Int	23	advmod	23:advmod	_
+18	how	how	SCONJ	WRB	PronType=Int	23	mark	23:mark	_
 19	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	20	nmod:poss	20:nmod:poss	_
 20	trial	trial	NOUN	NN	Number=Sing	23	nsubj:pass	23:nsubj:pass	_
 21	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
@@ -14972,7 +14972,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	lingerie	lingerie	NOUN	NN	Number=Sing	6	obl	6:obl:in	SpaceAfter=No
 9	,	,	PUNCT	,	_	2	punct	2:punct	_
-10	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
 13	home	home	ADV	RB	_	12	advmod	12:advmod	_
@@ -16083,7 +16083,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 11	present	present	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	day	day	NOUN	NN	Number=Sing	8	obl	8:obl:at	_
-13	when	when	ADV	WRB	PronType=Rel	19	advmod	19:advmod	_
+13	when	when	SCONJ	WRB	PronType=Rel	19	mark	19:mark	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	village	village	NOUN	NN	Number=Sing	16	compound	16:compound	_
 16	people	people	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
@@ -16598,7 +16598,7 @@
 8	Gulf	Gulf	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
 10	Mexico	Mexico	PROPN	NNP	Number=Sing	8	nmod	8:nmod:of	_
-11	where	where	ADV	WRB	PronType=Rel	21	advmod	21:advmod	_
+11	where	where	SCONJ	WRB	PronType=Rel	21	mark	21:mark	_
 12	about	about	ADV	RB	_	15	advmod	15:advmod	_
 13	one	one	NUM	CD	NumType=Card	15	compound	15:compound	SpaceAfter=No
 14	-	-	PUNCT	HYPH	_	15	punct	15:punct	SpaceAfter=No
@@ -17045,7 +17045,7 @@
 # text = But seeing how the private sector has been able to successfully transport civilians to the ISS (at about a fifth of the cost), it would come to no surprise if corporate America was able to out perform their bureaucratic friends in government.
 1	But	but	CCONJ	CC	_	29	cc	29:cc	_
 2	seeing	see	VERB	VBG	VerbForm=Ger	29	advcl	29:advcl	_
-3	how	how	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
+3	how	how	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	private	private	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	sector	sector	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|12:nsubj:xsubj	_
@@ -18786,7 +18786,7 @@
 # sent_id = answers-20111105145356AAtOJyP_ans-0005
 # newpar id = answers-20111105145356AAtOJyP_ans-p0003
 # text = when you turn 21 you can party any were you want
-1	when	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	when	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	turn	turn	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 4	21	21	NUM	CD	NumType=Card	3	obj	3:obj	_
@@ -19282,7 +19282,7 @@
 11	to	to	ADP	IN	_	12	case	12:case	_
 12	France	France	PROPN	NNP	Number=Sing	3	obl	3:obl:to	_
 13	and	and	CCONJ	CC	_	19	cc	19:cc	_
-14	where	where	ADV	WRB	PronType=Int	15	advmod	15:advmod	_
+14	where	where	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
 15	about	about	ADV	RB	_	19	advmod	19:advmod	_
 16	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux:pass	19:aux:pass	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
@@ -20328,7 +20328,7 @@
 # newpar id = answers-20111107173224AA22AwU_ans-p0005
 # text = depends where u are going.
 1	depends	depend	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-2	where	where	ADV	WRB	PronType=Int	5	mark	5:mark	_
+2	where	where	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 3	u	u	PRON	PRP	_	5	nsubj	5:nsubj	_
 4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	1	advcl	1:advcl:where	SpaceAfter=No
@@ -20374,7 +20374,7 @@
 4	please	please	INTJ	UH	_	5	discourse	5:discourse	_
 5	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	5	obj	5:obj	_
-7	where	where	ADV	WRB	PronType=Int	10	mark	10:mark	_
+7	where	where	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 8	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 10	buy	buy	VERB	VB	VerbForm=Inf	5	advcl	5:advcl:where	_
@@ -21211,7 +21211,7 @@
 4	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	know	know	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
-7	why	why	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
+7	why	why	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	YOU	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|11:nsubj:xsubj	_
 9	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
@@ -21230,7 +21230,7 @@
 4	list	list	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	reasons	reason	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of	_
-7	why	why	ADV	WRB	PronType=Rel	9	advmod	9:advmod	_
+7	why	why	SCONJ	WRB	PronType=Rel	9	mark	9:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 9	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -21367,7 +21367,7 @@
 8	n't	not	PART	RB	_	10	advmod	10:advmod	_
 9	really	really	ADV	RB	_	10	advmod	10:advmod	_
 10	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-11	where	where	ADV	WRB	PronType=Int	13	advmod	13:advmod	_
+11	where	where	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 13	cheap	cheap	ADJ	JJ	Degree=Pos	10	ccomp	10:ccomp	SpaceAfter=No
 14	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -22067,7 +22067,7 @@
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	tell	tell	VERB	VB	VerbForm=Inf	5	conj	5:conj:and	_
 10	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	9	obj	9:obj	_
-11	how	how	ADV	WRB	PronType=Int	13	advmod	13:advmod	_
+11	how	how	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
 13	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
 
@@ -22237,7 +22237,7 @@
 19	now	now	ADV	RB	_	20	advmod	20:advmod	_
 20	installing	install	VERB	VBG	Tense=Pres|VerbForm=Part	13	parataxis	13:parataxis	_
 21	some	some	DET	DT	_	20	obj	20:obj	_
-22	where	where	ADV	WRB	PronType=Rel	26	advmod	26:advmod	_
+22	where	where	SCONJ	WRB	PronType=Rel	26	mark	26:mark	_
 23	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj|28:nsubj:xsubj	SpaceAfter=No
 24	'll	will	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	26	cop	26:cop	_
@@ -22392,7 +22392,7 @@
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	do	do	VERB	VB	VerbForm=Inf	27	acl	27:acl:to	_
 30	with	with	SCONJ	IN	_	33	mark	33:mark	_
-31	how	how	ADV	WRB	PronType=Int	33	advmod	33:advmod	_
+31	how	how	SCONJ	WRB	PronType=Int	33	mark	33:mark	_
 32	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
 33	treat	treat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	29	advcl	29:advcl:with	_
 34	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	33	obj	33:obj	SpaceAfter=No
@@ -22560,7 +22560,7 @@
 4	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	an	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	island	island	NOUN	NN	Number=Sing	4	obj	4:obj	_
-7	where	where	ADV	WRB	PronType=Rel	10	advmod	10:advmod	_
+7	where	where	SCONJ	WRB	PronType=Rel	10	mark	10:mark	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 10	do	do	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
@@ -22695,7 +22695,7 @@
 7	,	,	PUNCT	,	_	6	punct	6:punct	_
 8	www.igourmet.com	www.igourmet.com	X	ADD	_	6	appos	6:appos	SpaceAfter=No
 9	,	,	PUNCT	,	_	6	punct	6:punct	_
-10	where	where	ADV	WRB	PronType=Rel	12	advmod	12:advmod	_
+10	where	where	SCONJ	WRB	PronType=Rel	12	mark	12:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 12	sell	sell	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 13	all	all	DET	DT	_	14	det	14:det	_
@@ -23130,7 +23130,7 @@
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	report	report	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	on	on	SCONJ	IN	_	12	mark	12:mark	_
-7	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
+7	how	how	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 8	afghanistan	afghanistan	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj|14:nsubj	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	Vietam	Vietam	PROPN	NNP	Number=Sing	8	conj	8:conj:and|12:nsubj	_
@@ -23166,7 +23166,7 @@
 2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|10:nsubj	_
 7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 8	different	different	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
@@ -23348,7 +23348,7 @@
 
 # sent_id = answers-20111108105146AAtiEx7_ans-0004
 # text = When she was a tiny little kitten she looked like those twinky snack cakes.
-1	When	when	ADV	WRB	PronType=Int	7	mark	7:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 2	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -23450,7 +23450,7 @@
 17	attacked	attack	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:bc	_
 18	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 19	feet	foot	NOUN	NNS	Number=Plur	17	obj	17:obj	_
-20	when	when	ADV	WRB	PronType=Int	22	mark	22:mark	_
+20	when	when	SCONJ	WRB	PronType=Int	22	mark	22:mark	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj	_
 22	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	advcl	17:advcl:when	_
 23	by	by	ADV	RB	_	22	advmod	22:advmod	SpaceAfter=No
@@ -23499,7 +23499,7 @@
 2	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	when	when	ADV	WRB	PronType=Int	11	mark	11:mark	_
+5	when	when	SCONJ	WRB	PronType=Int	11	mark	11:mark	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 7	veiled	veiled	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 8	chameleon	chameleon	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -23526,7 +23526,7 @@
 13	eggs	egg	NOUN	NNS	Number=Plur	10	nmod	10:nmod:of	_
 14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 15	soft	soft	ADJ	JJ	Degree=Pos	5	conj	5:conj:and	_
-16	when	when	ADV	WRB	PronType=Int	18	mark	18:mark	_
+16	when	when	SCONJ	WRB	PronType=Int	18	mark	18:mark	_
 17	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj|19:nsubj:xsubj	_
 18	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
 19	soft	soft	ADJ	JJ	Degree=Pos	18	xcomp	18:xcomp	_
@@ -25985,7 +25985,7 @@
 7	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 8	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	7:obj	_
 9	back	back	ADV	RB	_	7	advmod	7:advmod	_
-10	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	needed	need	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
 13	something	something	PRON	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No
@@ -26577,7 +26577,7 @@
 1	Be	be	AUX	VB	Mood=Imp|VerbForm=Fin	3	cop	3:cop	_
 2	more	more	ADV	RBR	_	3	advmod	3:advmod	_
 3	careful	careful	ADJ	JJ	Degree=Pos	0	root	0:root	_
-4	when	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 6	write	write	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	reviews	review	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
@@ -27728,7 +27728,7 @@
 # sent_id = reviews-202402-0002
 # newpar id = reviews-202402-p0002
 # text = When my server crashed, Greg worked from 7 PM until 4 AM and had my company up and running the next morning.
-1	When	when	ADV	WRB	PronType=Int	4	mark	4:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
 3	server	server	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
 4	crashed	crash	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	SpaceAfter=No
@@ -28622,7 +28622,7 @@
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
 6	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	exactly	exactly	ADV	RB	_	6	advmod	6:advmod	_
-8	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
+8	how	how	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	make	make	VERB	VB	VerbForm=Inf	6	ccomp	6:ccomp	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj|13:nsubj:xsubj	_
@@ -28948,7 +28948,7 @@
 12	very	very	ADV	RB	_	13	advmod	13:advmod	_
 13	impressed	impressed	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	_
 14	with	with	SCONJ	IN	_	16	case	16:case	_
-15	how	how	ADV	WRB	PronType=Int	16	advmod	16:advmod	_
+15	how	how	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 16	friendly	friendly	ADJ	JJ	Degree=Pos	13	obl	13:obl:with	_
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	polite	polite	ADJ	JJ	Degree=Pos	16	conj	13:obl:with|16:conj:and	_
@@ -30666,7 +30666,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
 3	there	there	ADV	RB	PronType=Dem	0	root	0:root	_
-4	when	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
 6	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
@@ -30918,7 +30918,7 @@
 11	new	new	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	things	thing	NOUN	NNS	Number=Plur	10	obj	10:obj	_
 13	on	on	SCONJ	IN	_	16	mark	16:mark	_
-14	how	how	ADV	WRB	PronType=Int	16	advmod	16:advmod	_
+14	how	how	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 15	to	to	PART	TO	_	16	mark	16:mark	_
 16	use	use	VERB	VB	VerbForm=Inf	12	acl	12:acl:to	_
 17	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
@@ -31034,7 +31034,7 @@
 6	positive	positive	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	20	punct	20:punct	_
 8	and	and	CCONJ	CC	_	20	cc	20:cc	_
-9	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+9	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 10	Alan	Alan	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj|14:nsubj:xsubj	SpaceAfter=No
 11	's	's	PART	POS	_	10	case	10:case	_
 12	refused	refuse	VERB	VBN	Tense=Past|VerbForm=Part	20	advcl	20:advcl:when	_
@@ -31248,7 +31248,7 @@
 # text = not sure how I feel about that one.
 1	not	not	PART	RB	_	2	advmod	2:advmod	_
 2	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
-3	how	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	about	about	ADP	IN	_	8	case	8:case	_
@@ -31620,7 +31620,7 @@
 3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	SpaceAfter=No
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
-6	when	when	ADV	WRB	PronType=Int	7	mark	7:mark	_
+6	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 7	promised	promise	VERB	VBN	Tense=Past|VerbForm=Part	5	advcl	5:advcl:when	_
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -31836,7 +31836,7 @@
 19	service	service	NOUN	NN	Number=Sing	14	obj	14:obj	_
 20	out	out	ADV	RB	_	21	advmod	21:advmod	_
 21	there	there	ADV	RB	PronType=Dem	14	advmod	14:advmod	_
-22	where	where	ADV	WRB	PronType=Int	24	mark	24:mark	_
+22	where	where	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 23	company	company	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	_
 24	care	care	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:where	_
 25	more	more	ADV	RBR	_	24	advmod	24:advmod	_
@@ -32044,7 +32044,7 @@
 19	$	$	SYM	$	_	2	conj	2:conj:and	SpaceAfter=No
 20	8.95	8.95	NUM	CD	NumType=Card	19	nummod	19:nummod	_
 21	but	but	CCONJ	CC	_	32	cc	32:cc	_
-22	when	when	ADV	WRB	PronType=Int	24	mark	24:mark	_
+22	when	when	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 24	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	32	advcl	32:advcl:when	_
 25	on	on	ADP	IN	_	26	case	26:case	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -699,7 +699,7 @@
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	embassy	embassy	NOUN	NN	Number=Sing	10	nmod	10:nmod:in	_
-14	when	when	ADV	WRB	PronType=Int	16	mark	16:mark	_
+14	when	when	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 16	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 17	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	obj	16:obj|18:nsubj:xsubj	_
@@ -1314,7 +1314,7 @@
 7	opinion	opinion	NOUN	NN	Number=Sing	4	nmod	4:nmod:from	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	dissents	dissent	NOUN	NNS	Number=Plur	7	conj	4:nmod:from|7:conj:and	_
-10	when	when	ADV	WRB	PronType=Int	13	mark	13:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	SpaceAfter=No
 12	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 13	finished	finished	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:when	SpaceAfter=No
@@ -1356,7 +1356,7 @@
 30	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 31	altar	altar	NOUN	NN	Number=Sing	26	parataxis	26:parataxis	SpaceAfter=No
 32	,	,	PUNCT	,	_	31	punct	31:punct	_
-33	where	where	ADV	WRB	PronType=Rel	42	advmod	42:advmod	_
+33	where	where	SCONJ	WRB	PronType=Rel	42	mark	42:mark	_
 34	of	of	ADV	RB	_	42	advmod	42:advmod	_
 35	course	course	ADV	RB	_	34	fixed	34:fixed	_
 36	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	37	nmod:poss	37:nmod:poss	_
@@ -1816,7 +1816,7 @@
 2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	market	market	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
 8	will	will	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -2046,7 +2046,7 @@
 39	inside	inside	ADP	IN	_	41	case	41:case	_
 40	of	of	ADP	IN	_	41	case	41:case	_
 41	Berkshire	Berkshire	PROPN	NNP	Number=Sing	34	xcomp	34:xcomp	_
-42	where	where	ADV	WRB	PronType=Rel	45	advmod	45:advmod	_
+42	where	where	SCONJ	WRB	PronType=Rel	45	mark	45:mark	_
 43	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	45	nsubj	45:nsubj	_
 44	will	will	AUX	MD	VerbForm=Fin	45	aux	45:aux	_
 45	compound	compound	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	SpaceAfter=No
@@ -2067,7 +2067,7 @@
 9	excellent	excellent	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	essay	essay	NOUN	NN	Number=Sing	7	obj	7:obj	_
 11	on	on	SCONJ	IN	_	28	mark	28:mark	_
-12	how	how	ADV	WRB	PronType=Int	28	advmod	28:advmod	_
+12	how	how	SCONJ	WRB	PronType=Int	28	mark	28:mark	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	MSM	MSM	PROPN	NNP	Number=Sing	28	nsubj	28:nsubj	_
 15	and	and	CCONJ	CC	_	17	cc	17:cc	_
@@ -2692,7 +2692,7 @@
 7	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 8	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|23:nsubj	_
 9	sinned	sin	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
-10	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 12	participated	participate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:when	_
 13	with	with	ADP	IN	_	15	case	15:case	_
@@ -4216,7 +4216,7 @@
 10	members	member	NOUN	NNS	Number=Plur	5	nmod	5:nmod:of	_
 11	in	in	ADP	IN	_	12	case	12:case	_
 12	Iraq	Iraq	PROPN	NNP	Number=Sing	10	nmod	10:nmod:in	_
-13	where	where	ADV	WRB	PronType=Rel	16	advmod	16:advmod	_
+13	where	where	SCONJ	WRB	PronType=Rel	16	mark	16:mark	_
 14	there	there	PRON	EX	_	16	expl	16:expl	_
 15	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
@@ -4498,7 +4498,7 @@
 4	czar	czar	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	Richard	Richard	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 6	Clarke	Clarke	PROPN	NNP	Number=Sing	5	flat	5:flat	_
-7	when	when	ADV	WRB	PronType=Int	10	mark	10:mark	_
+7	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	latter	latter	ADJ	JJ	Degree=Pos	10	nsubj	10:nsubj	_
 10	spoke	speak	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:when	_
@@ -4906,7 +4906,7 @@
 31	summer	summer	NOUN	NN	Number=Sing	25	obl	25:obl:in	_
 32	of	of	ADP	IN	_	33	case	33:case	_
 33	2001	2001	NUM	CD	NumType=Card	31	nmod	31:nmod:of	_
-34	when	when	ADV	WRB	PronType=Int	42	mark	42:mark	_
+34	when	when	SCONJ	WRB	PronType=Int	42	mark	42:mark	_
 35	George	George	PROPN	NNP	Number=Sing	38	nmod:poss	38:nmod:poss	_
 36	Tenet	Tenet	PROPN	NNP	Number=Sing	35	flat	35:flat	SpaceAfter=No
 37	's	's	PART	POS	_	35	case	35:case	_
@@ -5113,7 +5113,7 @@
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	figure	figure	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
-11	how	how	ADV	WRB	PronType=Int	21	advmod	21:advmod	SpaceAfter=No
+11	how	how	SCONJ	WRB	PronType=Int	21	mark	21:mark	SpaceAfter=No
 12	,	,	PUNCT	,	_	21	punct	21:punct	_
 13	in	in	ADP	IN	_	14	case	14:case	_
 14	fall	fall	NOUN	NN	Number=Sing	21	obl	21:obl:in	_
@@ -5207,7 +5207,7 @@
 # text = that is how i want you to refer to me as "the king"
 1	that	that	PRON	DT	Number=Sing|PronType=Dem	2	nsubj	2:nsubj	_
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	how	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	obj	5:obj|8:nsubj:xsubj	_
@@ -5723,7 +5723,7 @@
 3	buy	buy	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	iobj	3:iobj	_
 5	dinner	dinner	NOUN	NN	Number=Sing	3	obj	3:obj	_
-6	when	when	ADV	WRB	PronType=Int	8	mark	8:mark	_
+6	when	when	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 8	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 9	back	back	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
@@ -5831,7 +5831,7 @@
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 6	reliable	reliable	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
 7	that	that	PRON	DT	Number=Sing|PronType=Dem	6	nsubj	6:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	SpaceAfter=No
@@ -5936,7 +5936,7 @@
 2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	SpaceAfter=No
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 6	much	much	ADV	RB	_	9	advmod	9:advmod	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	will	will	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -5976,7 +5976,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	amazed	amazed	ADJ	JJ	Degree=Pos	0	root	0:root	_
-4	how	how	ADV	WRB	PronType=Int	7	advmod	7:advmod	_
+4	how	how	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	details	detail	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj|8:nsubj:xsubj	_
 7	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
@@ -5989,7 +5989,7 @@
 
 # sent_id = email-enronsent27_02-0011
 # text = When you discussed it, i was trying to think back to our remedies and discussions but the 3 years have made it difficult.
-1	When	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	SpaceAfter=No
@@ -6612,7 +6612,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	down	down	ADV	RB	_	0	root	0:root	_
 5	and	and	CCONJ	CC	_	14	cc	14:cc	_
-6	when	when	ADV	WRB	PronType=Int	8	mark	8:mark	_
+6	when	when	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 7	enron	enron	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 8	collapses	collapse	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:when	SpaceAfter=No
 9	,	,	PUNCT	,	_	14	punct	14:punct	_
@@ -7647,7 +7647,7 @@
 # text = Please advise when you can meet to discuss issues related to your area.
 1	Please	please	INTJ	UH	_	2	discourse	2:discourse	_
 2	advise	advise	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
-3	when	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+3	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 5	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 6	meet	meet	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:when	_
@@ -8199,7 +8199,7 @@
 20	there	there	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
 21	with	with	ADP	IN	_	22	case	22:case	_
 22	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	8	obl	8:obl:with	_
-23	whenever	whenever	ADV	WRB	PronType=Int	28	advmod	28:advmod	_
+23	whenever	whenever	SCONJ	WRB	PronType=Int	28	mark	28:mark	_
 24	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	nsubj	28:nsubj	_
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	28:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
@@ -10033,7 +10033,7 @@
 39	go	go	VERB	VB	VerbForm=Inf	31	conj	29:csubj|31:conj:and	_
 40	to	to	ADP	IN	_	41	case	41:case	_
 41	dinner	dinner	NOUN	NN	Number=Sing	39	obl	39:obl:to	_
-42	where	where	ADV	WRB	PronType=Rel	46	advmod	46:advmod	_
+42	where	where	SCONJ	WRB	PronType=Rel	46	mark	46:mark	_
 43	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	46	nsubj	46:nsubj	_
 44	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	46	aux	46:aux	SpaceAfter=No
 45	n't	not	PART	RB	_	46	advmod	46:advmod	_
@@ -10567,7 +10567,7 @@
 # text = not sure how much longer ene is going to be around and i'm checking out my options!
 1	not	not	PART	RB	_	2	advmod	2:advmod	_
 2	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
-3	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+3	how	how	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 4	much	much	ADV	RB	_	8	advmod	8:advmod	_
 5	longer	longer	ADV	RBR	Degree=Cmp	4	advmod	4:advmod	_
 6	ene	ene	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|11:nsubj:xsubj	_
@@ -10720,7 +10720,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	form	form	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part	4	acl	4:acl	_
-6	when	when	ADV	WRB	PronType=Int	7	mark	7:mark	_
+6	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 7	preparing	prepare	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl:when	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 9	top	top	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -11581,7 +11581,7 @@
 11	2	2	NUM	CD	NumType=Card	9	conj	9:conj:or|12:nummod	_
 12	day	day	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	contract	contract	NOUN	NN	Number=Sing	5	obl	5:obl:with	_
-14	where	where	ADV	WRB	PronType=Rel	16	advmod	16:advmod	_
+14	where	where	SCONJ	WRB	PronType=Rel	16	mark	16:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|28:nsubj	_
 16	give	give	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	some	some	DET	DT	_	18	det	18:det	_
@@ -12223,7 +12223,7 @@
 11	be	be	AUX	VB	VerbForm=Inf	12	cop	12:cop	_
 12	key	key	ADJ	JJ	Degree=Pos	0	root	0:root	_
 13	to	to	SCONJ	IN	_	15	case	15:case	_
-14	how	how	ADV	WRB	PronType=Int	15	advmod	15:advmod	_
+14	how	how	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
 15	worthy	worthy	ADJ	JJ	Degree=Pos	12	obl	12:obl:to	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	effort	effort	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	_
@@ -12724,7 +12724,7 @@
 10	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	not	not	PART	RB	_	12	advmod	12:advmod	_
 12	sure	sure	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
-13	why	why	ADV	WRB	PronType=Int	17	advmod	17:advmod	_
+13	why	why	SCONJ	WRB	PronType=Int	17	mark	17:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
 15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	SpaceAfter=No
 16	n't	not	PART	RB	_	17	advmod	17:advmod	_
@@ -13641,7 +13641,7 @@
 
 # sent_id = newsgroup-groups.google.com_GayNews_0f9e221229ed0ee5_ENG_20050307_110600-0004
 # text = When Baptist Pastor Stephen Jones talks about what makes for a happy marriage with Janice, his wife of 35 years, one special ingredient might surprise you: Double-dating with coupled friends who happen to be gay.
-1	When	when	ADV	WRB	PronType=Int	6	mark	6:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 2	Baptist	baptist	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	Pastor	pastor	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	Stephen	Stephen	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
@@ -14850,7 +14850,7 @@
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 8	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	-	-	PUNCT	,	_	1	punct	1:punct	_
-10	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 12	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:when	_
 13	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	12	obj	12:obj	SpaceAfter=No
@@ -16268,7 +16268,7 @@
 16	-	-	PUNCT	,	_	11	punct	11:punct	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	place	place	NOUN	NN	Number=Sing	11	appos	11:appos	_
-19	where	where	ADV	WRB	PronType=Rel	22	advmod	22:advmod	_
+19	where	where	SCONJ	WRB	PronType=Rel	22	mark	22:mark	_
 20	people	people	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
 22	exchange	exchange	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	_
@@ -16486,7 +16486,7 @@
 21	in	in	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	street	street	NOUN	NN	Number=Sing	20	obl	20:obl:in	_
-24	when	when	ADV	WRB	PronType=Int	27	mark	27:mark	_
+24	when	when	SCONJ	WRB	PronType=Int	27	mark	27:mark	_
 25	a	a	DET	DT	Definite=Ind|PronType=Art	26	det	26:det	_
 26	car	car	NOUN	NN	Number=Sing	27	nsubj	27:nsubj|30:nsubj	_
 27	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	advcl	20:advcl:when	_
@@ -18784,7 +18784,7 @@
 3	at	at	ADP	IN	_	5	case	5:case	_
 4	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	best	best	ADJ	JJS	Degree=Sup	2	obl	2:obl:at	_
-6	when	when	ADV	WRB	PronType=Int	9	mark	9:mark	_
+6	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 7	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	doing	do	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl:when	_
@@ -19093,7 +19093,7 @@
 6	bacon	bacon	NOUN	NN	Number=Sing	5	obj	5:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	sausage	sausage	NOUN	NN	Number=Sing	6	conj	5:obj|6:conj:and	_
-9	when	when	ADV	WRB	PronType=Int	11	mark	11:mark	_
+9	when	when	SCONJ	WRB	PronType=Int	11	mark	11:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 11	having	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
@@ -19283,7 +19283,7 @@
 16	out	out	ADV	RB	_	13	advmod	13:advmod	_
 17	for	for	ADP	IN	_	18	case	18:case	_
 18	dinner	dinner	NOUN	NN	Number=Sing	13	obl	13:obl:for	_
-19	where	where	ADV	WRB	PronType=Rel	21	advmod	21:advmod	_
+19	where	where	SCONJ	WRB	PronType=Rel	21	mark	21:mark	_
 20	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
 21	play	play	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 22	music	music	NOUN	NN	Number=Sing	21	obj	21:obj	_
@@ -19887,7 +19887,7 @@
 7	rough	rough	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	estimate	estimate	NOUN	NN	Number=Sing	5	obj	5:obj	_
 9	of	of	SCONJ	IN	_	13	mark	13:mark	_
-10	how	how	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
+10	how	how	SCONJ	WRB	PronType=Int	11	mark	11:mark	_
 11	much	much	ADJ	JJ	Degree=Pos	13	advmod	13:advmod	_
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 13	costs	cost	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl	8:acl:of	_
@@ -20003,7 +20003,7 @@
 19	not	not	ADV	RB	_	23	cc	23:cc	_
 20	to	to	PART	TO	_	19	fixed	19:fixed	_
 21	mention	mention	VERB	VB	VerbForm=Inf	19	fixed	19:fixed	_
-22	how	how	ADV	WRB	PronType=Int	23	advmod	23:advmod	_
+22	how	how	SCONJ	WRB	PronType=Int	23	mark	23:mark	_
 23	good	good	ADJ	JJ	Degree=Pos	2	conj	2:conj:and	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	support	support	NOUN	NN	Number=Sing	23	nsubj	23:nsubj	_
@@ -21064,7 +21064,7 @@
 # text = Come see how we continue this tradition."
 1	Come	come	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
-3	how	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	continue	continue	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
@@ -21098,12 +21098,12 @@
 
 # sent_id = answers-20081218053636AA9vV0u_ans-0006
 # text = Why certain slogans work and why some don't.
-1	Why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Why	why	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	certain	certain	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	slogans	slogan	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 4	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
-6	why	why	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+6	why	why	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 7	some	some	DET	DT	_	8	nsubj	8:nsubj	_
 8	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	SpaceAfter=No
 9	n't	not	PART	RB	_	8	advmod	8:advmod	SpaceAfter=No
@@ -21430,7 +21430,7 @@
 # sent_id = answers-20111107164802AAq8nhF_ans-0004
 # newpar id = answers-20111107164802AAq8nhF_ans-p0003
 # text = When the French returned to Indochina at the end of WW II the Viet Minh were in control of the Red River Delta.
-1	When	when	ADV	WRB	PronType=Int	4	mark	4:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	French	French	PROPN	NNPS	Number=Plur	4	nsubj	4:nsubj	_
 4	returned	return	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:when	_
@@ -21980,7 +21980,7 @@
 14	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	just	just	ADV	RB	_	16	advmod	16:advmod	_
 16	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	3	conj	3:conj:and	_
-17	how	how	ADV	WRB	PronType=Int	18	advmod	18:advmod	_
+17	how	how	SCONJ	WRB	PronType=Int	18	mark	18:mark	_
 18	much	much	ADJ	JJ	Degree=Pos	21	advmod	21:advmod	_
 19	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
 20	would	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
@@ -22745,7 +22745,7 @@
 
 # sent_id = answers-20111108081911AAy6QeW_ans-0005
 # text = When you press the button to stop recording the data is moved from the buffer to the memory card - no pause.
-1	When	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	press	press	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:when	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
@@ -22806,7 +22806,7 @@
 # sent_id = answers-20110320195750AAkPbFG_ans-0002
 # newpar id = answers-20110320195750AAkPbFG_ans-p0002
 # text = When nacho is driving to cure the influenza guy does he say to the man with the cow i like your blouse or I like your cow because my friend thinks he says I like your blouse, but that wouldn't make sense.
-1	When	when	ADV	WRB	PronType=Int	4	mark	4:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	nacho	nacho	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	driving	drive	VERB	VBG	VerbForm=Ger	12	advcl	12:advcl:when	_
@@ -23800,7 +23800,7 @@
 11	food	food	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
 12	,	,	PUNCT	,	_	20	punct	20:punct	_
 13	and	and	CCONJ	CC	_	20	cc	20:cc	_
-14	when	when	ADV	WRB	PronType=Int	17	mark	17:mark	_
+14	when	when	SCONJ	WRB	PronType=Int	17	mark	17:mark	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	17:nsubj:pass	SpaceAfter=No
 16	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	17:aux:pass	_
 17	finished	finish	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	20	advcl	20:advcl:when	_
@@ -24092,7 +24092,7 @@
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	work	work	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	again	again	ADV	RB	_	6	advmod	6:advmod	_
-8	when	when	ADV	WRB	PronType=Int	10	mark	10:mark	_
+8	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	i	i	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|15:nsubj	_
 10	take	take	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:when	_
 11	out	out	ADP	RP	_	10	compound:prt	10:compound:prt	_
@@ -24537,7 +24537,7 @@
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 16	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	8	punct	8:punct	_
-18	whenever	whenever	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+18	whenever	whenever	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -25825,7 +25825,7 @@
 3	impossible	impossible	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	understand	understand	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
-6	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
+6	how	how	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	place	place	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
 9	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
@@ -27305,7 +27305,7 @@
 9	at	at	ADP	IN	_	11	case	11:case	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	time	time	NOUN	NN	Number=Sing	8	obl	8:obl:at	_
-12	when	when	ADV	WRB	PronType=Int	14	mark	14:mark	_
+12	when	when	SCONJ	WRB	PronType=Int	14	mark	14:mark	_
 13	there	there	PRON	EX	_	14	expl	14:expl	_
 14	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 15	very	very	ADV	RB	_	17	advmod	17:advmod	_
@@ -27876,7 +27876,7 @@
 4	always	always	ADV	RB	_	5	advmod	5:advmod	_
 5	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 6	through	through	ADP	RP	_	5	compound:prt	5:compound:prt	_
-7	when	when	ADV	WRB	PronType=Int	9	mark	9:mark	_
+7	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 9	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
 10	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj	SpaceAfter=No
@@ -28075,7 +28075,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
 2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	now	now	ADV	RB	_	2	advmod	2:advmod	_
-4	where	where	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+4	where	where	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	get	get	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
 7	all	all	DET	DT	_	6	obj	6:obj	_
@@ -28463,7 +28463,7 @@
 
 # sent_id = reviews-299169-0003
 # text = When I tried to return it they refused, so I had to leave without a refund and still hungry.
-1	When	when	ADV	WRB	PronType=Int	3	mark	3:mark	_
+1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 3	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
@@ -29374,7 +29374,7 @@
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	upset	upset	ADJ	JJ	Degree=Pos	0	root	0:root	_
-5	when	when	ADV	WRB	PronType=Int	7	mark	7:mark	_
+5	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 7	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:when	_
 8	to	to	ADP	IN	_	9	case	9:case	_
@@ -29662,7 +29662,7 @@
 12	behind	behind	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	bar	bar	NOUN	NN	Number=Sing	11	nmod	11:nmod:behind	_
-15	where	where	ADV	WRB	PronType=Rel	18	advmod	18:advmod	_
+15	where	where	SCONJ	WRB	PronType=Rel	18	mark	18:mark	_
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
 18	delete	delete	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
@@ -31318,7 +31318,7 @@
 2	seemed	seem	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	understand	understand	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 6	important	important	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	6:expl	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
@@ -31571,7 +31571,7 @@
 2	definitely	definitely	ADV	RB	_	3	advmod	3:advmod	_
 3	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	back	back	ADV	RB	_	3	advmod	3:advmod	_
-5	when	when	ADV	WRB	PronType=Int	7	mark	7:mark	_
+5	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 8	medical	medical	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -31890,10 +31890,10 @@
 21	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	23:aux	SpaceAfter=No
 22	n't	not	PART	RB	_	23	advmod	23:advmod	_
 23	know	know	VERB	VB	VerbForm=Inf	19	conj	17:acl:relcl|19:conj:and	_
-24	where	where	ADV	WRB	PronType=Int	26	advmod	26:advmod	_
+24	where	where	SCONJ	WRB	PronType=Int	26	mark	26:mark	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	start	start	VERB	VB	VerbForm=Inf	23	ccomp	23:ccomp	_
-27	when	when	ADV	WRB	PronType=Int	29	mark	29:mark	_
+27	when	when	SCONJ	WRB	PronType=Int	29	mark	29:mark	_
 28	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	nsubj	29:nsubj	_
 29	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	advcl	26:advcl:when	_
 30	to	to	SCONJ	IN	_	31	mark	31:mark	_
@@ -32264,7 +32264,7 @@
 11	all	all	ADV	RB	_	13	advmod	13:advmod	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	same	same	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
-14	when	when	ADV	WRB	PronType=Int	16	mark	16:mark	_
+14	when	when	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 16	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:when	_
 17	to	to	ADP	IN	_	18	case	18:case	_
@@ -32335,7 +32335,7 @@
 7	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	order	order	NOUN	NN	Number=Sing	7	obj	7:obj	_
-10	when	when	ADV	WRB	PronType=Int	12	mark	12:mark	_
+10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 12	walk	walk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 13	in	in	ADP	IN	_	15	case	15:case	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -12222,13 +12222,13 @@
 10	could	could	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 11	be	be	AUX	VB	VerbForm=Inf	12	cop	12:cop	_
 12	key	key	ADJ	JJ	Degree=Pos	0	root	0:root	_
-13	to	to	SCONJ	IN	_	15	case	15:case	_
-14	how	how	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
-15	worthy	worthy	ADJ	JJ	Degree=Pos	12	obl	12:obl:to	_
+13	to	to	SCONJ	IN	_	15	mark	15:mark	_
+14	how	how	ADV	WRB	PronType=Int	15	advmod	15:advmod	_
+15	worthy	worthy	ADJ	JJ	Degree=Pos	12	advcl	12:advcl:to	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
-17	effort	effort	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	_
-18	might	might	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
-19	be	be	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	SpaceAfter=No
+17	effort	effort	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
+18	might	might	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
+19	be	be	VERB	VB	VerbForm=Inf	15	cop	15:cop	SpaceAfter=No
 20	.	.	PUNCT	.	_	12	punct	12:punct	_
 
 # sent_id = email-enronsent18_02-0069


### PR DESCRIPTION
  * Fixes #88
  * Implemented using the following DepEdit script:

```
#no special adverbial status for WH adverb subordinations
lemma=/^(when|how|where|while|why|whenever|wherever)$/&func=/mark/&head=/(.*)/&pos=/ADV/	none	#1:pos=SCONJ
lemma=/^(when|how|where|while|why|whenever|wherever)$/&func=/advmod/&head=/(.*)/	none	#1:func=mark;#1:pos=SCONJ;#1:head2=$2:mark

#exception for WH adverbs in questions, identified by question mark and not being an advcl
func!=/advcl/;lemma=/^(when|how|where|while|why|whenever|wherever)$/&pos=/SCONJ/&func=/mark/&head=/(.*)/;text=/^(\?+)!?$/	#1>#2;#2.*#3	#2:func=advmod;#2:pos=ADV;#2:head2=$2:advmod

#exception for 'why not'
func=/root/;lemma=/why/&func=/mark/&head=/(.*)/;lemma=/not/\t#1>#2;#2.#3\t#2:func=advmod;#2:pos=ADV;#2:head2=$1:advmod

#exception for do support
func=/root/;lemma=/^(why|how|when|where)$/&func=/mark/&head=/(.*)/;lemma=/do/\t#1>#2;#2.#3\t#2:func=advmod;#2:pos=ADV;#2:head2=$2:advmod
```