### PR TITLE
Fixed phrases formerly tagged RB+RB

### DIFF
--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -362,8 +362,8 @@
 20	wrong	wrong	ADV	RB	_	19	xcomp	19:xcomp	SpaceAfter=No
 21	,	,	PUNCT	,	_	26	punct	26:punct	_
 22	or	or	CCONJ	CC	_	26	cc	26:cc	_
-23	at	at	ADV	RB	_	26	advmod	26:advmod	_
-24	least	least	ADV	RBS	Degree=Sup	23	fixed	23:fixed	_
+23	at	at	ADP	IN	_	26	advmod	26:advmod	_
+24	least	least	ADJ	JJS	Degree=Sup	23	fixed	23:fixed	_
 25	in	in	ADP	IN	_	26	case	26:case	_
 26	ways	way	NOUN	NNS	Number=Plur	20	conj	19:xcomp|20:conj:or|29:nsubj	_
 27	that	that	PRON	WDT	PronType=Rel	29	nsubj	26:ref	_
@@ -453,8 +453,8 @@
 4	Wall	Wall	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Street	Street	PROPN	NNP	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
 6	,	,	PUNCT	,	_	2	punct	2:punct	_
-7	after	after	ADV	IN	_	8	case	8:case	_
-8	all	all	ADV	RB	_	2	obl	2:obl:after	SpaceAfter=No
+7	after	after	ADP	IN	_	8	case	8:case	_
+8	all	all	DET	DT	_	2	obl	2:obl:after	SpaceAfter=No
 9	,	,	PUNCT	,	_	2	punct	2:punct	_
 10	so	so	ADV	RB	_	28	advmod	28:advmod	_
 11	when	when	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
@@ -2580,8 +2580,8 @@
 5	North	North	PROPN	NNP	Number=Sing	6	compound	6:compound	_
 6	Korea	Korea	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
 7	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
-8	at	at	ADV	RB	_	9	case	9:case	_
-9	least	least	ADV	RBS	Degree=Sup	11	nmod	11:nmod:at	_
+8	at	at	ADP	IN	_	9	case	9:case	_
+9	least	least	ADJ	JJS	Degree=Sup	11	nmod	11:nmod:at	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	couple	couple	NOUN	NN	Number=Sing	13	nummod	13:nummod	_
 12	nuclear	nuclear	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
@@ -2766,8 +2766,8 @@
 8	street	street	NOUN	NN	Number=Sing	2	obl	2:obl:to	SpaceAfter=No
 9	"	"	PUNCT	''	_	8	punct	8:punct	SpaceAfter=No
 10	,	,	PUNCT	,	_	2	punct	2:punct	_
-11	of	of	ADV	RB	_	2	advmod	2:advmod	_
-12	course	course	ADV	RB	_	11	fixed	11:fixed	SpaceAfter=No
+11	of	of	ADP	IN	_	2	advmod	2:advmod	_
+12	course	course	NOUN	NN	Number=Sing	11	fixed	11:fixed	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0007
@@ -3484,8 +3484,8 @@
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	there	there	PRON	EX	_	27	expl	27:expl	_
 27	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
-28	at	at	ADV	RB	_	29	case	29:case	_
-29	least	least	ADV	RBS	Degree=Sup	30	nmod	30:nmod:at	_
+28	at	at	ADP	IN	_	29	case	29:case	_
+29	least	least	ADJ	JJS	Degree=Sup	30	nmod	30:nmod:at	_
 30	two	two	NUM	CD	NumType=Card	32	nummod	32:nummod	_
 31	other	other	ADJ	JJ	Degree=Pos	32	amod	32:amod	_
 32	horsemen	horseman	NOUN	NNS	Number=Plur	27	nsubj	27:nsubj	_
@@ -5290,8 +5290,8 @@
 1	But	but	CCONJ	CC	_	13	cc	13:cc	_
 2	sometimes	sometimes	ADV	RB	_	13	advmod	13:advmod	SpaceAfter=No
 3	,	,	PUNCT	,	_	13	punct	13:punct	_
-4	of	of	ADV	RB	_	13	advmod	13:advmod	_
-5	course	course	ADV	RB	_	4	fixed	4:fixed	SpaceAfter=No
+4	of	of	ADP	IN	_	13	advmod	13:advmod	_
+5	course	course	NOUN	NN	Number=Sing	4	fixed	4:fixed	SpaceAfter=No
 6	,	,	PUNCT	,	_	13	punct	13:punct	_
 7	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	Z	z	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
@@ -18216,8 +18216,8 @@
 # text = Argentinian foods of course, LMAO.
 1	Argentinian	Argentinian	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	foods	food	NOUN	NNS	Number=Plur	0	root	0:root	_
