### PR TITLE
fix new validation errors due to ADV/SCONJ changes in #90

### DIFF
--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -12228,7 +12228,7 @@
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	effort	effort	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 18	might	might	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-19	be	be	VERB	VB	VerbForm=Inf	15	cop	15:cop	SpaceAfter=No
+19	be	be	AUX	VB	VerbForm=Inf	15	cop	15:cop	SpaceAfter=No
 20	.	.	PUNCT	.	_	12	punct	12:punct	_
 
 # sent_id = email-enronsent18_02-0069
@@ -24537,9 +24537,9 @@
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 16	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	8	punct	8:punct	_
-18	whenever	whenever	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
+18	whenever	whenever	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	SpaceAfter=No
+20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:whenever	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111103205154AAOod9K_ans-0005

--- a/not-to-release/sources/answers/20111103205154AAOod9K_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111103205154AAOod9K_ans.xml.conllu
@@ -86,9 +86,9 @@
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 16	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	8	punct	8:punct	_
-18	whenever	whenever	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
+18	whenever	whenever	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	SpaceAfter=No
+20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:whenever	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111103205154AAOod9K_ans-0005

--- a/not-to-release/sources/email/enronsent18_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent18_02.xml.conllu
@@ -781,7 +781,7 @@
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	effort	effort	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 18	might	might	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-19	be	be	VERB	VB	VerbForm=Inf	15	cop	15:cop	SpaceAfter=No
+19	be	be	AUX	VB	VerbForm=Inf	15	cop	15:cop	SpaceAfter=No
 20	.	.	PUNCT	.	_	12	punct	12:punct	_
 
 # sent_id = email-enronsent18_02-0069

--- a/not-to-release/sources/reviews/044427.xml.conllu
+++ b/not-to-release/sources/reviews/044427.xml.conllu
@@ -50,9 +50,9 @@
 10	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	9	obj	9:obj|12:nsubj:xsubj	_
 11	very	very	ADV	RB	_	12	advmod	12:advmod	_
 12	helpful	helpful	ADJ	JJ	Degree=Pos	9	xcomp	9:xcomp	_
-13	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
+13	when	when	SCONJ	WRB	PronType=Int	15	mark	15:mark	_
 14	something	something	PRON	NN	Number=Sing	15	nsubj	15:nsubj|16:nsubj:xsubj	_
-15	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+15	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:when	_
 16	wrong	wrong	ADJ	JJ	Degree=Pos	15	xcomp	15:xcomp	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/reviews/063549.xml.conllu
+++ b/not-to-release/sources/reviews/063549.xml.conllu
@@ -18,7 +18,7 @@
 6	Frank	Frank	PROPN	NNP	Number=Sing	9	nsubj:pass	9:nsubj:pass|11:nsubj:xsubj	_
 7	mcclelland	mcclelland	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	named	name	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
+9	named	name	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 10	best	best	ADJ	JJS	Degree=Sup	11	amod	11:amod	_
 11	chef	chef	NOUN	NN	Number=Sing	9	xcomp	9:xcomp	_
 12	of	of	ADP	IN	_	16	case	16:case	_

--- a/not-to-release/sources/reviews/063549.xml.conllu
+++ b/not-to-release/sources/reviews/063549.xml.conllu
@@ -14,7 +14,7 @@
 2	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	reason	reason	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
-5	why	why	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
+5	why	why	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 6	Frank	Frank	PROPN	NNP	Number=Sing	9	nsubj:pass	9:nsubj:pass|11:nsubj:xsubj	_
 7	mcclelland	mcclelland	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux:pass	9:aux:pass	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20040823064025_ENG_20040823_064025.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20040823064025_ENG_20040823_064025.xml.conllu
@@ -2017,10 +2017,10 @@
 22	,	,	PUNCT	,	_	36	punct	36:punct	_
 23	and	and	CCONJ	CC	_	36	cc	36:cc	_
 24	how	how	SCONJ	WRB	PronType=Int	36	mark	36:mark	_
-25	whenever	whenever	SCONJ	WRB	PronType=Int	34	mark	34:mark	_
+25	whenever	whenever	SCONJ	WRB	PronType=Int	28	mark	28:mark	_
 26	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	28	nsubj:pass	28:nsubj:pass	_
 27	got	get	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	28	aux:pass	28:aux:pass	_
-28	pulled	pull	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	25	acl:relcl	25:acl:relcl	_
+28	pulled	pull	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	36	advcl	36:advcl:whenever	_
 29	over	over	ADV	RB	_	28	advmod	28:advmod	_
 30	for	for	ADP	IN	_	32	case	32:case	_
 31	erratic	erratic	ADJ	JJ	Degree=Pos	32	amod	32:amod	_


### PR DESCRIPTION
This is to fix issues that must be due to edge cases or errors in the original data not addressed by the DepEdit rules in #90. In particular, the `leaf-mark-case` errors occur in cases where "why/when/whenever/whatever" was analyzed as having a relative clause modifier and has now been changed to SCONJ.

Two issues of note:

weblog-juancole.com_juancole_20040823064025_ENG_20040823_064025-0086
"Mr. Bush would also sometimes tell stories about his days at Yale in New Haven, and **how whenever** he got pulled over for erratic driving, he was let go"

[his days at Yale in New Haven] is coordinated with [how [whenever he got pulled over for erratic driving], he was let go].
The validator is triggered by the relative clause analysis of "whenever + he got pulled over", which I will fix to match the SCONJ policy. But I am still not sure about the "how": should it remain conj(stories, let), mark(let, how/SCONJ)?

reviews-063549-0002: "Theres a reason why Frank mcclelland was named best chef of the north east reigon."

I can fix the validator error here, which is caused by the attachment of "why", but I am not sure of the relation between "reason" and "named", which is currently `acl:relcl`. In general, is the relative clause analysis appropriate for clauses licensed by "reason"? Searching the corpus for "reason" I see it is the typical analysis in examples such as "the main reason I wrote this post", "the primary reason we need these things", "the reason Senators Daschle and Leahy would have been targeted", "the only reason I would go to this particular QT", "the reason he transferred to the Alabama Air National Guard". But I wonder if it should be considered `acl` instead, because "reason" is not extracted from a core position of the embedded clause.