-3	of	of	ADV	RB	_	2	discourse	2:discourse	_
-4	course	course	ADV	RB	_	3	fixed	3:fixed	SpaceAfter=No
+3	of	of	ADP	IN	_	2	discourse	2:discourse	_
+4	course	course	NOUN	NN	Number=Sing	3	fixed	3:fixed	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	2:punct	_
 6	LMAO	lmao	INTJ	UH	_	2	discourse	2:discourse	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -18409,8 +18409,8 @@
 8	not	not	PART	RB	_	9	advmod	9:advmod	_
 9	help	help	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
-11	at	at	ADV	RB	_	12	case	12:case	_
-12	all	all	ADV	RB	_	9	obl	9:obl:at	_
+11	at	at	ADP	IN	_	12	case	12:case	_
+12	all	all	DET	DT	_	9	obl	9:obl:at	_
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
 14	says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 15	what	what	PRON	WP	PronType=Int	14	obj	14:obj	_
@@ -23586,8 +23586,8 @@
 3	HAVE	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	cat	cat	NOUN	NN	Number=Sing	3	obj	3:obj	_
-6	of	of	ADV	RB	_	3	advmod	3:advmod	_
-7	course	course	ADV	RB	_	6	fixed	6:fixed	SpaceAfter=No
+6	of	of	ADP	IN	_	3	advmod	3:advmod	_
+7	course	course	NOUN	NN	Number=Sing	6	fixed	6:fixed	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108105146AAtiEx7_ans-0003
@@ -24319,8 +24319,8 @@
 6	bother	bother	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	with	with	ADP	IN	_	8	case	8:case	_
 8	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	6	obl	6:obl:with	_
-9	at	at	ADV	RB	_	10	case	10:case	_
-10	all	all	ADV	RB	_	6	obl	6:obl:at	SpaceAfter=No
+9	at	at	ADP	IN	_	10	case	10:case	_
+10	all	all	DET	DT	_	6	obl	6:obl:at	SpaceAfter=No
 11	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111107201700AAKdymq_ans-0009

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -142,8 +142,8 @@
 2	own	own	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	blogger	blogger	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	2	punct	2:punct	_
-5	of	of	ADV	RB	_	2	advmod	2:advmod	_
-6	course	course	ADV	RB	_	5	fixed	5:fixed	SpaceAfter=No
+5	of	of	ADP	IN	_	2	advmod	2:advmod	_
+6	course	course	NOUN	NN	Number=Sing	5	fixed	5:fixed	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_marketview_20050511222700_ENG_20050511_222700-0006
@@ -1376,8 +1376,8 @@
 31	altar	altar	NOUN	NN	Number=Sing	26	parataxis	26:parataxis	SpaceAfter=No
 32	,	,	PUNCT	,	_	31	punct	31:punct	_
 33	where	where	SCONJ	WRB	PronType=Rel	42	mark	42:mark	_
-34	of	of	ADV	RB	_	42	advmod	42:advmod	_
-35	course	course	ADV	RB	_	34	fixed	34:fixed	_
+34	of	of	ADP	IN	_	42	advmod	42:advmod	_
+35	course	course	NOUN	NN	Number=Sing	34	fixed	34:fixed	_
 36	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	37	nmod:poss	37:nmod:poss	_
 37	relationships	relationship	NOUN	NNS	Number=Plur	42	nsubj:pass	42:nsubj:pass|48:nsubj:pass	_
 38	should	should	AUX	MD	VerbForm=Fin	42	aux	42:aux	_
@@ -4446,8 +4446,8 @@
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0006
 # text = Of course Bush would have tried to stop 9/11 if he had known it was coming.
-1	Of	of	ADV	RB	_	6	advmod	6:advmod	_
-2	course	course	ADV	RB	_	1	fixed	1:fixed	_
+1	Of	of	ADP	IN	_	6	advmod	6:advmod	_
+2	course	course	NOUN	NN	Number=Sing	1	fixed	1:fixed	_
 3	Bush	Bush	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj|8:nsubj:xsubj	_
 4	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	have	have	AUX	VB	VerbForm=Inf	6	aux	6:aux	_
@@ -5190,8 +5190,8 @@
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0036
 # text = Of course, you could just go in by main force.
-1	Of	of	ADV	RB	_	7	advmod	7:advmod	_
-2	course	course	ADV	RB	_	1	fixed	1:fixed	SpaceAfter=No
+1	Of	of	ADP	IN	_	7	advmod	7:advmod	_
+2	course	course	NOUN	NN	Number=Sing	1	fixed	1:fixed	SpaceAfter=No
 3	,	,	PUNCT	,	_	7	punct	7:punct	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 5	could	could	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -9622,8 +9622,8 @@
 
 # sent_id = email-enronsent28_01-0017
 # text = Of course, that was the bottom
-1	Of	of	ADV	RB	_	7	advmod	7:advmod	_
-2	course	course	ADV	RB	_	1	fixed	1:fixed	SpaceAfter=No
+1	Of	of	ADP	IN	_	7	advmod	7:advmod	_
+2	course	course	NOUN	NN	Number=Sing	1	fixed	1:fixed	SpaceAfter=No
 3	,	,	PUNCT	,	_	7	punct	7:punct	_
 4	that	that	PRON	DT	Number=Sing|PronType=Dem	7	nsubj	7:nsubj	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
@@ -18787,8 +18787,8 @@
 2	there	there	PRON	EX	_	4	expl	4:expl	_
 3	must	must	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 4	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	at	at	ADV	RB	_	6	case	6:case	_
-6	least	least	ADV	RBS	Degree=Sup	7	nmod	7:nmod:at	_
+5	at	at	ADP	IN	_	6	case	6:case	_
+6	least	least	ADJ	JJS	Degree=Sup	7	nmod	7:nmod:at	_
 7	1	1	NUM	CD	NumType=Card	8	nummod	8:nummod	_
 8	korean	Korean	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	SpaceAfter=No
 9	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -19713,8 +19713,8 @@
 2	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	besides	besides	ADP	IN	_	4	case	4:case	_
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obl	2:obl:besides	_
-5	of	of	ADV	RB	_	2	discourse	2:discourse	_
-6	course	course	ADV	RB	_	5	fixed	5:fixed	SpaceAfter=No
+5	of	of	ADP	IN	_	2	discourse	2:discourse	_
+6	course	course	NOUN	NN	Number=Sing	5	fixed	5:fixed	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20090717130909AAPrVWu_ans-0003
@@ -21829,8 +21829,8 @@
 17	80's	80'	NOUN	NNS	Number=Plur	18	compound	18:compound	_
 18	F	F	PROPN	NNP	Number=Sing	10	obl	10:obl:in	_
 19	for	for	ADP	IN	_	25	case	25:case	_
-20	at	at	ADV	RB	_	25	advmod	25:advmod	_
-21	least	least	ADV	RBS	Degree=Sup	20	fixed	20:fixed	_
+20	at	at	ADP	IN	_	25	advmod	25:advmod	_
+21	least	least	ADJ	JJS	Degree=Sup	20	fixed	20:fixed	_
 22	10	10	NUM	CD	NumType=Card	25	nummod	25:nummod	_
 23	-	-	SYM	SYM	_	24	case	24:case	_
 24	12	12	NUM	CD	NumType=Card	22	nmod	22:nmod	_
@@ -24295,8 +24295,8 @@
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	money	money	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	and	and	CCONJ	CC	_	18	cc	18:cc	_
-15	of	of	ADV	RB	_	17	advmod	17:advmod	_
-16	course	course	ADV	RB	_	15	fixed	15:fixed	_
+15	of	of	ADP	IN	_	17	advmod	17:advmod	_
+16	course	course	NOUN	NN	Number=Sing	15	fixed	15:fixed	_
 17	free	free	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	time	time	NOUN	NN	Number=Sing	13	conj	11:obj|13:conj:and	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
@@ -28427,8 +28427,8 @@
 3	Corona	Corona	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	dryers	dryer	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
 5	remove	remove	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-6	at	at	ADV	RB	_	7	case	7:case	_
-7	least	least	ADV	RBS	Degree=Sup	8	obl	8:obl:at	_
+6	at	at	ADP	IN	_	7	case	7:case	_
+7	least	least	ADJ	JJS	Degree=Sup	8	obl	8:obl:at	_
 8	twice	twice	ADV	RB	NumType=Mult	9	advmod	9:advmod	_
 9	as	as	ADV	RB	_	10	advmod	10:advmod	_
 10	much	much	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -31397,8 +31397,8 @@
 5	with	with	ADP	IN	_	7	case	7:case	_
 6	no	no	DET	DT	_	7	det	7:det	_
 7	hassle	hassle	NOUN	NN	Number=Sing	4	obl	4:obl:with	_
-8	at	at	ADV	RB	_	9	case	9:case	_
-9	all	all	ADV	RB	_	7	nmod	7:nmod:at	_
+8	at	at	ADP	IN	_	9	case	9:case	_
+9	all	all	DET	DT	_	7	nmod	7:nmod:at	_
 10	and	and	CCONJ	CC	_	14	cc	14:cc	_
 11-12	I'm	_	_	_	_	_	_	_	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_


### PR DESCRIPTION
  * Now conforms to PTB and GUM POS tagging practices
  * Fixes #141
  * Cases changed:
    * at least/most
    * at all
    * after all
    * of course
    * in between
    * let alone