### PR TITLE
added missing Person and Number

### DIFF
--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -17,7 +17,7 @@
 2	Bush	Bush	PROPN	NNP	Number=Sing	1	flat	1:flat	_
 3	on	on	ADP	IN	_	4	case	4:case	_
 4	Tuesday	Tuesday	PROPN	NNP	Number=Sing	5	obl	5:obl:on	_
-5	nominated	nominate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	nominated	nominate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	two	two	NUM	CD	NumType=Card	7	nummod	7:nummod	_
 7	individuals	individual	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
@@ -36,7 +36,7 @@
 # sent_id = weblog-blogspot.com_nominations_20041117172713_ENG_20041117_172713-0003
 # text = Bush nominated Jennifer M. Anderson for a 15-year term as associate judge of the Superior Court of the District of Columbia, replacing Steffen W. Graae.
 1	Bush	Bush	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	nominated	nominate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	nominated	nominate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Jennifer	Jennifer	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 4	M.	M.	PROPN	NNP	Number=Sing	3	flat	3:flat	_
 5	Anderson	Anderson	PROPN	NNP	Number=Sing	3	flat	3:flat	_
@@ -73,7 +73,7 @@
 # text = Bush also nominated A. Noel Anketell Kramer for a 15-year term as associate judge of the District of Columbia Court of Appeals, replacing John Montague Steadman.
 1	Bush	Bush	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	nominated	nominate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	nominated	nominate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	A.	A.	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 5	Noel	Noel	PROPN	NNP	Number=Sing	4	flat	4:flat	_
 6	Anketell	Anketell	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -136,14 +136,14 @@
 7	and	and	CCONJ	CC	_	10	cc	10:cc	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	israelians	Israelian	PROPN	NNPS	Number=Plur	10	nsubj	10:nsubj	_
-10	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+10	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 11	all	all	DET	PDT	_	13	det:predet	13:det:predet	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	reasons	reason	NOUN	NNS	Number=Plur	10	obj	10:obj	SpaceAfter=No
 14	,	,	PUNCT	,	_	10	punct	10:punct	_
 15	since	since	SCONJ	IN	_	17	mark	17:mark	_
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
-17	founded	found	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:since	_
+17	founded	found	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:since	_
 18	and	and	CCONJ	CC	_	23	cc	23:cc	_
 19	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	23:nsubj	_
 20	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	cop	23:cop	_
@@ -156,7 +156,7 @@
 27	but	but	CCONJ	CC	_	29	cc	29:cc	_
 28	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	29	nsubj	29:nsubj	_
 29-30	didn't	_	_	_	_	_	_	_	SpaceAfter=No
-29	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
+29	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
 30	n't	not	PART	RB	_	29	advmod	29:advmod	_
 31	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -185,12 +185,12 @@
 # text = Nervous people make mistakes, so I suppose there will be a wave of succesfull arab attacks.
 1	Nervous	nervous	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	people	people	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	make	make	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	mistakes	mistake	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	3	punct	3:punct	_
 6	so	so	ADV	RB	_	8	advmod	8:advmod	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	suppose	suppose	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+8	suppose	suppose	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 9	there	there	PRON	EX	_	11	expl	11:expl	_
 10	will	will	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 11	be	be	VERB	VB	VerbForm=Inf	8	ccomp	8:ccomp	_
@@ -226,7 +226,7 @@
 6	Baqubah	Baqubah	PROPN	NNP	Number=Sing	4	nmod	4:nmod:of	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
 8	guerrillas	guerrilla	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
-9	detonated	detonate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	detonated	detonate	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 11	car	car	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	bomb	bomb	NOUN	NN	Number=Sing	9	obj	9:obj	_
@@ -244,7 +244,7 @@
 # text = The US lost yet another helicopter to hostile fire near Habbaniyah in the Sunni heartland, but this time the crew was safe.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	US	US	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	lost	lose	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	lost	lose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	yet	yet	ADV	RB	_	6	advmod	6:advmod	_
 5	another	another	DET	DT	_	6	det	6:det	_
 6	helicopter	helicopter	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -276,7 +276,7 @@
 4	hundreds	hundred	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	demonstrators	demonstrator	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of	_
-7	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	came	come	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	out	out	ADV	RB	_	7	advmod	7:advmod	_
 9	against	against	ADP	IN	_	11	case	11:case	_
 10	US	US	PROPN	NNP	Number=Sing	11	compound	11:compound	_
@@ -284,7 +284,7 @@
 12	when	when	SCONJ	WRB	_	15	mark	15:mark	_
 13	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 14	briefly	briefly	ADV	RB	_	15	advmod	15:advmod	_
-15	arrested	arrest	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
+15	arrested	arrest	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 17	yound	yound	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 18	newlywed	newlywed	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -295,12 +295,12 @@
 # text = (I hope that the US army got an enormous amount of information from her relatives, because otherwise this move was a bad, bad tradeoff).
 1	(	(	PUNCT	-LRB-	_	3	punct	3:punct	SpaceAfter=No
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	that	that	SCONJ	IN	_	8	mark	8:mark	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	US	US	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 7	army	army	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
-8	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+8	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 9	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	enormous	enormous	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	amount	amount	NOUN	NN	Number=Sing	8	obj	8:obj	_
@@ -328,7 +328,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	US	US	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	troops	troops	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	fired	fire	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	fired	fire	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	into	into	ADP	IN	_	8	case	8:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	hostile	hostile	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -367,7 +367,7 @@
 25	in	in	ADP	IN	_	26	case	26:case	_
 26	ways	way	NOUN	NNS	Number=Plur	20	conj	19:xcomp|20:conj:or|29:nsubj	_
 27	that	that	PRON	WDT	PronType=Rel	29	nsubj	26:ref	_
-28	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
+28	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
 29	bad	bad	ADJ	JJ	Degree=Pos	26	acl:relcl	26:acl:relcl	_
 30	for	for	ADP	IN	_	32	case	32:case	_
 31	US	US	PROPN	NNP	Number=Sing	32	compound	32:compound	_
@@ -408,7 +408,7 @@
 24	people	people	NOUN	NNS	Number=Plur	21	nmod	21:nmod:of|28:nsubj	_
 25	who	who	PRON	WP	PronType=Rel	28	nsubj	24:ref	_
 26-27	haven't	_	_	_	_	_	_	_	_
-26	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
+26	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
 27	n't	not	PART	RB	_	28	advmod	28:advmod	_
 28	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	24	acl:relcl	24:acl:relcl	_
 29	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	obj	28:obj	SpaceAfter=No
@@ -419,7 +419,7 @@
 1	Usually	usually	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	7	punct	7:punct	_
 3	these	this	PRON	DT	Number=Plur|PronType=Dem	7	nsubj	7:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 5	just	just	ADV	RB	_	7	advmod	7:advmod	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	chance	chance	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -434,7 +434,7 @@
 16	this	this	DET	DT	Number=Sing|PronType=Dem	17	det	17:det	_
 17	time	time	NOUN	NN	Number=Sing	21	obl:tmod	21:obl:tmod	_
 18	people	people	NOUN	NNS	Number=Plur	21	nsubj	21:nsubj	_
-19	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
+19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
 20	actually	actually	ADV	RB	_	21	advmod	21:advmod	_
 21	concerned	concerned	ADJ	JJ	Degree=Pos	7	conj	7:conj:but	_
 22	about	about	ADP	IN	_	26	case	26:case	_
@@ -448,7 +448,7 @@
 # sent_id = weblog-blogspot.com_marketview_20050210075500_ENG_20050210_075500-0003
 # text = They work on Wall Street, after all, so when they hear a company who's stated goals include "Don't be evil," they imagine a company who's eventually history will be "Don't be profitable."
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	on	on	ADP	IN	_	5	case	5:case	_
 4	Wall	Wall	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Street	Street	PROPN	NNP	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
@@ -459,13 +459,13 @@
 10	so	so	ADV	RB	_	28	advmod	28:advmod	_
 11	when	when	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-13	hear	hear	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	28	advcl	28:advcl:when	_
+13	hear	hear	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	28	advcl	28:advcl:when	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	company	company	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	who's	who's	PRON	WP$	PronType=Int	18	nmod:poss	18:nmod:poss	_
 17	stated	state	VERB	VBN	Tense=Past|VerbForm=Part	18	amod	18:amod	_
 18	goals	goal	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-19	include	include	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+19	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 20	"	"	PUNCT	``	_	24	punct	24:punct	SpaceAfter=No
 21-22	Don't	_	_	_	_	_	_	_	_
 21	Do	do	AUX	VB	Mood=Imp|VerbForm=Fin	24	aux	24:aux	_
@@ -475,7 +475,7 @@
 25	,	,	PUNCT	,	_	13	punct	13:punct	SpaceAfter=No
 26	"	"	PUNCT	''	_	13	punct	13:punct	_
 27	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	28	nsubj	28:nsubj	_
-28	imagine	imagine	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+28	imagine	imagine	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 29	a	a	DET	DT	Definite=Ind|PronType=Art	30	det	30:det	_
 30	company	company	NOUN	NN	Number=Sing	28	obj	28:obj	_
 31	who's	who's	PRON	WP$	PronType=Int	33	nmod:poss	33:nmod:poss	_
@@ -630,7 +630,7 @@
 25	road	road	NOUN	NN	Number=Sing	28	nsubj	28:nsubj|29:nsubj:xsubj	_
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	negotiations	negotiation	NOUN	NNS	Number=Plur	25	nmod	25:nmod:of	_
-28	remained	remain	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:if	_
+28	remained	remain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:if	_
 29	rocky	rocky	ADJ	JJ	Degree=Pos	28	xcomp	28:xcomp	SpaceAfter=No
 30	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -648,7 +648,7 @@
 10	during	during	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	1990s	1990	NOUN	NNS	Number=Plur	4	nmod	4:nmod:during	_
-13	helped	help	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+13	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 14	,	,	PUNCT	,	_	13	punct	13:punct	_
 15	along	along	ADP	IN	_	18	case	18:case	_
 16	with	with	ADP	IN	_	18	case	18:case	_
@@ -669,7 +669,7 @@
 31	,	,	PUNCT	,	_	30	punct	30:punct	_
 32	which	which	PRON	WDT	PronType=Rel	36	obj	30:ref	_
 33	Sharon	Sharon	PROPN	NNP	Number=Sing	36	nsubj	36:nsubj	_
-34	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	36	aux	36:aux	_
+34	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	aux	36:aux	_
 35	always	always	ADV	RB	_	36	advmod	36:advmod	_
 36	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part	30	acl:relcl	30:acl:relcl	SpaceAfter=No
 37	.	.	PUNCT	.	_	13	punct	13:punct	_
@@ -744,7 +744,7 @@
 25	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	_
 26	up	up	ADP	RP	_	25	compound:prt	25:compound:prt	_
 27	that	that	PRON	WDT	PronType=Rel	28	nsubj	23:ref	_
-28	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	_
+28	look	look	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	_
 29	to	to	ADP	IN	_	30	case	30:case	_
 30	bin	bin	PROPN	NNP	Number=Sing	28	obl	28:obl:to	_
 31	Laden	Laden	PROPN	NNP	Number=Sing	30	flat	30:flat	_
@@ -760,7 +760,7 @@
 3	local	local	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	Palestinian	Palestinian	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	leaders	leader	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|8:nsubj:xsubj	_
-6	remain	remain	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+6	remain	remain	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
 7	strong	strong	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	enough	enough	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -832,7 +832,7 @@
 10	forces	force	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 11	on	on	ADP	IN	_	12	case	12:case	_
 12	Tuesday	Tuesday	PROPN	NNP	Number=Sing	13	obl	13:obl:on	_
-13	condemned	condemn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+13	condemned	condemn	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 14-15	Sharon's	_	_	_	_	_	_	_	_
 14	Sharon	Sharon	PROPN	NNP	Number=Sing	16	nmod:poss	16:nmod:poss	_
 15	's	's	PART	POS	_	14	case	14:case	_
@@ -870,11 +870,11 @@
 13	Baghdad	Baghdad	PROPN	NNP	Number=Sing	11	obl	11:obl:of	SpaceAfter=No
 14	,	,	PUNCT	,	_	11	punct	11:punct	_
 15	"	"	PUNCT	``	_	16	punct	16:punct	SpaceAfter=No
-16	condemned	condemn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+16	condemned	condemn	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	assassination	assassination	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	and	and	CCONJ	CC	_	20	cc	20:cc	_
-20	promised	promise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	conj	16:conj:and	_
+20	promised	promise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	conj	16:conj:and	_
 21	immediate	immediate	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
 22	revenge	revenge	NOUN	NN	Number=Sing	20	obj	20:obj	_
 23	against	against	ADP	IN	_	26	case	26:case	_
@@ -911,14 +911,14 @@
 1	US	US	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	troops	troops	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 3	there	there	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
-4	clashed	clash	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	clashed	clash	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	with	with	ADP	IN	_	6	case	6:case	_
 6	guerrillas	guerrilla	NOUN	NNS	Number=Plur	4	obl	4:obl:with	_
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	fight	fight	NOUN	NN	Number=Sing	4	obl	4:obl:in|11:nsubj	_
 10	that	that	PRON	WDT	PronType=Rel	11	nsubj	9:ref	_
-11	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	one	one	NUM	CD	NumType=Card	13	nummod	13:nummod	_
 13	Iraqi	Iraqi	PROPN	NNP	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	dead	dead	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -945,7 +945,7 @@
 5	al	al	PROPN	NNP	Number=Sing	4	flat	4:flat	SpaceAfter=No
 6	-	-	PUNCT	HYPH	_	4	punct	4:punct	SpaceAfter=No
 7	Sadr	Sadr	PROPN	NNP	Number=Sing	4	flat	4:flat	_
-8	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+8	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	attack	attack	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
 11	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
@@ -957,7 +957,7 @@
 17	"	"	PUNCT	``	_	21	punct	21:punct	SpaceAfter=No
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	Zionists	Zionist	PROPN	NNPS	Number=Plur	21	nsubj	21:nsubj	_
-20	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
+20	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
 21	left	leave	VERB	VBN	Tense=Past|VerbForm=Part	13	conj	8:ccomp|13:conj:and	_
 22	only	only	ADV	RB	_	24	advmod	24:advmod	_
 23	one	one	NUM	CD	NumType=Card	24	nummod	24:nummod	_
@@ -980,7 +980,7 @@
 2	interim	interim	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 3	Governing	Govern	VERB	NNP	VerbForm=Ger	4	amod	4:amod	_
 4	Council	Council	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-5	issued	issue	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	issued	issue	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	communique	communique	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	saying	say	VERB	VBG	VerbForm=Ger	7	acl	7:acl	SpaceAfter=No
@@ -1036,13 +1036,13 @@
 21	"	"	PUNCT	''	_	24	punct	24:punct	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	message	message	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	_
-24	claimed	claim	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+24	claimed	claim	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 25	.	.	PUNCT	.	_	24	punct	24:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040324065800_ENG_20040324_065800-0009
 # text = Xinhua alleged that "Many of the Iraqis, who suffer the American occupation of Iraq, relate their case with that of the Palestinian people, under the Israeli occupation."
 1	Xinhua	Xinhua	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	alleged	allege	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	alleged	allege	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	18	mark	18:mark	_
 4	"	"	PUNCT	``	_	18	punct	18:punct	SpaceAfter=No
 5	Many	many	ADJ	JJ	Degree=Pos	18	nsubj	18:nsubj	_
@@ -1051,7 +1051,7 @@
 8	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	5	nmod	5:nmod:of|11:nsubj	SpaceAfter=No
 9	,	,	PUNCT	,	_	8	punct	8:punct	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
-11	suffer	suffer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+11	suffer	suffer	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	American	American	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	occupation	occupation	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -1086,7 +1086,7 @@
 7	some	some	DET	DT	_	9	det	9:det	_
 8	eleven	eleven	NUM	CD	NumType=Card	9	nummod	9:nummod	_
 9	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	11	nsubj:pass	11:nsubj:pass	_
-10	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux:pass	11:aux:pass	_
+10	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	aux:pass	11:aux:pass	_
 11	killed	kill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 12	by	by	ADP	IN	_	13	case	13:case	_
 13	snipers	sniper	NOUN	NNS	Number=Plur	11	obl	11:obl:by	_
@@ -1128,7 +1128,7 @@
 10	,	,	PUNCT	,	_	14	punct	14:punct	_
 11	most	most	ADJ	JJS	Degree=Sup	12	amod	12:amod	_
 12	investors	investor	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
-13	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 14	feared	fear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 15	that	that	SCONJ	IN	_	19	mark	19:mark	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
@@ -1176,7 +1176,7 @@
 # text = We've moved on.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	moved	move	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	on	on	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 5	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -1185,7 +1185,7 @@
 # text = We've grown up.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	grown	grow	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	SpaceAfter=No
 5	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -1195,7 +1195,7 @@
 1	Now	now	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	people	people	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	wonder	wonder	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	if	if	SCONJ	IN	_	9	mark	9:mark	_
 6	Google	Google	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 7	can	can	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -1212,14 +1212,14 @@
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+7	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 8	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = weblog-blogspot.com_marketview_20040611132900_ENG_20040611_132900-0006
 # text = What they wonder is whether Google can be anything more than what it's always been -- a great search engine with some real grass-roots support, successful by the grace of simplicity.
 1	What	what	PRON	WP	PronType=Int	4	nsubj	4:nsubj	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	wonder	wonder	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	whether	whether	SCONJ	IN	_	9	mark	9:mark	_
 6	Google	Google	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
@@ -1258,7 +1258,7 @@
 # sent_id = weblog-blogspot.com_marketview_20040611132900_ENG_20040611_132900-0007
 # text = Simplicity gave it that blessed, laudatory lack of clutter, the efficient and effective text-based ads, and the support of anyone with a dial-up connection.
 1	Simplicity	simplicity	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
-2	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	iobj	2:iobj	_
 4	that	that	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 5	blessed	blessed	ADJ	JJ	Degree=Pos	8	amod	8:amod	SpaceAfter=No
@@ -1302,7 +1302,7 @@
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	simple	simple	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	interface	interface	NOUN	NN	Number=Sing	6	obl	6:obl:by	_
-11	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 12	among	among	ADP	IN	_	15	case	15:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 14	least	least	ADV	RBS	Degree=Sup	15	advmod	15:advmod	_
@@ -1373,7 +1373,7 @@
 14	Google	Google	PROPN	NNP	Number=Sing	15	compound	15:compound	_
 15	users	user	NOUN	NNS	Number=Plur	18	nsubj	18:nsubj|20:nsubj:xsubj	_
 16-17	don't	_	_	_	_	_	_	_	_
-16	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+16	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 17	n't	not	PART	RB	_	18	advmod	18:advmod	_
 18	intend	intend	VERB	VB	VerbForm=Inf	0	root	0:root	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
@@ -1398,7 +1398,7 @@
 # text = If they continue to add features so they can justify their likely sky-high valuation, Google risks losing a huge chunk of their customer base to the next keep-it-simple search engine.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	continue	continue	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	advcl	19:advcl:if	_
+3	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	advcl	19:advcl:if	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	add	add	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	features	feature	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -1446,14 +1446,14 @@
 5	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	people	people	NOUN	NNS	Number=Plur	5	nmod	5:nmod:of	_
-8	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:when	_
+8	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:when	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	die	die	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	because	because	SCONJ	IN	_	15	mark	15:mark	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 13	Swedish	Swedish	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	newspaper	newspaper	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
-15	printed	print	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:because	_
+15	printed	print	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:because	_
 16	those	that	DET	DT	Number=Plur|PronType=Dem	17	det	17:det	_
 17	cartoons	cartoon	NOUN	NNS	Number=Plur	15	obj	15:obj	_
 18	of	of	ADP	IN	_	21	case	21:case	_
@@ -1491,7 +1491,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3	these	this	DET	DT	Number=Plur|PronType=Dem	4	det	4:det	_
 4	idiots	idiot	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	cartoon	cartoon	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
 8	of	of	ADP	IN	_	9	case	9:case	_
@@ -1528,7 +1528,7 @@
 6	on	on	ADP	IN	_	8	case	8:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	Holocaust	Holocaust	PROPN	NNP	Number=Sing	5	nmod	5:nmod:on	_
-9	opened	open	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	opened	open	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Tehran	Tehran	PROPN	NNP	Number=Sing	9	obl	9:obl:in	_
 12	in	in	ADP	IN	_	13	case	13:case	_
@@ -1553,7 +1553,7 @@
 # text = "We staged this fair to explore the limits of freedom Westerners believe in," Masoud Shojai, head of the country's "Iran Cartoon" association and the fair organizer, said.
 1	"	"	PUNCT	``	_	35	punct	35:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	staged	stage	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	35	ccomp	35:ccomp	_
+3	staged	stage	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	35	ccomp	35:ccomp	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	fair	fair	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -1563,7 +1563,7 @@
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	freedom	freedom	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	_
 12	Westerners	Westerner	PROPN	NNPS	Number=Plur	13	nsubj	13:nsubj	_
-13	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	in	in	ADP	IN	_	13	obl	13:obl	SpaceAfter=No
 15	,	,	PUNCT	,	_	35	punct	35:punct	SpaceAfter=No
 16	"	"	PUNCT	''	_	35	punct	35:punct	_
@@ -1586,7 +1586,7 @@
 32	fair	fair	NOUN	NN	Number=Sing	33	compound	33:compound	_
 33	organizer	organizer	NOUN	NN	Number=Sing	20	conj	17:appos|20:conj:and	SpaceAfter=No
 34	,	,	PUNCT	,	_	35	punct	35:punct	_
-35	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+35	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 36	.	.	PUNCT	.	_	35	punct	35:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0007
@@ -1598,7 +1598,7 @@
 5	write	write	VERB	VB	VerbForm=Inf	32	ccomp	32:ccomp	_
 6	anything	anything	PRON	NN	Number=Sing	5	obj	5:obj	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
-8	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	about	about	ADP	IN	_	11	case	11:case	_
 10	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	prophet	prophet	NOUN	NN	Number=Sing	6	nmod	6:nmod:about	SpaceAfter=No
@@ -1622,7 +1622,7 @@
 29	,	,	PUNCT	,	_	32	punct	32:punct	SpaceAfter=No
 30	"	"	PUNCT	''	_	32	punct	32:punct	_
 31	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	32	nsubj	32:nsubj	_
-32	added	add	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+32	added	add	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 33	.	.	PUNCT	.	_	32	punct	32:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0008
@@ -1630,14 +1630,14 @@
 1	"	"	PUNCT	``	_	25	punct	25:punct	SpaceAfter=No
 2	Though	though	SCONJ	IN	_	6	mark	6:mark	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
 6	deny	deny	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:though	_
 7	that	that	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	fact	fact	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	that	that	SCONJ	IN	_	12	mark	12:mark	_
 10	Jews	Jew	PROPN	NNPS	Number=Plur	12	nsubj:pass	12:nsubj:pass	_
-11	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	aux:pass	12:aux:pass	_
+11	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux:pass	12:aux:pass	_
 12	killed	kill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl	8:acl:that	_
 13	in	in	ADP	IN	_	19	case	19:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
@@ -1660,7 +1660,7 @@
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0009
 # text = Shojai told the opening ceremony of the month-long fair in Tehran's Palestine Contemporary Art Museum.
 1	Shojai	Shojai	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	opening	open	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	ceremony	ceremony	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -1683,12 +1683,12 @@
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0010
 # text = He added that around 1,100 cartoons were submitted by participants from more than 60 countries and that more than 200 are on show.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	added	add	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	added	add	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	8	mark	8:mark	_
 4	around	around	ADV	RB	_	5	advmod	5:advmod	_
 5	1,100	1100	NUM	CD	NumType=Card	6	nummod	6:nummod	_
 6	cartoons	cartoon	NOUN	NNS	Number=Plur	8	nsubj:pass	8:nsubj:pass	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
 8	submitted	submit	VERB	VBN	Tense=Past|VerbForm=Part	2	ccomp	2:ccomp	_
 9	by	by	ADP	IN	_	10	case	10:case	_
 10	participants	participant	NOUN	NNS	Number=Plur	8	obl	8:obl:by	_
@@ -1710,7 +1710,7 @@
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0011
 # text = He said the top three cartoons will be announced on September 2, with the winners being awarded prizes of 12,000, 8,000 and 5,000 dollars respectively.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	top	top	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	three	three	NUM	CD	NumType=Card	6	nummod	6:nummod	_
@@ -1755,14 +1755,14 @@
 13	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 14	extremist	extremist	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	Muslims	Muslim	PROPN	NNPS	Number=Plur	12	nsubj	12:nsubj	_
-16	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	SpaceAfter=No
+16	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	SpaceAfter=No
 17	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060814163400_ENG_20060814_163400-0013
 # text = When they saw a cartoon of their prophet, people had to die.
 1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	saw	see	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:when	_
+3	saw	see	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:when	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	cartoon	cartoon	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	of	of	ADP	IN	_	8	case	8:case	_
@@ -1770,7 +1770,7 @@
 8	prophet	prophet	NOUN	NN	Number=Sing	5	nmod	5:nmod:of	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10	people	people	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	die	die	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	SpaceAfter=No
 14	.	.	PUNCT	.	_	11	punct	11:punct	_
@@ -1781,11 +1781,11 @@
 2	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 3	precious	precious	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	cartoons	cartoon	NOUN	NNS	Number=Plur	6	nsubj:pass	6:nsubj:pass	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	released	release	VERB	VBN	Tense=Past|VerbForm=Part	9	advcl	9:advcl:when	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	highly	highly	ADV	RB	_	9	advmod	9:advmod	_
-9	doubt	doubt	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+9	doubt	doubt	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 12	look	look	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
@@ -1803,7 +1803,7 @@
 # text = US Marines moved into most of Fallujah on Wednesday, though they were still meeting pockets of resistance.
 1	US	US	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	Marines	Marine	PROPN	NNPS	Number=Plur	3	nsubj	3:nsubj	_
-3	moved	move	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	moved	move	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	into	into	ADP	IN	_	5	case	5:case	_
 5	most	most	ADJ	JJS	Degree=Sup	3	obl	3:obl:into	_
 6	of	of	ADP	IN	_	7	case	7:case	_
@@ -1813,7 +1813,7 @@
 10	,	,	PUNCT	,	_	3	punct	3:punct	_
 11	though	though	SCONJ	IN	_	15	mark	15:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-13	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
+13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
 14	still	still	ADV	RB	_	15	advmod	15:advmod	_
 15	meeting	meet	VERB	VBG	VerbForm=Ger	3	advcl	3:advcl:though	_
 16	pockets	pocket	NOUN	NNS	Number=Plur	15	obj	15:obj	_
@@ -1854,7 +1854,7 @@
 # text = Armed clashes broke out in several northern Iraqi cities on Wednesday, leaving some 22 persons dead in Mosul, Baiji, and Tuz.
 1	Armed	armed	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	clashes	clash	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	broke	break	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	broke	break	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	in	in	ADP	IN	_	9	case	9:case	_
 6	several	several	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -1883,7 +1883,7 @@
 1	Hundreds	hundred	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 2	of	of	ADP	IN	_	3	case	3:case	_
 3	persons	person	NOUN	NNS	Number=Plur	1	nmod	1:nmod:of	_
-4	mounted	mount	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	mounted	mount	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	demonstrations	demonstration	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	against	against	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -1910,7 +1910,7 @@
 2	battles	battle	NOUN	NNS	Number=Plur	6	nsubj:pass	6:nsubj:pass	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	demonstrations	demonstration	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj:pass	_
-5	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
+5	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 6	provoked	provoke	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 7	by	by	ADP	IN	_	10	case	10:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
@@ -1923,7 +1923,7 @@
 # sent_id = weblog-juancole.com_juancole_20041111060900_ENG_20041111_060900-0006
 # text = Guerrillas threatened to assassinate Prime Minister Iyad Allawi and Minister of Defense Hazem Shaalan in retaliation for the attack.
 1	Guerrillas	guerrilla	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	threatened	threaten	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	threatened	threaten	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	assassinate	assassinate	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	Prime	Prime	ADJ	NNP	Degree=Pos	6	amod	6:amod	_
@@ -1962,11 +1962,11 @@
 13	in	in	ADP	IN	_	15	case	15:case	SpaceAfter=No
 14	-	-	PUNCT	HYPH	_	15	punct	15:punct	SpaceAfter=No
 15	law	law	NOUN	NN	Number=Sing	11	nmod	11:nmod:in	_
-16	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux:pass	17:aux:pass	_
+16	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	aux:pass	17:aux:pass	_
 17	abducted	abduct	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	guerrillas	guerrilla	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj|22:nsubj:xsubj	_
-20	threaten	threaten	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	conj	17:conj:and	_
+20	threaten	threaten	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	conj	17:conj:and	_
 21	to	to	PART	TO	_	22	mark	22:mark	_
 22	behead	behead	VERB	VB	VerbForm=Inf	20	xcomp	20:xcomp	_
 23	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	22	obj	22:obj	_
@@ -2020,7 +2020,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	US	US	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	Marines	Marine	PROPN	NNPS	Number=Plur	4	nsubj	4:nsubj|12:nsubj	_
-4	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	took	take	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	most	most	ADJ	JJS	Degree=Sup	4	obj	4:obj	_
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	Fallujah	Fallujah	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
@@ -2028,7 +2028,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	but	but	CCONJ	CC	_	12	cc	12:cc	_
 11	still	still	ADV	RB	_	12	advmod	12:advmod	_
-12	face	face	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+12	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 13	pockets	pocket	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 14	of	of	ADP	IN	_	15	case	15:case	_
 15	resistance	resistance	NOUN	NN	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
@@ -2041,7 +2041,7 @@
 3	and	and	CCONJ	CC	_	5	cc	5:cc	_
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	cities	city	NOUN	NNS	Number=Plur	2	conj	2:conj:and|8:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	any	any	DET	DT	_	8	det	8:det	_
 8	guide	guide	NOUN	NN	Number=Sing	15	advcl	15:advcl:if	SpaceAfter=No
 9	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -2093,7 +2093,7 @@
 7	Party	Party	PROPN	NNP	Number=Sing	24	nsubj	14:nsubj:pass|24:nsubj|26:nsubj	SpaceAfter=No
 8	,	,	PUNCT	,	_	7	punct	7:punct	_
 9	which	which	PRON	WDT	PronType=Rel	14	nsubj:pass	7:ref	_
-10	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
+10	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
 11	earlier	early	ADV	RBR	Degree=Cmp	14	advmod	14:advmod	_
 12	been	be	AUX	VBN	Tense=Past|VerbForm=Part	14	aux:pass	14:aux:pass	_
 13	absolutely	absolutely	ADV	RB	_	14	advmod	14:advmod	_
@@ -2134,7 +2134,7 @@
 11	regions	region	NOUN	NNS	Number=Plur	2	nmod	2:nmod:throughout	_
 12	on	on	ADP	IN	_	13	case	13:case	_
 13	Wednesday	Wednesday	PROPN	NNP	Number=Sing	2	nmod	2:nmod:on	_
-14	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
+14	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	not	not	PART	RB	_	16	advmod	16:advmod	_
 16	bode	bode	VERB	VB	VerbForm=Inf	0	root	0:root	_
 17	well	well	ADV	RB	Degree=Pos	16	advmod	16:advmod	_
@@ -2280,7 +2280,7 @@
 4	few	few	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	years	year	NOUN	NNS	Number=Plur	8	obl	8:obl:for	_
 6	there	there	PRON	EX	_	8	expl	8:expl	_
-7	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+7	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 8	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 9	tensions	tension	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 10	with	with	ADP	IN	_	14	case	14:case	_
@@ -2327,10 +2327,10 @@
 7	Iranian	Iranian	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 8	Opposition	opposition	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	Group	group	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
-10	released	release	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+10	released	release	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	what	what	PRON	WP	PronType=Int	13	obj	13:obj|14:nsubj:xsubj	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-13	call	call	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+13	call	call	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
 14	proof	proof	NOUN	NN	Number=Sing	13	xcomp	13:xcomp	_
 15	of	of	ADP	IN	_	20	case	20:case	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
@@ -2352,21 +2352,21 @@
 8	Kahn	Kahn	PROPN	NNP	Number=Sing	7	flat	7:flat	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	Libya	Libya	PROPN	NNP	Number=Sing	7	conj	5:nmod:to|7:conj:and	_
-11	make	make	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+11	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 12	up	up	ADP	RP	_	11	compound:prt	11:compound:prt	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	evidence	evidence	NOUN	NN	Number=Sing	11	obj	11:obj|18:obj	_
 15	that	that	PRON	WDT	PronType=Rel	18	obj	14:ref	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	group	group	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
-18	presented	present	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
+18	presented	present	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 19	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0006
 # text = Russia also announced that it was seeking and building the best nukes the world’s ever seen.
 1	Russia	Russia	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	that	that	SCONJ	IN	_	7	mark	7:mark	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj|9:nsubj	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
@@ -2389,7 +2389,7 @@
 1	President	President	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 2	Vladimir	Vladimir	PROPN	NNP	Number=Sing	1	flat	1:flat	_
 3	Putin	Putin	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-4	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	Russia	Russia	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	reparandum	8:reparandum	_
 7	will	will	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
@@ -2400,7 +2400,7 @@
 12	that	that	PRON	WDT	PronType=Rel	20	obj	20:obj	_
 13	other	other	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	countries	country	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj|20:nsubj	_
-15	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+15	do	do	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 16	not	not	PART	RB	_	15	advmod	15:advmod	_
 17	and	and	CCONJ	CC	_	20	cc	20:cc	_
 18	will	will	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
@@ -2467,7 +2467,7 @@
 9	and	and	CCONJ	CC	_	15	cc	15:cc	_
 10	not	not	PART	RB	_	11	advmod	11:advmod	_
 11	always	always	ADV	RB	_	15	advmod	15:advmod	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 14	decisions	decision	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
 15	equal	equal	ADJ	JJ	Degree=Pos	7	conj	7:conj:and	SpaceAfter=No
@@ -2500,7 +2500,7 @@
 23	said	say	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
 24	that	that	SCONJ	IN	_	26	mark	26:mark	_
 25	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	26	nsubj	26:nsubj	_
-26	posses	poss	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	ccomp	23:ccomp	_
+26	posses	poss	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	ccomp	23:ccomp	_
 27	nuclear	nuclear	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
 28	weapons	weapon	NOUN	NNS	Number=Plur	26	obj	26:obj	SpaceAfter=No
 29	,	,	PUNCT	,	_	30	punct	30:punct	_
@@ -2651,7 +2651,7 @@
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0018
 # text = America cried wolf in Iraq, and what’s scary is that sooner or later, that wolf will probably get us.
 1	America	America	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	cried	cry	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	cried	cry	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	wolf	wolf	NOUN	NN	Number=Sing	2	obj	2:obj	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	Iraq	Iraq	PROPN	NNP	Number=Sing	2	obl	2:obl:in	SpaceAfter=No
@@ -2680,7 +2680,7 @@
 # newpar id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-p0001
 # text = I ran across this item on the Internet.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	ran	run	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	ran	run	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	across	across	ADP	IN	_	5	case	5:case	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	item	item	NOUN	NN	Number=Sing	2	obl	2:obl:across	_
@@ -2692,7 +2692,7 @@
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0002
 # newpar id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-p0002
 # text = Sooooo.
-1	Sooooo	so	ADV	RB	Style=Expr	0	root	0:root	SpaceAfter=No|CorrectForm=so
+1	Sooooo	so	ADV	RB	Style=Expr	0	root	0:root	CorrectForm=so|SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0003
@@ -2737,12 +2737,12 @@
 8	Department	Department	PROPN	NNP	Number=Sing	11	nsubj	11:nsubj	_
 9	of	of	ADP	IN	_	10	case	10:case	_
 10	State	State	PROPN	NNP	Number=Sing	8	nmod	8:nmod:of	_
-11	waived	waive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	waived	waive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	fees	fee	NOUN	NNS	Number=Plur	11	obj	11:obj|16:obj	_
 14	that	that	PRON	WDT	PronType=Rel	16	obj	13:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	charge	charge	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	for	for	SCONJ	IN	_	18	mark	18:mark	_
 18	evacuating	evacuate	VERB	VBG	VerbForm=Ger	16	advcl	16:advcl:for	_
 19	U.S.	U.S.	PROPN	NNP	Number=Sing	20	compound	20:compound	_
@@ -2825,7 +2825,7 @@
 4	,	,	PUNCT	,	_	8	punct	8:punct	_
 5	those	that	DET	DT	Number=Plur|PronType=Dem	6	det	6:det	_
 6	Americans	American	PROPN	NNPS	Number=Plur	8	nsubj	8:nsubj	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
 8	there	there	ADV	RB	PronType=Dem	0	root	0:root	_
 9	by	by	ADP	IN	_	12	case	12:case	_
 10	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
@@ -2847,7 +2847,7 @@
 1	Yet	yet	CCONJ	CC	_	5	cc	5:cc	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 3-4	didn't	_	_	_	_	_	_	_	_
-3	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+3	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	charge	charge	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	5	obj	5:obj	_
@@ -2869,13 +2869,13 @@
 9	Asia	Asia	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
 10	when	when	SCONJ	WRB	PronType=Rel	12	mark	12:mark	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	evacuated	evacuate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+12	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 13	U.S.	U.S.	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	citizens	citizen	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	from	from	ADP	IN	_	16	case	16:case	_
 16	areas	area	NOUN	NNS	Number=Plur	12	obl	12:obl:from|19:nsubj:pass	_
 17	that	that	PRON	WDT	PronType=Rel	19	nsubj:pass	16:ref	_
-18	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	19	aux:pass	19:aux:pass	_
+18	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	19	aux:pass	19:aux:pass	_
 19	hit	hit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	_
 20	by	by	ADP	IN	_	22	case	22:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -2895,7 +2895,7 @@
 35	provoked	provoke	VERB	VBN	Tense=Past|VerbForm=Part	36	amod	36:amod	_
 36	destruction	destruction	NOUN	NN	Number=Sing	30	obl	30:obl:than|38:nsubj	_
 37	that	that	PRON	WDT	PronType=Rel	38	nsubj	36:ref	_
-38	rained	rain	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
+38	rained	rain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
 39	down	down	ADV	RB	_	38	advmod	38:advmod	_
 40	on	on	ADP	IN	_	41	case	41:case	_
 41	Lebanon	Lebanon	PROPN	NNP	Number=Sing	38	obl	38:obl:on	SpaceAfter=No
@@ -2905,7 +2905,7 @@
 # text = And what do we get for this effort?
 1	And	and	CCONJ	CC	_	5	cc	5:cc	_
 2	what	what	PRON	WP	PronType=Int	5	obj	5:obj	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	for	for	ADP	IN	_	8	case	8:case	_
@@ -2949,7 +2949,7 @@
 15	charging	charge	VERB	VBG	VerbForm=Ger	8	advcl	8:advcl	_
 16	that	that	SCONJ	IN	_	18	mark	18:mark	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
-18	mismanaged	mismanage	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
+18	mismanaged	mismanage	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	evacuation	evacuation	NOUN	NN	Number=Sing	21	compound	21:compound	_
 21	efforts	effort	NOUN	NNS	Number=Plur	18	obj	18:obj	SpaceAfter=No
@@ -2988,7 +2988,7 @@
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	lawsuit	lawsuit	NOUN	NN	Number=Sing	14	nmod	14:nmod:in	SpaceAfter=No
 18	,	,	PUNCT	,	_	19	punct	19:punct	_
-19	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+19	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 20	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	21	nmod:poss	21:nmod:poss	_
 21	wedding	wedding	NOUN	NN	Number=Sing	29	nsubj:pass	29:nsubj:pass	_
 22	in	in	ADP	IN	_	25	case	25:case	_
@@ -3008,14 +3008,14 @@
 # text = The wedding had to be postponed as family members fled the outbreak of the war, she said.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	wedding	wedding	NOUN	NN	Number=Sing	3	nsubj	3:nsubj|6:nsubj:xsubj	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux:pass	6:aux:pass	_
 6	postponed	postpone	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	xcomp	3:xcomp	_
 7	as	as	SCONJ	IN	_	10	mark	10:mark	_
 8	family	family	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	members	member	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	_
-10	fled	flee	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:as	_
+10	fled	flee	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:as	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	outbreak	outbreak	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	of	of	ADP	IN	_	15	case	15:case	_
@@ -3023,14 +3023,14 @@
 15	war	war	NOUN	NN	Number=Sing	12	nmod	12:nmod:of	SpaceAfter=No
 16	,	,	PUNCT	,	_	18	punct	18:punct	_
 17	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
-18	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	SpaceAfter=No
+18	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	SpaceAfter=No
 19	.	.	PUNCT	.	_	18	punct	18:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0018
 # text = "We were on the road and the first bridge was bombed and we drove home and all the other bridges were bombed and there was absolutely no way for us to get home," Chahine told reporters outside federal court in Detroit.
 1	"	"	PUNCT	``	_	38	punct	38:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 4	on	on	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	road	road	NOUN	NN	Number=Sing	38	parataxis	38:parataxis	_
@@ -3042,14 +3042,14 @@
 12	bombed	bomb	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	conj	6:conj:and	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
-15	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
+15	drove	drive	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
 16	home	home	ADV	RB	_	15	advmod	15:advmod	_
 17	and	and	CCONJ	CC	_	23	cc	23:cc	_
 18	all	all	DET	PDT	_	21	det:predet	21:det:predet	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	other	other	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	bridges	bridge	NOUN	NNS	Number=Plur	23	nsubj:pass	23:nsubj:pass	_
-22	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	23	aux:pass	23:aux:pass	_
+22	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	23	aux:pass	23:aux:pass	_
 23	bombed	bomb	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	15	conj	15:conj:and	_
 24	and	and	CCONJ	CC	_	26	cc	26:cc	_
 25	there	there	PRON	EX	_	26	expl	26:expl	_
@@ -3065,7 +3065,7 @@
 35	,	,	PUNCT	,	_	38	punct	38:punct	SpaceAfter=No
 36	"	"	PUNCT	''	_	38	punct	38:punct	_
 37	Chahine	Chahine	PROPN	NNP	Number=Sing	38	nsubj	38:nsubj	_
-38	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+38	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 39	reporters	reporter	NOUN	NNS	Number=Plur	38	obj	38:obj	_
 40	outside	outside	ADP	IN	_	42	case	42:case	_
 41	federal	federal	ADJ	JJ	Degree=Pos	42	amod	42:amod	_
@@ -3078,7 +3078,7 @@
 # text = "We were all American citizens and there was no way that anybody helped us.
 1	"	"	PUNCT	``	_	6	punct	6:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 4	all	all	ADV	RB	_	6	advmod	6:advmod	_
 5	American	American	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	citizens	citizen	NOUN	NNS	Number=Plur	0	root	0:root	_
@@ -3089,7 +3089,7 @@
 11	way	way	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|14:mark	_
 12	that	that	ADV	WRB	PronType=Rel	14	mark	11:ref	_
 13	anybody	anybody	PRON	NN	Number=Sing	14	nsubj	14:nsubj	_
-14	helped	help	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+14	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 15	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -3120,11 +3120,11 @@
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0022
 # text = Chahine said her immediate family spent about $20,000 to return to Detroit via Syria and Jordan.
 1	Chahine	Chahine	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	immediate	immediate	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	family	family	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
-6	spent	spend	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+6	spent	spend	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 7	about	about	ADV	RB	_	8	advmod	8:advmod	_
 8	$	$	SYM	$	_	6	obj	6:obj	SpaceAfter=No
 9	20,000	20000	NUM	CD	NumType=Card	8	nummod	8:nummod	_
@@ -3161,16 +3161,16 @@
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	countries	country	NOUN	NNS	Number=Plur	9	obl	9:obl:in|13:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	house	house	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	house	house	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	illegal	illegal	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	militias	militia	NOUN	NNS	Number=Plur	13	obj	13:obj|17:nsubj	_
 16	that	that	PRON	WDT	PronType=Rel	17	nsubj	15:ref	_
-17	attack	attack	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	attack	attack	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	other	other	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	countries	country	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
 21	hence	hence	ADV	RB	_	23	advmod	23:advmod	_
-22	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	23:cop	_
+22	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	cop	23:cop	_
 23	likely	likely	ADJ	JJ	Degree=Pos	17	conj	15:acl:relcl|17:conj:and	_
 24	to	to	PART	TO	_	25	mark	25:mark	_
 25	come	come	VERB	VB	VerbForm=Inf	23	csubj	23:csubj	_
@@ -3307,7 +3307,7 @@
 # text = "Q Thank you -- I was wondering, there's a lot of talk right now about memoirs being written with the former President.
 1	"	"	PUNCT	``	_	2	punct	2:punct	SpaceAfter=No
 2	Q	q	NOUN	NN	Number=Sing	0	root	0:root	_
-3	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+3	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	3	obj	3:obj	_
 5	--	--	PUNCT	,	_	3	punct	3:punct	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
@@ -3337,7 +3337,7 @@
 # text = After you are elected in 2004, what will your memoirs say about you, what will the title be, and what will the main theme say?
 1	After	after	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	elected	elect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	advcl	12:advcl:after	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	2004	2004	NUM	CD	NumType=Card	4	obl	4:obl:in	SpaceAfter=No
@@ -3372,7 +3372,7 @@
 3	PRESIDENT	PRESIDENT	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
 4	:	:	PUNCT	:	_	3	punct	3:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	appreciate	appreciate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+6	appreciate	appreciate	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 7	that	that	PRON	DT	Number=Sing|PronType=Dem	6	obj	6:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -3402,7 +3402,7 @@
 15	,	,	PUNCT	,	_	19	punct	19:punct	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 17-18	don't	_	_	_	_	_	_	_	_
-17	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	n't	not	PART	RB	_	19	advmod	19:advmod	_
 19	know	know	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	SpaceAfter=No
 20	.	.	PUNCT	.	_	19	punct	19:punct	_
@@ -3411,7 +3411,7 @@
 # text = I'm just speculating now.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
 4	speculating	speculate	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	now	now	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
@@ -3422,7 +3422,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 2	really	really	ADV	RB	_	5	advmod	5:advmod	_
 3-4	haven't	_	_	_	_	_	_	_	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	thought	think	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	about	about	SCONJ	IN	_	7	mark	7:mark	_
@@ -3483,7 +3483,7 @@
 24	,	,	PUNCT	,	_	27	punct	27:punct	_
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	there	there	PRON	EX	_	27	expl	27:expl	_
-27	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+27	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 28	at	at	ADP	IN	_	29	case	29:case	_
 29	least	least	ADJ	JJS	Degree=Sup	30	nmod	30:nmod:at	_
 30	two	two	NUM	CD	NumType=Card	32	nummod	32:nummod	_
@@ -3552,9 +3552,9 @@
 9	wife	wife	NOUN	NN	Number=Sing	6	conj	6:conj:and|12:nsubj	_
 10	Jan	Jan	PROPN	NNP	Number=Sing	9	appos	9:appos	SpaceAfter=No
 11	,	,	PUNCT	,	_	14	punct	14:punct	_
-12	introduced	introduce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	reparandum	14:reparandum	_
+12	introduced	introduce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	reparandum	14:reparandum	_
 13	--	--	PUNCT	,	_	14	punct	14:punct	_
-14	reintroduced	reintroduce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
+14	reintroduced	reintroduce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 15	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	14	obj	14:obj	_
 16	and	and	CCONJ	CC	_	17	cc	17:cc	_
 17	Laura	Laura	PROPN	NNP	Number=Sing	15	conj	14:obj|15:conj:and	_
@@ -3574,7 +3574,7 @@
 3	later	later	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj:pass	7:nsubj:pass	_
-6	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux:pass	7:aux:pass	_
+6	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	7:aux:pass	_
 7	married	marry	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
 8	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -3589,7 +3589,7 @@
 6	--	--	PUNCT	,	_	12	punct	12:punct	_
 7-8	I'm	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-8	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+8	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 10	decision	decision	NOUN	NN	Number=Sing	12	compound	12:compound	SpaceAfter=No
 11	-	-	PUNCT	HYPH	_	12	punct	12:punct	SpaceAfter=No
@@ -3616,7 +3616,7 @@
 2	And	and	CCONJ	CC	_	5	cc	5:cc	_
 3	so	so	ADV	RB	_	5	advmod	5:advmod	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	sang	sing	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	sang	sing	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	hymn	hymn	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	--	--	PUNCT	,	_	5	punct	5:punct	_
@@ -3699,7 +3699,7 @@
 1	Laura	Laura	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	1	conj	1:conj:and|5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	Methodists	Methodist	PROPN	NNPS	Number=Plur	0	root	0:root	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -3737,7 +3737,7 @@
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0030
 # text = I have.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0031
@@ -3761,7 +3761,7 @@
 2	--	--	PUNCT	,	_	1	punct	1:punct	_
 3	which	which	PRON	WDT	PronType=Int	7	obj	7:obj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj	_
-5	try	try	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
+5	try	try	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	do	do	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	SpaceAfter=No
 8	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -3787,7 +3787,7 @@
 3	book	book	NOUN	NN	Number=Sing	0	root	0:root	_
 4	--	--	PUNCT	,	_	3	punct	3:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	guess	guess	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+6	guess	guess	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 7	one	one	NUM	CD	NumType=Card	8	nummod	8:nummod	_
 8	way	way	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 9	,	,	PUNCT	,	_	16	punct	16:punct	_
@@ -3819,7 +3819,7 @@
 # text = And I gave it all my heart, all my energy, based upon principles that did not change once I got into the Oval Office.
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	iobj	3:iobj	_
 5	all	all	DET	PDT	_	7	det:predet	7:det:predet	_
 6	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	7	nmod:poss	7:nmod:poss	_
@@ -3833,12 +3833,12 @@
 14	upon	upon	ADP	IN	_	15	case	15:case	_
 15	principles	principle	NOUN	NNS	Number=Plur	3	obl	3:obl:upon|19:nsubj	_
 16	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
-17	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
+17	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
 18	not	not	PART	RB	_	19	advmod	19:advmod	_
 19	change	change	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	_
 20	once	once	SCONJ	IN	_	22	mark	22:mark	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-22	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	19	advcl	19:advcl:once	_
+22	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	19	advcl	19:advcl:once	_
 23	into	into	ADP	IN	_	26	case	26:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 25	Oval	Oval	PROPN	NNP	Number=Sing	26	compound	26:compound	_
@@ -3870,11 +3870,11 @@
 # text = And I have to wonder: Did he forget that he already has a memoir called "A Charge to Keep"?
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	wonder	wonder	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	SpaceAfter=No
 6	:	:	PUNCT	:	_	3	punct	3:punct	_
-7	Did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
+7	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
 8	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 9	forget	forget	VERB	VB	VerbForm=Inf	3	appos	3:appos	_
 10	that	that	SCONJ	IN	_	13	mark	13:mark	_
@@ -3954,7 +3954,7 @@
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0003
 # text = They have acquired Urchin, Zipdash, Applied Semantics, Picasa, Blogger, and satellite imaging company Keyhole, so why not Firefox?
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	acquired	acquire	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Urchin	Urchin	PROPN	NNP	Number=Sing	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -3982,21 +3982,21 @@
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0004
 # text = I have no inside information, but I have been following links today that strongly indicate that Google is damn serious about securing permanent control of the leading edge browser technology in Firefox.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	no	no	DET	DT	_	5	det	5:det	_
 4	inside	inside	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	information	information	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	11	punct	11:punct	_
 7	but	but	CCONJ	CC	_	11	cc	11:cc	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	been	be	AUX	VBN	Tense=Past|VerbForm=Part	11	aux	11:aux	_
 11	following	follow	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:but	_
 12	links	link	NOUN	NNS	Number=Plur	11	obj	11:obj|16:nsubj	_
 13	today	today	NOUN	NN	Number=Sing	11	obl:tmod	11:obl:tmod	_
 14	that	that	PRON	WDT	PronType=Rel	16	nsubj	12:ref	_
 15	strongly	strongly	ADV	RB	_	16	advmod	16:advmod	_
-16	indicate	indicate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+16	indicate	indicate	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 17	that	that	SCONJ	IN	_	21	mark	21:mark	_
 18	Google	Google	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
@@ -4032,7 +4032,7 @@
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0006
 # text = He announced this in January:
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	this	this	PRON	DT	Number=Sing|PronType=Dem	2	obj	2:obj	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	January	January	PROPN	NNP	Number=Sing	2	obl	2:obl:in	SpaceAfter=No
@@ -4051,7 +4051,7 @@
 9	source	source	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	income	income	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	_
-12	changed	change	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+12	changed	change	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 13	from	from	ADP	IN	_	16	case	16:case	_
 14	The	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	Mozilla	Mozilla	PROPN	NNP	Number=Sing	16	compound	16:compound	_
@@ -4092,7 +4092,7 @@
 21	work	work	NOUN	NN	Number=Sing	17	obj	17:obj	_
 22	as	as	SCONJ	IN	_	25	mark	25:mark	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj	25:nsubj	_
-24	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
+24	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
 25	described	describe	VERB	VBN	Tense=Past|VerbForm=Part	16	advcl	16:advcl:as	_
 26	above	above	ADV	RB	_	25	advmod	25:advmod	_
 27	-	-	PUNCT	,	_	16	punct	16:punct	_
@@ -4113,7 +4113,7 @@
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0009
 # text = I remain devoted full-time to the advancement of Firefox, the Mozilla platform and web browsing in general.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	remain	remain	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	remain	remain	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	devoted	devoted	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	full	full	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
 5	-	-	PUNCT	HYPH	_	6	punct	6:punct	SpaceAfter=No
@@ -4138,7 +4138,7 @@
 # text = He also announced this in January:
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	3	obj	3:obj	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	January	January	PROPN	NNP	Number=Sing	3	obl	3:obl:in	SpaceAfter=No
@@ -4169,7 +4169,7 @@
 14	Darin	Darin	PROPN	NNP	Number=Sing	5	obl	5:obl:to|17:nsubj	_
 15	Fisher	Fisher	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	who	who	PRON	WP	PronType=Rel	17	nsubj	14:ref	_
-17	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	obj	17:obj	_
 19	at	at	ADP	IN	_	20	case	20:case	_
 20	Google	Google	PROPN	NNP	Number=Sing	17	obl	17:obl:at	_
@@ -4190,7 +4190,7 @@
 # text = Darin Fisher wrote this response on January 25, 2005:
 1	Darin	Darin	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	Fisher	Fisher	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-3	wrote	write	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	wrote	write	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	response	response	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	on	on	ADP	IN	_	7	case	7:case	_
@@ -4225,14 +4225,14 @@
 9	yesterday	yesterday	NOUN	NN	Number=Sing	8	nmod:tmod	8:nmod:tmod	SpaceAfter=No
 10	,	,	PUNCT	,	_	12	punct	12:punct	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+12	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 13-14	I'd	_	_	_	_	_	_	_	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 14	'd	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 15	post	post	VERB	VB	VerbForm=Inf	12	ccomp	12:ccomp	_
 16	that	that	SCONJ	IN	_	19	mark	19:mark	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
-18	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+18	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 19	joined	join	VERB	VBN	Tense=Past|VerbForm=Part	15	ccomp	15:ccomp	_
 20	Google	Google	PROPN	NNP	Number=Sing	19	obj	19:obj	_
 21	as	as	ADV	RB	_	19	advmod	19:advmod	_
@@ -4269,7 +4269,7 @@
 # newpar id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-p0004
 # text = Ben made another announcement on March 28, 2005:
 1	Ben	Ben	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	another	another	DET	DT	_	4	det	4:det	_
 4	announcement	announcement	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	on	on	ADP	IN	_	6	case	6:case	_
@@ -4283,7 +4283,7 @@
 # newpar id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-p0005
 # text = I want to use this opportunity to welcome Brian Ryner to Google!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	use	use	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
@@ -4358,7 +4358,7 @@
 21	adage	adage	NOUN	NN	Number=Sing	8	conj	8:conj:but	_
 22	that	that	SCONJ	IN	_	24	mark	24:mark	_
 23	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj	_
-24	follow	follow	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	csubj	21:csubj	_
+24	follow	follow	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	21	csubj	21:csubj	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	money	money	NOUN	NN	Number=Sing	24	obj	24:obj	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
@@ -4406,7 +4406,7 @@
 # text = If you have not already seen the Flash movie Epic , you should take a few minutes and view the future history of media as conceived by Robin Sloan and Matt Thompson, with music by Aaron McLeran.
 1	If	if	SCONJ	IN	_	6	mark	6:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 4	not	not	PART	RB	_	6	advmod	6:advmod	_
 5	already	already	ADV	RB	_	6	advmod	6:advmod	_
 6	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	14	advcl	14:advcl:if	_
@@ -4455,7 +4455,7 @@
 7	(	(	PUNCT	-LRB-	_	8	punct	8:punct	SpaceAfter=No
 8	GOOGLEZON	GOOGLEZON	PROPN	NNP	Number=Sing	4	appos	4:appos	_
 9	)	)	PUNCT	-RRB-	_	8	punct	8:punct	_
-10	create	create	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+10	create	create	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 12	brave	brave	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 13	new	new	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -4507,7 +4507,7 @@
 12	far	far	ADV	RB	Degree=Pos	9	advmod	9:advmod	_
 13	as	as	SCONJ	IN	_	15	mark	15:mark	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
-15	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:as	SpaceAfter=No
+15	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:as	SpaceAfter=No
 16	,	,	PUNCT	,	_	9	punct	9:punct	_
 17	for	for	SCONJ	IN	_	21	mark	21:mark	_
 18	Google	Google	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
@@ -4522,7 +4522,7 @@
 # text = They already have rights to take it, alter it, and release those changes to the world - this is what the whole open source thing is about.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	already	already	ADV	RB	_	3	advmod	3:advmod	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	rights	rights	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	take	take	VERB	VB	VerbForm=Inf	4	acl	4:acl:to	_
@@ -4555,7 +4555,7 @@
 # text = I'm inclined to say that google is doing what they can to both shape and support the growth of the most popular non-Microsoft browser out there - by taking on the leading lights in Firefox development, they're ensuring the continued life of the project, and ensuring (not that I think they need to) that their voice will be heard admidst the higher echelons of the firefox development team.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	inclined	inclined	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	say	say	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
@@ -4594,7 +4594,7 @@
 38	,	,	PUNCT	,	_	41	punct	41:punct	_
 39-40	they're	_	_	_	_	_	_	_	_
 39	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	41	nsubj	41:nsubj|50:nsubj	_
-40	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	41	aux	41:aux	_
+40	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	41	aux	41:aux	_
 41	ensuring	ensure	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 42	the	the	DET	DT	Definite=Def|PronType=Art	44	det	44:det	_
 43	continued	continue	VERB	VBN	Tense=Past|VerbForm=Part	44	amod	44:amod	_
@@ -4609,9 +4609,9 @@
 52	not	not	PART	RB	_	50	parataxis	50:parataxis	_
 53	that	that	SCONJ	IN	_	55	mark	55:mark	_
 54	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	55	nsubj	55:nsubj	_
-55	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	52	csubj	52:csubj	_
+55	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	52	csubj	52:csubj	_
 56	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	57	nsubj	57:nsubj	_
-57	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	55	ccomp	55:ccomp	_
+57	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	55	ccomp	55:ccomp	_
 58	to	to	PART	TO	_	57	xcomp	57:xcomp	SpaceAfter=No
 59	)	)	PUNCT	-RRB-	_	52	punct	52:punct	_
 60	that	that	SCONJ	IN	_	65	mark	65:mark	_
@@ -4677,7 +4677,7 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	What	what	PRON	WP	PronType=Int	6	nsubj	6:nsubj	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	sense	sense	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -4784,7 +4784,7 @@
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0002
 # text = How did the CPA get to the point where it has turned even Iraqi Shiites, who were initially grateful for the removal of Saddam Hussein, against the United States?
 1	How	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	CPA	CPA	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -4800,7 +4800,7 @@
 15	Shiites	Shiite	PROPN	NNPS	Number=Plur	12	obj	12:obj|20:nsubj	SpaceAfter=No
 16	,	,	PUNCT	,	_	15	punct	15:punct	_
 17	who	who	PRON	WP	PronType=Rel	20	nsubj	15:ref	_
-18	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	cop	20:cop	_
+18	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	cop	20:cop	_
 19	initially	initially	ADV	RB	_	20	advmod	20:advmod	_
 20	grateful	grateful	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	_
 21	for	for	ADP	IN	_	23	case	23:case	_
@@ -4836,7 +4836,7 @@
 16	when	when	ADV	WRB	PronType=Rel	20	advmod	20:advmod	_
 17	US	US	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	troops	troops	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj|26:nsubj|28:nsubj:xsubj	_
-19	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 20	rotating	rotate	VERB	VBG	Tense=Pres|VerbForm=Part	15	acl:relcl	15:acl:relcl	_
 21	on	on	ADP	IN	_	24	case	24:case	_
 22	a	a	DET	DT	Definite=Ind|PronType=Art	24	det	24:det	_
@@ -4865,7 +4865,7 @@
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	other	other	ADJ	JJ	Degree=Pos	6	conj	6:conj:and|11:amod	_
 11	contingents	contingent	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	already	already	ADV	RB	_	14	advmod	14:advmod	_
 14	committed	committed	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	_
 15	to	to	SCONJ	IN	_	16	mark	16:mark	_
@@ -4889,7 +4889,7 @@
 4	that	that	SCONJ	IN	_	7	mark	7:mark	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Pentagon	Pentagon	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
-7	prevented	prevent	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+7	prevented	prevent	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	State	State	PROPN	NNP	Number=Sing	10	compound	10:compound	_
 10	Department	Department	PROPN	NNP	Number=Sing	7	obj	7:obj	_
@@ -4924,7 +4924,7 @@
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	Defense	Defense	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
 8	only	only	ADV	RB	_	9	advmod	9:advmod	_
-9	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+9	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 10	how	how	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	blow	blow	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
@@ -4939,7 +4939,7 @@
 3	Wolfowitz	Wolfowitz	PROPN	NNP	Number=Sing	1	conj	1:conj:and|6:nsubj	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	Feith	Feith	PROPN	NNP	Number=Sing	1	conj	1:conj:and|6:nsubj	_
-6	staffed	staff	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	staffed	staff	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	CPA	CPA	PROPN	NNP	Number=Sing	6	obj	6:obj	_
 9	with	with	ADP	IN	_	10	case	10:case	_
@@ -4974,7 +4974,7 @@
 # text = They actively excluded State Department Iraq hands like Tom Warrick.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	actively	actively	ADV	RB	_	3	advmod	3:advmod	_
-3	excluded	exclude	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	excluded	exclude	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	State	State	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Department	Department	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 6	Iraq	Iraq	PROPN	NNP	Number=Sing	7	compound	7:compound	_
@@ -4989,7 +4989,7 @@
 1	(	(	PUNCT	-LRB-	_	12	punct	12:punct	SpaceAfter=No
 2	Only	only	ADV	RB	_	3	advmod	3:advmod	_
 3	recently	recently	ADV	RB	_	12	advmod	12:advmod	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 6	few	few	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 7	experienced	experienced	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
@@ -5017,7 +5017,7 @@
 3	in	in	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	CPA	CPA	PROPN	NNP	Number=Sing	2	nmod	2:nmod:in	_
-6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	all	all	DET	DT	_	8	det	8:det	_
 8	sorts	sort	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -5027,7 +5027,7 @@
 13	social	social	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	experiments	experiment	NOUN	NNS	Number=Plur	11	conj	8:nmod:of|11:conj:and	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+16	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	impose	impose	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
 19	on	on	ADP	IN	_	22	case	22:case	_
@@ -5112,7 +5112,7 @@
 13	Bush	Bush	PROPN	NNP	Number=Sing	10	obl	10:obl:to	_
 14	administration	administration	NOUN	NN	Number=Sing	13	flat	13:flat	SpaceAfter=No
 15	,	,	PUNCT	,	_	16	punct	16:punct	_
-16	admitted	admit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+16	admitted	admit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 17	on	on	ADP	IN	_	18	case	18:case	_
 18	Sept.	Sept.	PROPN	NNP	Number=Sing	16	obl	16:obl:on	_
 19	10	10	NUM	CD	NumType=Card	18	nummod	18:nummod	SpaceAfter=No
@@ -5148,7 +5148,7 @@
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0014
 # text = I have long been a trenchant critic of the Sadrists.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 3	long	long	ADV	RB	Degree=Pos	7	advmod	7:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	cop	7:cop	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -5164,7 +5164,7 @@
 1	But	but	CCONJ	CC	_	8	cc	8:cc	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
 3-4	haven't	_	_	_	_	_	_	_	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 4	n't	not	PART	RB	_	8	advmod	8:advmod	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	8	cop	8:cop	_
 6	up	up	ADP	IN	_	8	case	8:case	_
@@ -5188,10 +5188,10 @@
 2	in	in	ADP	IN	_	4	case	4:case	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	CPA	CPA	PROPN	NNP	Number=Sing	1	nmod	1:nmod:in	_
-5	sat	sit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	sat	sit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	down	down	ADV	RB	_	5	advmod	5:advmod	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+8	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	ways	way	NOUN	NNS	Number=Plur	8	obj	8:obj	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
@@ -5267,7 +5267,7 @@
 26	,	,	PUNCT	,	_	29	punct	29:punct	_
 27	and	and	CCONJ	CC	_	29	cc	29:cc	_
 28	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	29	nsubj	29:nsubj|30:nsubj:xsubj	_
-29	keep	keep	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+29	keep	keep	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 30	revising	revise	VERB	VBG	VerbForm=Ger	29	xcomp	29:xcomp	_
 31	this	this	DET	DT	Number=Sing|PronType=Dem	32	det	32:det	_
 32	posting	posting	NOUN	NN	Number=Sing	30	obj	30:obj	_
@@ -5276,7 +5276,7 @@
 35	because	because	SCONJ	IN	_	39	mark	39:mark	_
 36	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	39	nsubj	39:nsubj|41:nsubj:xsubj	_
 37-38	don't	_	_	_	_	_	_	_	_
-37	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	39	aux	39:aux	_
+37	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	39	aux	39:aux	_
 38	n't	not	PART	RB	_	39	advmod	39:advmod	_
 39	want	want	VERB	VB	VerbForm=Inf	30	advcl	30:advcl:because	_
 40	to	to	PART	TO	_	41	mark	41:mark	_
@@ -5344,7 +5344,7 @@
 35	April	April	PROPN	NNP	Number=Sing	38	obl	38:obl:on	_
 36	2	2	NUM	CD	NumType=Card	35	nummod	35:nummod	_
 37	AP	AP	PROPN	NNP	Number=Sing	38	nsubj	38:nsubj	_
-38	reported	report	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	csubj	15:csubj	_
+38	reported	report	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	csubj	15:csubj	_
 39	of	of	ADP	IN	_	40	case	40:case	_
 40	Muqtada	Muqtada	PROPN	NNP	Number=Sing	38	obl	38:obl:of	SpaceAfter=No
 41	:	:	PUNCT	:	_	7	punct	7:punct	_
@@ -5389,11 +5389,11 @@
 # text = "I have said and I repeat my expression of solidarity which Hassan Nasrallah called for to stand with Hamas," Shiite cleric Muqtada al-Sadr said Friday in a reference to Nasrallah, the leader of the militant Lebanese Shiite group Hezbollah.
 1	"	"	PUNCT	``	_	29	punct	29:punct	SpaceAfter=No
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	said	say	VERB	VBN	Tense=Past|VerbForm=Part	29	ccomp	29:ccomp	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	repeat	repeat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and|29:ccomp	_
+7	repeat	repeat	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and|29:ccomp	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	expression	expression	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
@@ -5401,7 +5401,7 @@
 12	which	which	PRON	WDT	PronType=Rel	15	obl	11:ref	_
 13	Hassan	Hassan	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj	_
 14	Nasrallah	Nasrallah	PROPN	NNP	Number=Sing	13	flat	13:flat	_
-15	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+15	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 16	for	for	ADP	IN	_	12	case	12:case	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	stand	stand	VERB	VB	VerbForm=Inf	9	acl	9:acl:to	_
@@ -5415,7 +5415,7 @@
 26	al	al	PROPN	NNP	Number=Sing	25	flat	25:flat	SpaceAfter=No
 27	-	-	PUNCT	HYPH	_	25	punct	25:punct	SpaceAfter=No
 28	Sadr	Sadr	PROPN	NNP	Number=Sing	25	flat	25:flat	_
-29	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+29	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 30	Friday	Friday	PROPN	NNP	Number=Sing	29	obl:tmod	29:obl:tmod	_
 31	in	in	ADP	IN	_	33	case	33:case	_
 32	a	a	DET	DT	Definite=Ind|PronType=Art	33	det	33:det	_
@@ -5440,7 +5440,7 @@
 2	month	month	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	Nasrallah	Nasrallah	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-5	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	that	that	SCONJ	IN	_	10	mark	10:mark	_
 7	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	party	party	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
@@ -5480,7 +5480,7 @@
 25	al	al	PROPN	NNP	Number=Sing	28	nsubj	28:nsubj	SpaceAfter=No
 26	-	-	PUNCT	HYPH	_	25	punct	25:punct	SpaceAfter=No
 27	Sadr	Sadr	PROPN	NNP	Number=Sing	25	flat	25:flat	_
-28	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+28	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 29	during	during	ADP	IN	_	33	case	33:case	_
 30	a	a	DET	DT	Definite=Ind|PronType=Art	33	det	33:det	_
 31	Friday	Friday	PROPN	NNP	Number=Sing	32	compound	32:compound	_
@@ -5500,12 +5500,12 @@
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0025
 # text = He did comment on what he meant by the phrase. '
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 3	comment	comment	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	on	on	SCONJ	IN	_	7	mark	7:mark	_
 5	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
 6	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	meant	mean	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:on	_
+7	meant	mean	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:on	_
 8	by	by	ADP	IN	_	10	case	10:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	phrase	phrase	NOUN	NN	Number=Sing	7	obl	7:obl:by	SpaceAfter=No
@@ -5539,7 +5539,7 @@
 23	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 24	Coalition	Coalition	PROPN	NNP	Number=Sing	25	compound	25:compound	_
 25	forces	force	NOUN	NNS	Number=Plur	27	nsubj:pass	27:nsubj:pass	_
-26	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	27	aux:pass	27:aux:pass	_
+26	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	aux:pass	27:aux:pass	_
 27	put	put	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	conj	12:conj:and	_
 28	into	into	ADP	IN	_	30	case	30:case	_
 29	violent	violent	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
@@ -5569,7 +5569,7 @@
 9	;	;	PUNCT	,	_	4	punct	4:punct	_
 10	but	but	CCONJ	CC	_	12	cc	12:cc	_
 11	who	who	PRON	WP	PronType=Int	12	nsubj	12:nsubj|15:nsubj	_
-12	provoked	provoke	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
+12	provoked	provoke	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
 15	why	why	ADV	WRB	PronType=Int	12	conj	12:conj:and	SpaceAfter=No
@@ -5579,7 +5579,7 @@
 # text = I'm not even in Iraq and I could have predicted to you the consequences of doing what the CPA has been doing.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	not	not	PART	RB	_	6	advmod	6:advmod	_
 4	even	even	ADV	RB	_	6	advmod	6:advmod	_
 5	in	in	ADP	IN	_	6	case	6:case	_
@@ -5618,7 +5618,7 @@
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	arrests	arrest	NOUN	NNS	Number=Plur	10	nmod	10:nmod:for	_
-14	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
+14	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	been	be	AUX	VBN	Tense=Past|VerbForm=Part	16	aux:pass	16:aux:pass	_
 16	issued	issue	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	ccomp	7:ccomp	_
 17	months	month	NOUN	NNS	Number=Plur	18	obl:tmod	18:obl:tmod	_
@@ -5629,7 +5629,7 @@
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0030
 # text = Why were they suddenly acted on Saturday?
 1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
 4	suddenly	suddenly	ADV	RB	_	5	advmod	5:advmod	_
 5	acted	act	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
@@ -5682,7 +5682,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3-4	you're	_	_	_	_	_	_	_	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-4	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	in	in	ADV	RB	_	0	root	0:root	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	right	right	INTJ	UH	_	5	discourse	5:discourse	SpaceAfter=No
@@ -5724,7 +5724,7 @@
 # text = you don't know what that means?
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
@@ -5735,7 +5735,7 @@
 # sent_id = email-enronsent23_13-0008
 # text = where did you grow up?
 1	where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	up	up	ADP	RP	_	4	compound:prt	4:compound:prt	SpaceAfter=No
@@ -5762,7 +5762,7 @@
 5	that	that	SCONJ	IN	_	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 7-8	haven't	_	_	_	_	_	_	_	_
-7	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 8	n't	not	PART	RB	_	7	advmod	7:advmod	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	slightest	slight	ADJ	JJS	Degree=Sup	11	amod	11:amod	_
@@ -5803,7 +5803,7 @@
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	friends	friend	NOUN	NNS	Number=Plur	8	conj	8:conj:and|13:nsubj|15:nsubj:xsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 13	going	go	VERB	VBG	VerbForm=Ger	3	conj	3:conj:and	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	party	party	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	SpaceAfter=No
@@ -5815,7 +5815,7 @@
 1	max	max	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	jen	jen	PROPN	NNP	Number=Sing	1	conj	1:conj:and|5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 6	for	for	ADP	IN	_	7	case	7:case	_
 7	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	5	obl	5:obl:for	SpaceAfter=No
@@ -5833,7 +5833,7 @@
 # text = they haven't heard from you in a while.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	haven't	_	_	_	_	_	_	_	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	from	from	ADP	IN	_	6	case	6:case	_
@@ -5863,12 +5863,12 @@
 15	Jen	Jen	PROPN	NNP	Number=Sing	18	vocative	18:vocative	SpaceAfter=No
 16	,	,	PUNCT	,	_	18	punct	18:punct	_
 17	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|23:nsubj	_
-18	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl	10:acl:of	_
+18	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	acl	10:acl:of	_
 19	from	from	ADP	IN	_	21	case	21:case	_
 20	great	great	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	people	people	NOUN	NNS	Number=Plur	18	obl	18:obl:from	_
 22	and	and	CCONJ	CC	_	23	cc	23:cc	_
-23	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	conj	10:acl:of|18:conj:and	_
+23	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	conj	10:acl:of|18:conj:and	_
 24	fantastic	fantastic	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	friends	friend	NOUN	NNS	Number=Plur	23	obj	23:obj	SpaceAfter=No
 26	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -5880,17 +5880,17 @@
 3	Peder	Peder	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	conj	3:conj:and|7:nsubj	_
-6	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
+6	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 7	remarking	remark	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 8	on	on	SCONJ	IN	_	10	mark	10:mark	_
 9	how	how	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 10	agreeable	agreeable	ADJ	JJ	Degree=Pos	7	advcl	7:advcl:on	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 12	all	all	DET	DT	_	11	det	11:det	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 14	as	as	SCONJ	IN	_	16	mark	16:mark	_
 15	the	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs|Typo=Yes	16	nsubj	16:nsubj	CorrectForm=they
-16	sucked	suck	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	_
+16	sucked	suck	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	_
 17	on	on	ADP	IN	_	19	case	19:case	_
 18	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 19	balls	ball	NOUN	NNS	Number=Plur	16	obl	16:obl:on	_
@@ -5910,7 +5910,7 @@
 # newpar id = email-enronsent23_11-p0001
 # text = i have to go to butt-fucking mississippi.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	go	go	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	to	to	ADP	IN	_	9	case	9:case	_
@@ -5954,9 +5954,9 @@
 # newpar id = email-enronsent23_11-p0002
 # text = i think they are all bark and no bite.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj|9:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	all	all	DET	DT	_	6	det	6:det	_
 6	bark	bark	NOUN	NN	Number=Sing	2	ccomp	2:ccomp	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
@@ -5967,7 +5967,7 @@
 # sent_id = email-enronsent23_11-0005
 # text = i think they could get their asses kicked by cats.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	could	could	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 5	get	get	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -5981,14 +5981,14 @@
 # sent_id = email-enronsent23_11-0006
 # text = they look like they were doberman pinchers who were shrunk.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	like	like	SCONJ	IN	_	7	mark	7:mark	_
 4	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-5	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
+5	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
 6	doberman	doberman	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	pinchers	pincher	NOUN	NNS	Number=Plur	2	advcl	2:advcl:like|10:nsubj:pass	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj:pass	7:ref	_
-9	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
+9	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
 10	shrunk	shrink	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -5998,7 +5998,7 @@
 2	should	should	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 3	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
-5	cocker	cocker	NOUN	NN	Number=Sing	6	compound	6:compound	SpaceAfter=No|CorrectSpaceAfter=Yes
+5	cocker	cocker	NOUN	NN	Number=Sing	6	compound	6:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
 6	spaniel	spaniel	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -6015,7 +6015,7 @@
 8	no	no	INTJ	UH	_	12	discourse	12:discourse	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10-11	don't	_	_	_	_	_	_	_	_
-10	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+10	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	n't	not	PART	RB	_	12	advmod	12:advmod	_
 12	want	want	VERB	VB	VerbForm=Inf	6	conj	6:conj:and	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_
@@ -6030,7 +6030,7 @@
 # sent_id = email-enronsent23_11-0009
 # text = i want it b/c it is really small and cute.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	_
 4	b/c	because	SCONJ	IN	Abbr=Yes	8	mark	8:mark	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	8:nsubj|10:nsubj	_
@@ -6044,34 +6044,34 @@
 # sent_id = email-enronsent23_11-0010
 # text = i knew someone in college who had one and i loved it.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	knew	know	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	someone	someone	PRON	NN	Number=Sing	2	obj	2:obj|7:nsubj	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	college	college	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	3:ref	_
-7	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 8	one	one	NUM	CD	NumType=Card	7	obj	7:obj	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	loved	love	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+11	loved	love	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_11-0011
 # text = why do you think they are mean?
 1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	mean	mean	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	SpaceAfter=No
 8	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent23_11-0012
 # newpar id = email-enronsent23_11-p0004
 # text = are you kidding?
-1	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	kidding	kid	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -6091,7 +6091,7 @@
 1	those	that	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	dogs	dog	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 3-4	aren't	_	_	_	_	_	_	_	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	n't	not	PART	RB	_	6	advmod	6:advmod	_
 5	even	even	ADV	RB	_	6	advmod	6:advmod	_
 6	friendly	friendly	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -6099,11 +6099,11 @@
 
 # sent_id = email-enronsent23_11-0015
 # text = do you think they are cool b/c of the taco bell dog?
-1	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	cool	cool	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	_
 7	b/c	because	ADP	IN	Abbr=Yes	12	case	12:case	_
 8	of	of	ADP	IN	_	7	fixed	7:fixed	_
@@ -6192,7 +6192,7 @@
 11	if	if	SCONJ	IN	_	14	mark	14:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
 13	expeditiously	expeditiously	ADV	RB	_	14	advmod	14:advmod	_
-14	suspend	suspend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
+14	suspend	suspend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
 15-16	everyone's	_	_	_	_	_	_	_	_
 15	everyone	everyone	PRON	NN	Number=Sing	17	nmod:poss	17:nmod:poss	_
 16	's	's	PART	POS	_	15	case	15:case	_
@@ -6237,7 +6237,7 @@
 5	where	where	ADV	WRB	PronType=Rel	9	obl	9:obl:from	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	dishes	dish	NOUN	NNS	Number=Plur	9	nsubj:pass	9:nsubj:pass	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
 9	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -6318,7 +6318,7 @@
 24	say	say	VERB	VB	VerbForm=Inf	22	xcomp	22:xcomp	_
 25	that	that	SCONJ	IN	_	27	mark	27:mark	_
 26	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	27	nsubj	27:nsubj	_
-27	oppose	oppose	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	ccomp	24:ccomp	_
+27	oppose	oppose	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	ccomp	24:ccomp	_
 28	direct	direct	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 29	access	access	NOUN	NN	Number=Sing	27	obj	27:obj	SpaceAfter=No
 30	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -6338,7 +6338,7 @@
 # text = you aren't going in for the wedding until sunday now?
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	aren't	_	_	_	_	_	_	_	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	in	in	ADV	RB	_	4	advmod	4:advmod	_
@@ -6355,7 +6355,7 @@
 # text = I'm in
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	in	in	ADV	RB	_	0	root	0:root	_
 
 # sent_id = email-enronsent23_14-0003
@@ -6492,7 +6492,7 @@
 # text = If you have received it in error, please notify the sender immediately and delete the original.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	_
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
 6	in	in	ADP	IN	_	7	case	7:case	_
@@ -6554,7 +6554,7 @@
 # newpar id = email-enronsent23_14-p0006
 # text = what do you mean i am perverted?
 1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
@@ -6568,7 +6568,7 @@
 2	,	,	PUNCT	,	_	8	punct	8:punct	_
 3-4	you're	_	_	_	_	_	_	_	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-4	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+4	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 6	perverted	perverted	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	old	old	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -6579,18 +6579,18 @@
 # newpar id = email-enronsent23_14-p0007
 # text = you love it when i come over.
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	_
 4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:when	_
+6	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:when	_
 7	over	over	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_14-0018
 # text = i satisfy your appetitie for lovin.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	satisfy	satisfy	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	satisfy	satisfy	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	appetitie	appetitie	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	for	for	ADP	IN	_	6	case	6:case	_
@@ -6614,7 +6614,7 @@
 # text = I just wanted to send you a quick note to let you know that I'm outta here!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	send	send	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	iobj	5:iobj	_
@@ -6628,7 +6628,7 @@
 14	that	that	SCONJ	IN	_	17	mark	17:mark	_
 15-16	I'm	_	_	_	_	_	_	_	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-16	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
+16	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
 17-18	outta	_	_	_	_	_	_	_	_
 17	out	out	ADV	RB	_	13	ccomp	13:ccomp	_
 18	ta	of	ADP	IN	Abbr=Yes	19	case	19:case	_
@@ -6679,31 +6679,31 @@
 # sent_id = email-enronsent20_02-0005
 # text = This happened very quickly, and I wanted to make sure that I let everyone know before I left.
 1	This	this	PRON	DT	Number=Sing|PronType=Dem	2	nsubj	2:nsubj	_
-2	happened	happen	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	happened	happen	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	quickly	quickly	ADV	RB	_	2	advmod	2:advmod	SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj|11:nsubj:xsubj	_
-8	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+8	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	make	make	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	sure	sure	ADJ	JJ	Degree=Pos	10	xcomp	10:xcomp	_
 12	that	that	SCONJ	IN	_	14	mark	14:mark	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	let	let	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	ccomp	11:ccomp	_
+14	let	let	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	ccomp	11:ccomp	_
 15	everyone	everyone	PRON	NN	Number=Sing	14	obj	14:obj|16:nsubj:xsubj	_
 16	know	know	VERB	VB	VerbForm=Inf	14	xcomp	14:xcomp	_
 17	before	before	SCONJ	IN	_	19	mark	19:mark	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
-19	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	advcl	14:advcl:before	SpaceAfter=No
+19	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	advcl	14:advcl:before	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent20_02-0006
 # text = I don't have any contact information yet for my new job, but if you want to reach me, you can do so at RobBrnglsn@aol.com or at 713-664-7478.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	any	any	DET	DT	_	7	det	7:det	_
@@ -6718,7 +6718,7 @@
 14	but	but	CCONJ	CC	_	24	cc	24:cc	_
 15	if	if	SCONJ	IN	_	17	mark	17:mark	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj|19:nsubj:xsubj	_
-17	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
+17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	reach	reach	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	19	obj	19:obj	SpaceAfter=No
@@ -6737,7 +6737,7 @@
 # sent_id = email-enronsent20_02-0007
 # text = I enjoyed working with all of you during the past five years at Enron / Azurix, and I wish you all of the best.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	working	work	VERB	VBG	VerbForm=Ger	2	xcomp	2:xcomp	_
 4	with	with	ADP	IN	_	5	case	5:case	_
 5	all	all	DET	DT	_	3	obl	3:obl:with	_
@@ -6755,7 +6755,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+20	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 21	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	20	iobj	20:iobj	_
 22	all	all	DET	DT	_	20	obj	20:obj	_
 23	of	of	ADP	IN	_	25	case	25:case	_
@@ -6839,7 +6839,7 @@
 # sent_id = email-enronsent20_02-0014
 # text = Just wanted to confirm our meeting on Tuesday Aug 29th from 1:30 -2:30 to discuss Uof H's endowment proposal.
 1	Just	just	ADV	RB	_	2	advmod	2:advmod	_
-2	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	confirm	confirm	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -6854,7 +6854,7 @@
 14	2:30	2:30	NUM	CD	NumType=Card	12	nmod	12:nmod	_
 15	to	to	PART	TO	_	16	mark	16:mark	_
 16	discuss	discuss	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:to	_
-17	U	U	PROPN	NNP	Number=Sing	22	nmod:poss	22:nmod:poss	SpaceAfter=No|CorrectSpaceAfter=Yes
+17	U	U	PROPN	NNP	Number=Sing	22	nmod:poss	22:nmod:poss	CorrectSpaceAfter=Yes|SpaceAfter=No
 18	of	of	ADP	IN	_	19	case	19:case	_
 19-20	H's	_	_	_	_	_	_	_	_
 19	H	H	PROPN	NNP	Number=Sing	17	nmod	17:nmod:of	_
@@ -6879,7 +6879,7 @@
 # newpar id = email-enronsent20_02-p0006
 # text = I look forward to seeing you all there.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	forward	forward	ADV	RB	_	2	advmod	2:advmod	_
 4	to	to	SCONJ	IN	_	5	mark	5:mark	_
 5	seeing	see	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl:to	_
@@ -6997,7 +6997,7 @@
 # sent_id = email-enronsent26_02-0009
 # text = We have changed our e-mail address.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	changed	change	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 5	e-mail	e-mail	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -7038,7 +7038,7 @@
 # sent_id = email-enronsent26_02-0012
 # text = Here are two examples: janesmith@paulhastings.com and danjones@paulhastings.com.
 1	Here	here	ADV	RB	PronType=Dem	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	two	two	NUM	CD	NumType=Card	4	nummod	4:nummod	_
 4	examples	example	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	SpaceAfter=No
 5	:	:	PUNCT	:	_	6	punct	6:punct	_
@@ -7051,7 +7051,7 @@
 # text = If you have any questions, please contact us at noc@paulhastings.com.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
 4	any	any	DET	DT	_	5	det	5:det	_
 5	questions	question	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
@@ -7138,7 +7138,7 @@
 # text = If you received this in error, please contact the sender and delete the material from all computers."
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	3	obj	3:obj	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	error	error	NOUN	NN	Number=Sing	3	obl	3:obl:in	SpaceAfter=No
@@ -7179,7 +7179,7 @@
 1	Also	also	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 7	pdf	pdf	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -7271,7 +7271,7 @@
 # sent_id = email-enronsent28_02-0003
 # text = I spoke to Bruce Garcey at NiMo regarding their RFP.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	spoke	speak	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	spoke	speak	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	4	case	4:case	_
 4	Bruce	Bruce	PROPN	NNP	Number=Sing	2	obl	2:obl:to	_
 5	Garcey	Garcey	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -7285,15 +7285,15 @@
 # sent_id = email-enronsent28_02-0004
 # text = Bruce indicated NiMo short listed five companies who all bid higher than ENA.
 1	Bruce	Bruce	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	indicated	indicate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	indicated	indicate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	NiMo	NiMo	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 4	short	short	ADJ	JJ	Degree=Pos	5	advmod	5:advmod	_
-5	listed	list	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	listed	list	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	five	five	NUM	CD	NumType=Card	7	nummod	7:nummod	_
 7	companies	company	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj	7:ref	_
 9	all	all	DET	DT	_	10	advmod	10:advmod	_
-10	bid	bid	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+10	bid	bid	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 11	higher	high	ADV	RBR	Degree=Cmp	10	advmod	10:advmod	_
 12	than	than	ADP	IN	_	13	case	13:case	_
 13	ENA	ENA	PROPN	NNP	Number=Sing	11	obl	11:obl:than	SpaceAfter=No
@@ -7305,9 +7305,9 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	also	also	ADV	RB	_	5	advmod	5:advmod	_
-5	mentioned	mention	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	mentioned	mention	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	close	close	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	sixth	sixth	NOUN	NN	Number=Sing	5	ccomp	5:ccomp|14:nsubj	SpaceAfter=No
@@ -7325,7 +7325,7 @@
 # sent_id = email-enronsent28_02-0006
 # text = He gave no indication on the value of the highest bid.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	no	no	DET	DT	_	4	det	4:det	_
 4	indication	indication	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	on	on	ADP	IN	_	7	case	7:case	_
@@ -7341,7 +7341,7 @@
 # text = He also said that the other five companies making the short list all proposed alternative structures to the proposed NiMo Tier Structure.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	that	that	SCONJ	IN	_	14	mark	14:mark	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 6	other	other	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -7352,7 +7352,7 @@
 11	short	short	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	list	list	NOUN	NN	Number=Sing	9	obj	9:obj	_
 13	all	all	ADV	RB	_	8	det	8:det	_
-14	proposed	propose	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+14	proposed	propose	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 15	alternative	alternative	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 16	structures	structure	NOUN	NNS	Number=Plur	14	obj	14:obj	_
 17	to	to	ADP	IN	_	22	case	22:case	_
@@ -7366,7 +7366,7 @@
 # sent_id = email-enronsent28_02-0008
 # text = NiMo released an additional RFP for peaking supplies for this winter, I believe Phil should have or be getting that RFP.
 1	NiMo	NiMo	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	released	release	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	released	release	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	additional	additional	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	RFP	rfp	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -7378,7 +7378,7 @@
 11	winter	winter	NOUN	NN	Number=Sing	7	obl	7:obl:for	SpaceAfter=No
 12	,	,	PUNCT	,	_	2	punct	2:punct	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+14	believe	believe	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 15	Phil	Phil	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj|20:nsubj	_
 16	should	should	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 17	have	have	VERB	VB	VerbForm=Inf	14	ccomp	14:ccomp	_
@@ -7416,14 +7416,14 @@
 # text = Here you go.
 1	Here	here	ADV	RB	PronType=Dem	3	advmod	3:advmod	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent28_02-0013
 # text = If you have any other questions, please let me know.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	any	any	DET	DT	_	6	det	6:det	_
 5	other	other	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	questions	question	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
@@ -7476,14 +7476,14 @@
 8	sources	source	NOUN	NNS	Number=Plur	6	obl	6:obl:on|11:obj	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	8:ref	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj|14:nsubj:xsubj	_
-11	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+11	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 12	to	to	PART	TO	_	14	mark	14:mark	_
 13	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 14	reliable	reliable	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 15	,	,	PUNCT	,	_	20	punct	20:punct	_
 16	but	but	CCONJ	CC	_	20	cc	20:cc	_
 17	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-18	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+18	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 19	not	not	PART	RB	_	20	advmod	20:advmod	_
 20	represent	represent	VERB	VB	VerbForm=Inf	6	conj	6:conj:but	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_
@@ -7528,7 +7528,7 @@
 2	opinions	opinion	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 3	expressed	express	VERB	VBN	Tense=Past|VerbForm=Part	2	acl	2:acl	_
 4	herein	herein	ADV	RB	_	3	advmod	3:advmod	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	solely	solely	ADV	RB	_	7	advmod	7:advmod	_
 7	those	that	PRON	DT	Number=Plur|PronType=Dem	0	root	0:root	_
 8	of	of	ADP	IN	_	10	case	10:case	_
@@ -7584,7 +7584,7 @@
 # text = The charts are now in the most recent version of Adobe Acrobat 4.0 and they should print clearly from Adobe Acrobat Reader 3.0 or higher.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	charts	chart	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 4	now	now	ADV	RB	_	9	advmod	9:advmod	_
 5	in	in	ADP	IN	_	9	case	9:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -7768,7 +7768,7 @@
 # text = These agreements were forwarded to the counterparty, CCNG, Inc..
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	agreements	agreement	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	forwarded	forward	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 5	to	to	ADP	IN	_	7	case	7:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -7804,9 +7804,9 @@
 21	)	)	PUNCT	-RRB-	_	22	punct	22:punct	_
 22	235-1972	235-1972	NUM	CD	NumType=Card	10	list	10:list	SpaceAfter=No
 23	,	,	PUNCT	,	_	24	punct	24:punct	_
-24	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+24	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 25	and	and	CCONJ	CC	_	26	cc	26:cc	_
-26	informed	inform	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	24	conj	24:conj:and	_
+26	informed	inform	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	24	conj	24:conj:and	_
 27	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	26	iobj	26:iobj	_
 28	that	that	SCONJ	IN	_	35	mark	35:mark	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	30	det	30:det	_
@@ -7823,7 +7823,7 @@
 1	Further	further	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	informed	inform	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	informed	inform	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	iobj	4:iobj	_
 6	that	that	SCONJ	IN	_	32	mark	32:mark	_
 7	Section	section	NOUN	NN	Number=Sing	32	nsubj:pass	14:nsubj|32:nsubj:pass	_
@@ -7964,14 +7964,14 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	redlined	redline	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:and|5:amod	_
 5	version	version	NOUN	NN	Number=Sing	7	nsubj:pass	7:nsubj:pass	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
 7	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
 8	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = email-enronsent28_03-0016
 # text = I revised the language based on our discussions and added the language concerning interest which we had both previously approved.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|10:nsubj	_
-2	revised	revise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	revised	revise	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	language	language	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	based	base	VERB	VBN	Tense=Past|VerbForm=Part	8	case	8:case	_
@@ -7979,14 +7979,14 @@
 7	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	discussions	discussion	NOUN	NNS	Number=Plur	2	obl	2:obl:on	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	added	add	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+10	added	add	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	language	language	NOUN	NN	Number=Sing	10	obj	10:obj|20:obj	_
 13	concerning	concern	VERB	VBG	VerbForm=Ger	14	case	14:case	_
 14	interest	interest	NOUN	NN	Number=Sing	12	nmod	12:nmod:concerning	_
 15	which	which	PRON	WDT	PronType=Rel	20	obj	12:ref	_
 16	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-17	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
+17	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
 18	both	both	ADV	RB	_	20	advmod	20:advmod	_
 19	previously	previously	ADV	RB	_	20	advmod	20:advmod	_
 20	approved	approve	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
@@ -7995,7 +7995,7 @@
 # sent_id = email-enronsent28_03-0017
 # text = We are OK to execute this form.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	OK	ok	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	execute	execute	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:to	_
@@ -8068,7 +8068,7 @@
 # sent_id = email-enronsent28_03-0025
 # text = I survived it without a problem.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	survived	survive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	survived	survive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	_
 4	without	without	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -8091,7 +8091,7 @@
 # text = I didn't realize how much "stuff" you could pack into a one bedroom apartment.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	didn't	_	_	_	_	_	_	_	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	realize	realize	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
@@ -8132,7 +8132,7 @@
 
 # sent_id = email-enronsent28_03-0030
 # text = Are you still chasing that?
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
 4	chasing	chase	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
@@ -8164,7 +8164,7 @@
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
 2	old	old	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	bed	bed	NOUN	NN	Number=Sing	5	nsubj:pass	5:nsubj:pass	_
-4	got	get	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
+4	got	get	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 5	tossed	toss	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 6	in	in	ADP	IN	_	8	case	8:case	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -8174,7 +8174,7 @@
 # sent_id = email-enronsent28_03-0034
 # text = It smelled like shit.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	smelled	smell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	smelled	smell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	like	like	ADP	IN	_	4	case	4:case	_
 4	shit	shit	NOUN	NN	Number=Sing	2	obl	2:obl:like	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -8202,7 +8202,7 @@
 
 # sent_id = email-enronsent28_03-0038
 # text = Did you survive the honeymoon?
-1	Did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+1	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	survive	survive	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
@@ -8213,7 +8213,7 @@
 # newpar id = email-enronsent28_03-p0008
 # text = These look fine to me.
 1	These	this	PRON	DT	Number=Plur|PronType=Dem	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	fine	fine	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obl	2:obl:to	SpaceAfter=No
@@ -8229,7 +8229,7 @@
 6	Brant	Brant	PROPN	NNP	Number=Sing	4	obl	4:obl:to	_
 7	if	if	SCONJ	IN	_	10	mark	10:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -8261,7 +8261,7 @@
 # text = You've all won!
 1-2	You've	_	_	_	_	_	_	_	_
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	all	all	ADV	RB	_	4	advmod	4:advmod	_
 4	won	win	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	4:punct	_
@@ -8302,7 +8302,7 @@
 2	to	to	ADP	IN	_	3	case	3:case	_
 3	all	all	DET	DT	_	1	nmod	1:nmod:to|5:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	5	nsubj	3:ref	_
-5	volunteered	volunteer	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	SpaceAfter=No
+5	volunteered	volunteer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent01_01-0009
@@ -8412,7 +8412,7 @@
 1	Mixed	mix	VERB	VBN	Tense=Past|VerbForm=Part	5	amod	5:amod	_
 2	A	a	NOUN	NN	Number=Sing	4	compound	4:compound	SpaceAfter=No
 3	/	/	PUNCT	,	_	4	punct	4:punct	SpaceAfter=No
-4	A	a	NOUN	NN	Number=Sing	5	compound	5:compound	SpaceAfter=No|CorrectSpaceAfter=Yes
+4	A	a	NOUN	NN	Number=Sing	5	compound	5:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
 5	Team	team	NOUN	NN	Number=Sing	0	root	0:root	_
 6	2	2	NUM	CD	NumType=Card	5	nummod	5:nummod	SpaceAfter=No
 7	:	:	PUNCT	:	_	5	punct	5:punct	_
@@ -8474,9 +8474,9 @@
 # sent_id = email-enronsent01_01-0021
 # text = We hope you do!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	hope	hope	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	SpaceAfter=No
+4	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	SpaceAfter=No
 5	!	!	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent01_01-0022
@@ -8583,7 +8583,7 @@
 2	:	:	PUNCT	:	_	1	punct	1:punct	_
 3	If	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:if	_
 6	any	any	DET	DT	_	7	det	7:det	_
 7	questions	question	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 8	regarding	regard	VERB	VBG	VerbForm=Ger	11	case	11:case	_
@@ -8615,13 +8615,13 @@
 # sent_id = email-enronsent01_01-0029
 # text = you know that both o'neal and matt are out?
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	9	mark	9:mark	_
 4	both	both	CCONJ	CC	_	5	cc:preconj	5:cc:preconj	_
 5	o'neal	o'neal	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
 7	matt	matt	PROPN	NNP	Number=Sing	5	conj	5:conj:and|9:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 9	out	out	ADV	RB	_	2	ccomp	2:ccomp	SpaceAfter=No
 10	?	?	PUNCT	.	_	2	punct	2:punct	_
 
@@ -8646,7 +8646,7 @@
 # sent_id = email-enronsent01_01-0031
 # text = i have not gotten a good response so i think shanna and i are going to stay in town.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	gotten	get	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -8654,11 +8654,11 @@
 7	response	response	NOUN	NN	Number=Sing	4	obj	4:obj	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+10	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
 11	shanna	shanna	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj|17:nsubj:xsubj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	conj	11:conj:and|15:nsubj|17:nsubj:xsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 15	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	10	ccomp	10:ccomp	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	stay	stay	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
@@ -8697,7 +8697,7 @@
 
 # sent_id = email-enronsent01_01-0035
 # text = have you heard from anyone?
-1	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	from	from	ADP	IN	_	5	case	5:case	_
@@ -8773,7 +8773,7 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3-4	I'm	_	_	_	_	_	_	_	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	very	very	ADV	RB	_	6	advmod	6:advmod	_
 6	happy	happy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	for	for	ADP	IN	_	8	case	8:case	_
@@ -8783,7 +8783,7 @@
 # sent_id = email-enronsent01_01-0041
 # text = How are you?
 1	How	how	ADV	WRB	PronType=Int	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	nsubj	1:nsubj	SpaceAfter=No
 4	?	?	PUNCT	.	_	1	punct	1:punct	_
 
@@ -8820,12 +8820,12 @@
 # sent_id = email-enronsent08_01-0002
 # text = I meant to comment that I thought the people profiled in the article should pull their heads out of their self important asses.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	meant	mean	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	meant	mean	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	comment	comment	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	that	that	SCONJ	IN	_	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	people	people	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
 10	profiled	profile	VERB	VBN	Tense=Past|VerbForm=Part	9	acl	9:acl	_
@@ -8893,7 +8893,7 @@
 1	Things	thing	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
 2	with	with	ADP	IN	_	3	case	3:case	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	nmod	1:nmod:with	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -8914,7 +8914,7 @@
 13	sooner	soon	ADJ	JJR	Degree=Cmp	8	acl:relcl	8:acl:relcl	_
 14	than	than	SCONJ	IN	_	16	mark	16:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:than	_
+16	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:than	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 18	would	would	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 19	be	be	AUX	VB	VerbForm=Inf	20	aux	20:aux	_
@@ -8926,7 +8926,7 @@
 25	knocks	knock	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	advcl	27:advcl:when	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
 27-28	gotta	_	_	_	_	_	_	_	_
-27	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:but	_
+27	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	1	conj	1:conj:but	_
 28	ta	to	PART	TO	Abbr=Yes	29	mark	29:mark	_
 29	go	go	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	SpaceAfter=No
 30	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -8941,7 +8941,7 @@
 # text = I don't hear from you in months and then you level me with such a thought provoking, soul searching article.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	hear	hear	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	from	from	ADP	IN	_	6	case	6:case	_
@@ -8951,7 +8951,7 @@
 9	and	and	CCONJ	CC	_	12	cc	12:cc	_
 10	then	then	ADV	RB	PronType=Dem	12	advmod	12:advmod	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	level	level	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+12	level	level	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	obj	12:obj	_
 14	with	with	ADP	IN	_	22	case	22:case	_
 15	such	such	DET	PDT	_	22	det:predet	22:det:predet	_
@@ -8981,7 +8981,7 @@
 # text = I really enjoyed reading it.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
 2	really	really	ADV	RB	_	3	advmod	3:advmod	_
-3	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	reading	read	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -8990,7 +8990,7 @@
 # text = We certainly fit into certain parts of the article.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	certainly	certainly	ADV	RB	_	3	advmod	3:advmod	_
-3	fit	fit	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	fit	fit	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	into	into	ADP	IN	_	6	case	6:case	_
 5	certain	certain	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	parts	part	NOUN	NNS	Number=Plur	3	obl	3:obl:into	_
@@ -9002,7 +9002,7 @@
 # sent_id = email-enronsent08_01-0015
 # text = There are a few life theories like that which working through.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	few	few	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	life	life	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -9028,7 +9028,7 @@
 # newpar id = email-enronsent08_01-p0002
 # text = How are things going with you?
 1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	things	thing	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 4	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	with	with	ADP	IN	_	6	case	6:case	_
@@ -9037,7 +9037,7 @@
 
 # sent_id = email-enronsent08_01-0018
 # text = Are you enjoying Houston?
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	enjoying	enjoy	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	Houston	Houston	PROPN	NNP	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -9068,7 +9068,7 @@
 1	Traders	trader	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 2	over	over	ADP	IN	_	3	case	3:case	_
 3	here	here	ADV	RB	PronType=Dem	1	nmod	1:nmod:over	_
-4	seem	seem	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	seem	seem	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	have	have	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -9240,7 +9240,7 @@
 4	next	next	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	time	time	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	amstel	Amstel	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	lights	Light	PROPN	NNPS	Number=Plur	7	obj	7:obj	_
 10	together	together	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
@@ -9311,19 +9311,19 @@
 # text = If you are not the intended recipient, you are hereby notified that you have received this transmittal in error; any review, dissemination, distribution or copying of this transmittal is strictly prohibited.
 1	If	if	SCONJ	IN	_	7	mark	7:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 4	not	not	PART	RB	_	7	advmod	7:advmod	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	intended	intend	VERB	VBN	Tense=Past|VerbForm=Part	7	amod	7:amod	_
 7	recipient	recipient	NOUN	NN	Number=Sing	12	advcl	12:advcl:if	SpaceAfter=No
 8	,	,	PUNCT	,	_	12	punct	12:punct	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj:pass	12:nsubj:pass	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
 11	hereby	hereby	ADV	RB	_	12	advmod	12:advmod	_
 12	notified	notify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 13	that	that	SCONJ	IN	_	16	mark	16:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-15	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+15	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 16	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	12	ccomp	12:ccomp	_
 17	this	this	DET	DT	Number=Sing|PronType=Dem	18	det	18:det	_
 18	transmittal	transmittal	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -9350,7 +9350,7 @@
 # text = If you have received this transmittal and/or attachments in error, please notify us immediately by reply or by telephone (call us collect at +1 212-848-8400) and immediately delete this message and all its attachments.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
 6	transmittal	transmittal	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -9391,7 +9391,7 @@
 
 # sent_id = email-enronsent08_01-0045
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -9493,7 +9493,7 @@
 # newpar id = email-enronsent30_02-p0001
 # text = You have always been on the move seeking affectionate, satisfying and harmonious relationships.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 3	always	always	ADV	RB	_	7	advmod	7:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	cop	7:cop	_
 5	on	on	ADP	IN	_	7	case	7:case	_
@@ -9560,7 +9560,7 @@
 20	if	if	SCONJ	IN	_	24	mark	24:mark	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj	_
 22-23	haven't	_	_	_	_	_	_	_	_
-22	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
+22	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	n't	not	PART	RB	_	24	advmod	24:advmod	_
 24	found	find	VERB	VBN	Tense=Past|VerbForm=Part	32	advcl	32:advcl:if	_
 25	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	obj	24:obj	_
@@ -9579,19 +9579,19 @@
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	past	past	NOUN	NN	Number=Sing	6	obl	6:obl:in	_
 4	there	there	PRON	EX	_	6	expl	6:expl	_
-5	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 7	..	..	PUNCT	,	_	6	punct	6:punct	_
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_
 9	maybe	maybe	ADV	RB	_	12	advmod	12:advmod	_
 10	there	there	PRON	EX	_	12	expl	12:expl	_
 11	still	still	ADV	RB	_	12	advmod	12:advmod	_
-12	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
+12	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
 13	many	many	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	things	thing	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 15	that	that	PRON	WDT	PronType=Dem	20	obl	20:obl:without	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|20:nsubj:xsubj	_
-17	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 18	had	have	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	do	do	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
@@ -9601,7 +9601,7 @@
 # sent_id = email-enronsent30_02-0005
 # text = You have now decided to set your sights on a position or situation that could give you greater prestige and which will afford you considerable self esteem.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	now	now	ADV	RB	_	4	advmod	4:advmod	_
 4	decided	decide	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -9632,7 +9632,7 @@
 # sent_id = email-enronsent30_02-0006
 # text = You wear your heart on your sleeve ... and since you are an emotional person you are apt to give your all ... heart and soul ... to all those that show you a little affection ... but take care... it would appear that you have been extremely hurt in the past...and you keep leaving yourself wide open for punishment..
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|39:nsubj	_
-2	wear	wear	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wear	wear	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	heart	heart	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	on	on	ADP	IN	_	7	case	7:case	_
@@ -9642,12 +9642,12 @@
 9	and	and	CCONJ	CC	_	18	cc	18:cc	_
 10	since	since	SCONJ	IN	_	15	mark	15:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	an	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	emotional	emotional	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	person	person	NOUN	NN	Number=Sing	18	advcl	18:advcl:since	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|20:nsubj:xsubj	_
-17	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+17	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 18	apt	apt	ADJ	JJ	Degree=Pos	2	conj	2:conj:and	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	give	give	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
@@ -9662,7 +9662,7 @@
 29	all	all	DET	PDT	_	30	det:predet	30:det:predet	_
 30	those	that	DET	DT	Number=Plur|PronType=Dem	20	obl	20:obl:to|32:nsubj	_
 31	that	that	PRON	WDT	PronType=Rel	32	nsubj	30:ref	_
-32	show	show	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
+32	show	show	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
 33	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	32	iobj	32:iobj	_
 34	a	a	DET	DT	Definite=Ind|PronType=Art	36	det	36:det	_
 35	little	little	ADJ	JJ	Degree=Pos	36	amod	36:amod	_
@@ -9677,7 +9677,7 @@
 44	appear	appear	VERB	VB	VerbForm=Inf	2	conj	2:conj:but	_
 45	that	that	SCONJ	IN	_	50	mark	50:mark	_
 46	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	50	nsubj:pass	50:nsubj:pass	_
-47	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	50	aux	50:aux	_
+47	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	50	aux	50:aux	_
 48	been	be	AUX	VBN	Tense=Past|VerbForm=Part	50	aux:pass	50:aux:pass	_
 49	extremely	extremely	ADV	RB	_	50	advmod	50:advmod	_
 50	hurt	hurt	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	44	ccomp	44:ccomp	_
@@ -9687,7 +9687,7 @@
 54	...	...	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 55	and	and	CCONJ	CC	_	57	cc	57:cc	_
 56	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	57	nsubj	57:nsubj|58:nsubj:xsubj	_
-57	keep	keep	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+57	keep	keep	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 58	leaving	leave	VERB	VBG	VerbForm=Ger	57	xcomp	57:xcomp	_
 59	yourself	yourself	PRON	PRP	Case=Acc|Number=Sing|Person=2|PronType=Prs|Reflex=Yes	58	obj	58:obj|61:nsubj:xsubj	_
 60	wide	wide	ADV	RB	_	61	advmod	61:advmod	_
@@ -9700,7 +9700,7 @@
 # text = Whatever you strive to do, something always seems to be holding you back.
 1	Whatever	whatever	PRON	WP	PronType=Int	3	obj	3:obj|5:nsubj:xsubj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	strive	strive	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl	_
+3	strive	strive	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	SpaceAfter=No
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -9727,14 +9727,14 @@
 # sent_id = email-enronsent30_02-0009
 # text = You are a clear thinker and all you demand from life, in a relationship, is a partner whom you can trust and with whom you can, together, develop a foundation of trust based on understanding.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	clear	clear	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	thinker	thinker	NOUN	NN	Number=Sing	0	root	0:root	_
 6	and	and	CCONJ	CC	_	19	cc	19:cc	_
 7	all	all	DET	DT	_	19	nsubj	19:nsubj	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	demand	demand	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	from	from	ADP	IN	_	11	case	11:case	_
 11	life	life	NOUN	NN	Number=Sing	9	obl	9:obl:from	SpaceAfter=No
 12	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -9770,14 +9770,14 @@
 # sent_id = email-enronsent30_02-0010
 # text = You are your own person... and you demand freedom of thought ...to follow your own convictions.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	own	own	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	person	person	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 6	...	...	PUNCT	,	_	5	punct	5:punct	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	demand	demand	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 10	freedom	freedom	NOUN	NN	Number=Sing	9	obj	9:obj	_
 11	of	of	ADP	IN	_	12	case	12:case	_
 12	thought	thought	NOUN	NN	Number=Sing	10	nmod	10:nmod:of	_
@@ -9792,7 +9792,7 @@
 # sent_id = email-enronsent30_02-0011
 # text = You have no interest in "two-timing" and all you seek is sincerity and "straight-dealing".
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	no	no	DET	DT	_	4	det	4:det	_
 4	interest	interest	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	in	in	ADP	IN	_	9	case	9:case	_
@@ -9804,7 +9804,7 @@
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	all	all	DET	DT	_	16	nsubj	16:nsubj|21:nsubj	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	seek	seek	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	seek	seek	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	sincerity	sincerity	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
 17	and	and	CCONJ	CC	_	21	cc	21:cc	_
@@ -9818,7 +9818,7 @@
 # sent_id = email-enronsent30_02-0012
 # text = You wish to be left in peace... no more conflict and no more differences of opinion ...
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|5:nsubj:xsubj	_
-2	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	5	mark	5:mark	_
 4	be	be	AUX	VB	VerbForm=Inf	5	aux:pass	5:aux:pass	_
 5	left	leave	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	xcomp	2:xcomp	_
@@ -9843,7 +9843,7 @@
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj|10:nsubj:xsubj	_
 4	just	just	ADV	RB	_	7	advmod	7:advmod	_
 5-6	don't	_	_	_	_	_	_	_	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	_	7	advmod	7:advmod	_
 7	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	to	to	PART	TO	_	10	mark	10:mark	_
@@ -9863,7 +9863,7 @@
 # text = All you want is for "them" to get on with it - and to leave you alone..
 1	All	all	DET	DT	_	4	nsubj	4:nsubj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	for	for	SCONJ	IN	_	10	mark	10:mark	_
 6	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
@@ -9901,7 +9901,7 @@
 8	earlier	early	ADV	RBR	Degree=Cmp	4	advmod	4:advmod	_
 9	(	(	PUNCT	-LRB-	_	11	punct	11:punct	SpaceAfter=No
 10	totally	totally	ADV	RB	_	11	advmod	11:advmod	_
-11	forgot	forget	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+11	forgot	forget	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	open	open	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
@@ -9934,7 +9934,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
 7	any	any	DET	DT	_	8	det	8:det	_
 8	questions	question	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -9954,7 +9954,7 @@
 # sent_id = email-enronsent30_02-0021
 # newpar id = email-enronsent30_02-p0006
 # text = Do you still have the historical nymex settle file that you created for Lavo's spread analysis?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
 4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -9965,7 +9965,7 @@
 9	file	file	NOUN	NN	Number=Sing	4	obj	4:obj|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	created	create	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+12	created	create	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 13	for	for	ADP	IN	_	17	case	17:case	_
 14-15	Lavo's	_	_	_	_	_	_	_	_
 14	Lavo	Lavo	PROPN	NNP	Number=Sing	17	nmod:poss	17:nmod:poss	_
@@ -9978,7 +9978,7 @@
 # text = If you do would you send me a copy?
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
+3	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
 4	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 6	send	send	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -10036,7 +10036,7 @@
 # text = If you are located in London, Calgary, Toronto, Omaha, New York, Portland (ENA) or Houston, you can access the live event at http://home.enron.com/employeemeeting.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	26	advcl	26:advcl:if	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	London	London	PROPN	NNP	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
@@ -10088,7 +10088,7 @@
 11	and	and	CCONJ	CC	_	15	cc	15:cc	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 13-14	didn't	_	_	_	_	_	_	_	_
-13	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
+13	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
 14	n't	not	PART	RB	_	15	advmod	15:advmod	_
 15	submit	submit	VERB	VB	VerbForm=Inf	4	conj	4:conj:and	_
 16	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
@@ -10099,7 +10099,7 @@
 # sent_id = email-enronsent30_02-0029
 # text = I tried to do it on the HRonline web-site, but the procedure is too complicated.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	do	do	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
@@ -10150,7 +10150,7 @@
 # sent_id = email-enronsent30_02-0032
 # newpar id = email-enronsent30_02-p0010
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -10191,7 +10191,7 @@
 # sent_id = email-enronsent29_01-0004
 # text = I have attached a revised copy of the GISB Agreement and Special Provisions for your review and consideration.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	revised	revise	VERB	VBN	Tense=Past|VerbForm=Part	6	amod	6:amod	_
@@ -10213,7 +10213,7 @@
 # sent_id = email-enronsent29_01-0005
 # text = I anticipate completing the review of the Master Agreement form and submitting comments to you by Monday.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj|12:nsubj:xsubj	_
-2	anticipate	anticipate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	anticipate	anticipate	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	completing	complete	VERB	VBG	VerbForm=Ger	2	xcomp	2:xcomp	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	review	review	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -10237,7 +10237,7 @@
 2	addition	addition	NOUN	NN	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	feedback	feedback	NOUN	NN	Number=Sing	5	obj	5:obj	_
 7	from	from	ADP	IN	_	10	case	10:case	_
 8	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -10261,7 +10261,7 @@
 26	to	to	ADP	IN	_	27	case	27:case	_
 27	CPS	cps	NOUN	NN	Number=Sing	24	obl	24:obl:to	_
 28	---	---	PUNCT	,	_	5	punct	5:punct	_
-29	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
+29	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
 30	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	31	nsubj	31:nsubj	_
 31	know	know	VERB	VB	VerbForm=Inf	5	parataxis	5:parataxis	_
 32	who	who	PRON	WP	PronType=Int	34	nsubj	34:nsubj	_
@@ -10280,7 +10280,7 @@
 # sent_id = email-enronsent29_01-0007
 # text = Greatly appreciate your prompt feedback to this inquiry.
 1	Greatly	greatly	ADV	RB	_	2	advmod	2:advmod	_
-2	appreciate	appreciate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	appreciate	appreciate	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	prompt	prompt	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	feedback	feedback	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -10292,7 +10292,7 @@
 # sent_id = email-enronsent29_01-0008
 # text = I look forward to your feedback on the GISB.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	forward	forward	ADV	RB	_	2	advmod	2:advmod	_
 4	to	to	ADP	IN	_	6	case	6:case	_
 5	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -10342,7 +10342,7 @@
 # text = PS- Were you having phone system problems this morning?
 1	PS	ps	NOUN	NN	Number=Sing	5	advmod	5:advmod	SpaceAfter=No
 2	-	-	PUNCT	,	_	5	punct	5:punct	_
-3	Were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+3	Were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 5	having	have	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 6	phone	phone	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -10357,7 +10357,7 @@
 1	Myself	myself	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	5	nsubj	5:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	Credit	credit	NOUN	NN	Number=Sing	1	conj	1:conj:and|5:nsubj	_
-4	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+4	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 5	calling	call	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 6	in	in	ADV	RB	_	5	advmod	5:advmod	_
 7	and	and	CCONJ	CC	_	12	cc	12:cc	_
@@ -10365,7 +10365,7 @@
 9	of	of	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	calls	call	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	_
-12	rolled	roll	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+12	rolled	roll	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 13	into	into	ADP	IN	_	15	case	15:case	_
 14	voice	voice	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	mail	mail	NOUN	NN	Number=Sing	12	obl	12:obl:into	_
@@ -10460,7 +10460,7 @@
 # newpar id = email-enronsent29_01-p0003
 # text = I have sent your question re on line trading to that area.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	sent	send	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	question	question	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -10543,7 +10543,7 @@
 3	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 4	all	all	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	"	"	PUNCT	''	_	4	punct	4:punct	_
-6	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 8	intend	intend	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 9	10MM	10mm	NOUN	NN	Number=Sing	8	obj	8:obj	_
@@ -10607,7 +10607,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
 8	anything	anything	PRON	NN	Number=Sing	7	obj	7:obj	_
 9	else	else	ADJ	JJ	Degree=Pos	8	amod	8:amod	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -10644,7 +10644,7 @@
 # text = As you see it was CES acquired by ENA in asset purchase.
 1	As	as	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	see	see	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:as	_
+3	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:as	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 6	CES	ces	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -10698,7 +10698,7 @@
 # newpar id = email-enronsent29_01-p0016
 # text = I do not find the term "Alternate Transporter Imbalance" in our agreement..
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -10737,7 +10737,7 @@
 4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
 5-6	your	_	_	_	_	_	_	_	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-6	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+6	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 7	referencing	reference	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	SpaceAfter=No
 8	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -10783,7 +10783,7 @@
 # sent_id = email-enronsent29_01-0053
 # text = These look fine to me.
 1	These	this	PRON	DT	Number=Plur|PronType=Dem	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	fine	fine	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obl	2:obl:to	SpaceAfter=No
@@ -10799,7 +10799,7 @@
 6	Brant	Brant	PROPN	NNP	Number=Sing	4	obl	4:obl:to	_
 7	if	if	SCONJ	IN	_	10	mark	10:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -10835,7 +10835,7 @@
 # newpar id = email-enronsent29_01-p0022
 # text = You are correct, I will make the appropriate changes and give you another review before sending execution papers.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	correct	correct	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj|12:nsubj	_
@@ -10904,7 +10904,7 @@
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 4	see	see	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:as	_
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	several	several	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	blanks	blank	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 9	concerning	concern	VERB	VBG	VerbForm=Ger	11	case	11:case	_
@@ -10943,7 +10943,7 @@
 
 # sent_id = email-enronsent29_01-0069
 # text = Do you have this information?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
@@ -11090,7 +11090,7 @@
 # newpar id = email-enronsent29_01-p0033
 # text = They are taking delivery in the U.S.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	taking	take	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	delivery	delivery	NOUN	NN	Number=Sing	3	obj	3:obj	_
 5	in	in	ADP	IN	_	7	case	7:case	_
@@ -11129,7 +11129,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	data	data	NOUN	NN	Number=Sing	3	obj	3:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+8	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 9	:	:	PUNCT	:	_	12	punct	12:punct	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	shall	shall	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -11164,7 +11164,7 @@
 # sent_id = email-enronsent19_02-0007
 # text = I used to e-mail Vince Kaminski about the advice on his article "The Challenge of Pricing and Risk Managing Electricity Derivatives" and he had mailed me the copy.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	e-mail	e-mail	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	Vince	Vince	PROPN	NNP	Number=Sing	4	obj	4:obj	_
@@ -11188,7 +11188,7 @@
 23	"	"	PUNCT	''	_	15	punct	15:punct	_
 24	and	and	CCONJ	CC	_	27	cc	27:cc	_
 25	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	27:nsubj	_
-26	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	27	aux	27:aux	_
+26	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	27	aux	27:aux	_
 27	mailed	mail	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:and	_
 28	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	27	iobj	27:iobj	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	30	det	30:det	_
@@ -11215,7 +11215,7 @@
 16	Diffusion	diffusion	NOUN	NN	Number=Sing	17	compound	17:compound	_
 17	Model	model	NOUN	NN	Number=Sing	10	obj	10:obj	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
-19	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+19	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 20	followed	follow	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:and	_
 21	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	22	nmod:poss	22:nmod:poss	_
 22	paper	paper	NOUN	NN	Number=Sing	20	obj	20:obj	_
@@ -11238,7 +11238,7 @@
 # sent_id = email-enronsent19_02-0009
 # text = I use Queensland half-hourly price during 13 December, 1998-30 June 2001 giving about 44,000 price observations.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	use	use	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Queensland	Queensland	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 4	half	half	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
 5	-	-	PUNCT	HYPH	_	6	punct	6:punct	SpaceAfter=No
@@ -11292,9 +11292,9 @@
 3	and	and	CCONJ	CC	_	5	cc	5:cc	_
 4	standard	standard	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	error	error	NOUN	NN	Number=Sing	2	conj	2:conj:and|6:nsubj	_
-6	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	as	as	SCONJ	IN	_	8	mark	8:mark	_
-8	followed	follow	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	SpaceAfter=No
+8	followed	follow	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	SpaceAfter=No
 9	:	:	PUNCT	:	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent19_02-0012
@@ -11347,7 +11347,7 @@
 # sent_id = email-enronsent19_02-0016
 # text = I have also tried monthly data and the results are the same.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	also	also	ADV	RB	_	4	advmod	4:advmod	_
 4	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	monthly	monthly	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -11355,7 +11355,7 @@
 7	and	and	CCONJ	CC	_	12	cc	12:cc	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	results	result	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	same	same	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	SpaceAfter=No
 13	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -11457,7 +11457,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	uncertainties	uncertainty	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	face	face	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+11	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 12	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent19_02-0027
@@ -11491,7 +11491,7 @@
 2	now	now	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
 3	,	,	PUNCT	,	_	8	punct	8:punct	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj|23:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 6	in	in	ADP	IN	_	8	case	8:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	process	process	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -11524,7 +11524,7 @@
 # text = Until we have come up with those numbers it would be premature to make any offers for the summer.
 1	Until	until	SCONJ	IN	_	4	mark	4:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	come	come	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl	12:advcl:until	_
 5	up	up	ADV	RB	_	4	advmod	4:advmod	_
 6	with	with	ADP	IN	_	8	case	8:case	_
@@ -11601,7 +11601,7 @@
 # text = When we start the summer process, we will interview the candidate and slot him for your group.
 1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	start	start	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:when	_
+3	start	start	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:when	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	summer	summer	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	process	process	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -11632,7 +11632,7 @@
 # sent_id = email-enronsent19_02-0035
 # newpar id = email-enronsent19_02-p0010
 # text = Hope all is well with you
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	all	all	DET	DT	_	4	nsubj	4:nsubj	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	well	well	ADJ	JJ	Degree=Pos	1	ccomp	1:ccomp	_
@@ -11657,7 +11657,7 @@
 # newpar id = email-enronsent19_02-p0011
 # text = I have visited Georgia Tech on Thursday.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	visited	visit	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Georgia	Georgia	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Tech	Tech	PROPN	NNP	Number=Sing	3	obj	3:obj	_
@@ -11685,7 +11685,7 @@
 # sent_id = email-enronsent19_02-0041
 # text = He came across as a very bright person, very personable.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	across	across	ADV	RB	_	2	advmod	2:advmod	_
 4	as	as	ADP	IN	_	8	case	8:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -11732,7 +11732,7 @@
 # sent_id = email-enronsent19_02-0046
 # text = How are you doing?
 1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -11740,9 +11740,9 @@
 # sent_id = email-enronsent19_02-0047
 # text = I hope you have a good flight back to home.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	good	good	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	flight	flight	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -11770,7 +11770,7 @@
 
 # sent_id = email-enronsent19_02-0049
 # text = Thank you for your time.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
@@ -11781,7 +11781,7 @@
 # newpar id = email-enronsent19_02-p0015
 # text = I have already submitted my resume and cover letter right after the talk.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	already	already	ADV	RB	_	4	advmod	4:advmod	_
 4	submitted	submit	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -11800,7 +11800,7 @@
 1	However	however	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	ask	ask	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	ask	ask	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	4:obj|7:nsubj:xsubj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	send	send	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
@@ -11818,7 +11818,7 @@
 # text = Those attachments are what I was asked.
 1	Those	that	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	attachments	attachment	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj:pass	7:nsubj:pass	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	7:aux:pass	_
@@ -11850,7 +11850,7 @@
 21	and	and	CCONJ	CC	_	24	cc	24:cc	_
 22	what	what	PRON	WP	PronType=Int	24	obj	24:obj|27:nsubj:xsubj	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
-24	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	conj	13:obj|17:conj:and	_
+24	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	conj	13:obj|17:conj:and	_
 25	to	to	PART	TO	_	27	mark	27:mark	_
 26	more	more	ADV	RBR	_	27	advmod	27:advmod	_
 27	focus	focus	VERB	VB	VerbForm=Inf	24	xcomp	24:xcomp	_
@@ -11879,7 +11879,7 @@
 
 # sent_id = email-enronsent19_02-0055
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -12042,7 +12042,7 @@
 # sent_id = email-enronsent00_02-0006
 # newpar id = email-enronsent00_02-p0003
 # text = Thank you,
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	,	,	PUNCT	,	_	1	punct	1:punct	_
 
@@ -12067,7 +12067,7 @@
 5	terminated	terminate	VERB	VBN	Tense=Past|VerbForm=Part	6	amod	6:amod	_
 6	employees	employee	NOUN	NNS	Number=Plur	3	obl	3:obl:to|9:nsubj:pass	_
 7	who	who	PRON	WP	PronType=Rel	9	nsubj:pass	6:ref	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
 9	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	_
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
 11	in	in	ADP	IN	_	13	case	13:case	_
@@ -12202,10 +12202,10 @@
 # text = As you know, we are in the process of transferring recordkeeping services from NTRC to Hewitt.
 1	As	as	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:as	SpaceAfter=No
+3	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:as	SpaceAfter=No
 4	,	,	PUNCT	,	_	9	punct	9:punct	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	process	process	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -12225,7 +12225,7 @@
 2	such	such	ADJ	JJ	Degree=Pos	5	obl	5:obl:as	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	CPA	cpa	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	SpaceAfter=No
 8	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -12337,7 +12337,7 @@
 # sent_id = email-enronsent00_02-0023
 # newpar id = email-enronsent00_02-p0011
 # text = Thank you for digging in to the issue of Deferred Phantom Stock Units.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	SCONJ	IN	_	4	mark	4:mark	_
 4	digging	dig	VERB	VBG	VerbForm=Ger	1	advcl	1:advcl:for	_
@@ -12374,7 +12374,7 @@
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 4	still	still	ADV	RB	_	7	advmod	7:advmod	_
 5-6	don't	_	_	_	_	_	_	_	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	_	7	advmod	7:advmod	_
 7	understand	understand	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	which	which	DET	WDT	PronType=Int	9	det	9:det	_
@@ -12480,7 +12480,7 @@
 # sent_id = email-enronsent00_02-0029
 # newpar id = email-enronsent00_02-p0012
 # text = Thank you,
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	,	,	PUNCT	,	_	1	punct	1:punct	_
 
@@ -12498,7 +12498,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
+6	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	quotes	quote	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	from	from	ADP	IN	_	10	case	10:case	_
@@ -12565,7 +12565,7 @@
 # text = If they are getting quotes to put up new rock then we will need to clarify.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:if	_
 5	quotes	quote	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -12602,13 +12602,13 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	negotiations	negotiation	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	stall	stall	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	SpaceAfter=No
+4	stall	stall	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	7:expl	_
 7	seems	seem	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	like	like	SCONJ	IN	_	10	mark	10:mark	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj|15:nsubj:xsubj	_
-10	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:like	_
+10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:like	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	go	go	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	ahead	ahead	ADV	RB	_	12	advmod	12:advmod	_
@@ -12675,7 +12675,7 @@
 # sent_id = email-enronsent00_02-0047
 # text = I faxed you the promotional on 10300 Heritage Office Building with the Nimitz post office.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	faxed	fax	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	faxed	fax	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	iobj	2:iobj	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	promotional	promotional	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -12695,12 +12695,12 @@
 # text = The broker called back shortly after I spoke to you to let me know that the kestrel air park building and the strip center at fm78 & walzem had both sold.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	broker	broker	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	back	back	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	shortly	shortly	ADV	RB	_	3	advmod	3:advmod	_
 6	after	after	SCONJ	IN	_	8	mark	8:mark	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	spoke	speak	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:after	_
+8	spoke	speak	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:after	_
 9	to	to	ADP	IN	_	10	case	10:case	_
 10	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	8	obl	8:obl:to	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
@@ -12721,7 +12721,7 @@
 26	fm78	fm78	PROPN	NNP	Number=Sing	24	nmod	24:nmod:at	_
 27	&	&	CCONJ	CC	_	28	cc	28:cc	_
 28	walzem	walzem	PROPN	NNP	Number=Sing	26	conj	24:nmod:at|26:conj	_
-29	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
+29	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
 30	both	both	ADV	RB	_	31	advmod	31:advmod	_
 31	sold	sell	VERB	VBN	Tense=Past|VerbForm=Part	14	ccomp	14:ccomp	SpaceAfter=No
 32	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -12733,7 +12733,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	what	what	PRON	WP	PronType=Int	6	obj	6:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
 9	property	property	NOUN	NN	Number=Sing	6	obl	6:obl:of	SpaceAfter=No
@@ -12780,7 +12780,7 @@
 # sent_id = email-enronsent00_02-0054
 # text = I tried to calculate the IRR on the port Aransas and Roma post offices.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	calculate	calculate	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -12803,7 +12803,7 @@
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	clients	client	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 6	usually	usually	ADV	RB	_	7	advmod	7:advmod	_
-7	evaluate	evaluate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
+7	evaluate	evaluate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
 8	these	this	DET	DT	Number=Plur|PronType=Dem	9	det	9:det	_
 9	properties	property	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	?	?	PUNCT	.	_	1	punct	1:punct	_
@@ -12838,7 +12838,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	limitations	limitation	NOUN	NNS	Number=Plur	3	obl	3:obl:than	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-8	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
+8	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
 9	describing	describe	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
@@ -12866,9 +12866,9 @@
 # sent_id = newsgroup-groups.google.com_AlaskaTheLastFrontier_e483fe7209d6282b_ENG_20050531_202500-0001
 # newpar id = newsgroup-groups.google.com_AlaskaTheLastFrontier_e483fe7209d6282b_ENG_20050531_202500-p0001
 # text = Hope you enjoy the posts and feel free to jump in anywhere.
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	enjoy	enjoy	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
+3	enjoy	enjoy	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	posts	post	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
@@ -12883,7 +12883,7 @@
 # sent_id = newsgroup-groups.google.com_AlaskaTheLastFrontier_e483fe7209d6282b_ENG_20050531_202500-0002
 # newpar id = newsgroup-groups.google.com_AlaskaTheLastFrontier_e483fe7209d6282b_ENG_20050531_202500-p0002
 # text = Hope to see you soon!
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	to	to	PART	TO	_	3	mark	3:mark	_
 3	see	see	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	obj	3:obj	_
@@ -12903,7 +12903,7 @@
 # text = All you have to do is sign up for one free offer (such as efax) and then cancel within the offer time frame.
 1	All	all	DET	DT	_	6	nsubj	6:nsubj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
@@ -13025,13 +13025,13 @@
 # newpar id = newsgroup-groups.google.com_APassionforRats_13b309ec29808aeb_ENG_20050523_143400-p0001
 # text = I took a tip from Carri and looked up Rat ASCII's on Google.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|8:nsubj	_
-2	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	tip	tip	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	from	from	ADP	IN	_	6	case	6:case	_
 6	Carri	Carri	PROPN	NNP	Number=Sing	2	obl	2:obl:from	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+8	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	Rat	rat	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	ASCII's	ascii'	NOUN	NNS	Number=Plur	8	obj	8:obj	_
@@ -13085,7 +13085,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13142,7 +13142,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13200,7 +13200,7 @@
 5	inputs	input	NOUN	NNS	Number=Plur	8	obl	8:obl:on	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	Army	army	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
-8	arrested	arrest	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+8	arrested	arrest	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 9	Ghulam	Ghulam	PROPN	NNP	Number=Sing	8	obj	8:obj	_
 10	Mohiuddin	Mohiuddin	PROPN	NNP	Number=Sing	9	flat	9:flat	_
 11	Lone	Lone	PROPN	NNP	Number=Sing	9	flat	9:flat	SpaceAfter=No
@@ -13223,7 +13223,7 @@
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	Lone	Lone	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|16:nsubj	_
 7	'	'	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
-8	confessed	confess	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+8	confessed	confess	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 9	'	'	PUNCT	''	_	8	punct	8:punct	_
 10	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	involvement	involvement	NOUN	NN	Number=Sing	8	obj	8:obj	_
@@ -13231,7 +13231,7 @@
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	blasts	blast	NOUN	NNS	Number=Plur	11	nmod	11:nmod:in	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	conj	8:conj:and	_
+16	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	conj	8:conj:and	_
 17	several	several	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 18	vital	vital	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	clues	clue	NOUN	NNS	Number=Plur	16	obj	16:obj	SpaceAfter=No
@@ -13357,7 +13357,7 @@
 # text = All you have to do is become a member and watch your earnings grow!
 1	All	all	DET	DT	_	6	nsubj	6:nsubj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
@@ -13375,7 +13375,7 @@
 # sent_id = newsgroup-groups.google.com_DorothyofOz_7933f288ff583a7f_ENG_20050607_240200-0001
 # newpar id = newsgroup-groups.google.com_DorothyofOz_7933f288ff583a7f_ENG_20050607_240200-p0001
 # text = Thank you for helping us to sell out of our first issue, now let your friends and local news organizations know that a delicious reprint, with a hot spanking new cover by Greg Mannino, is available for order on our website.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	SCONJ	IN	_	4	mark	4:mark	_
 4	helping	help	VERB	VBG	VerbForm=Ger	1	advcl	1:advcl:for	_
@@ -13570,7 +13570,7 @@
 # newpar id = newsgroup-groups.google.com_AlexandrianReligiousStudies_ebcd97e243c4440b_ENG_20051021_201800-p0001
 # text = I apologize for the following inconvenience, but I have decided to move this group to Yahoo, so that we can post files and photos and other useful things.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	apologize	apologize	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	apologize	apologize	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	for	for	ADP	IN	_	6	case	6:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	following	follow	VERB	VBG	VerbForm=Ger	6	amod	6:amod	_
@@ -13578,7 +13578,7 @@
 7	,	,	PUNCT	,	_	11	punct	11:punct	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-10	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	decided	decide	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:but	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	move	move	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
@@ -13608,7 +13608,7 @@
 3	update	update	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 4	whatever	whatever	PRON	WP	PronType=Int	3	obj	3:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	to	to	PART	TO	_	6	xcomp	6:xcomp	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	_
@@ -13619,7 +13619,7 @@
 # text = Again I apologize, but it'll be better over there.
 1	Again	again	ADV	RB	_	3	advmod	3:advmod	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	apologize	apologize	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	apologize	apologize	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	9	punct	9:punct	_
 5	but	but	CCONJ	CC	_	9	cc	9:cc	_
 6-7	it'll	_	_	_	_	_	_	_	_
@@ -13653,7 +13653,7 @@
 3	last	last	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	news	news	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	message	message	NOUN	NN	Number=Sing	6	nsubj	6:nsubj|9:nsubj:xsubj	_
-6	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	out	out	ADV	RP	_	6	compound:prt	6:compound:prt	_
 8	kinda	kinda	ADV	RB	_	9	advmod	9:advmod	_
 9	weird	weird	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	SpaceAfter=No
@@ -13668,7 +13668,7 @@
 18	website	website	NOUN	NN	Number=Sing	15	obj	15:obj	_
 19	while	while	SCONJ	IN	_	21	mark	21:mark	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	changed	change	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:while	_
+21	changed	change	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:while	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	text	text	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24-25	iwas	_	_	_	_	_	_	_	_
@@ -13680,13 +13680,13 @@
 29	up	up	ADV	RB	_	28	advmod	28:advmod	_
 30	but	but	CCONJ	CC	_	32	cc	32:cc	_
 31	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	32	nsubj	32:nsubj	_
-32	ran	run	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	conj	13:conj:but	_
+32	ran	run	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	conj	13:conj:but	_
 33	out	out	ADP	RP	_	32	compound:prt	32:compound:prt	_
 34	of	of	ADP	IN	_	35	case	35:case	_
 35	time	time	NOUN	NN	Number=Sing	32	obl	32:obl:of	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
 37	there	there	PRON	EX	_	38	expl	38:expl	_
-38	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	32	conj	32:conj	_
+38	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	conj	32:conj	_
 39	no	no	DET	DT	_	41	det	41:det	_
 40	real	real	ADJ	JJ	Degree=Pos	41	amod	41:amod	_
 41	pictures	picture	NOUN	NNS	Number=Plur	38	nsubj	38:nsubj	_
@@ -13730,7 +13730,7 @@
 # text = I've never been a smoker & am a very strong anti-smoker, but I'm an over-eater & so I know how hard it is to change a habit.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj|12:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 3	never	never	ADV	RB	_	6	advmod	6:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -13745,13 +13745,13 @@
 14	but	but	CCONJ	CC	_	18	cc	18:cc	_
 15-16	I'm	_	_	_	_	_	_	_	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-16	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+16	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 17	an	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	over-eater	over-eater	NOUN	NN	Number=Sing	6	conj	6:conj:but	_
 19	&	&	CCONJ	CC	_	22	cc	22:cc	_
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-22	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	conj	18:conj	_
+22	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	conj	18:conj	_
 23	how	how	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 24	hard	hard	ADJ	JJ	Degree=Pos	22	ccomp	22:ccomp	_
 25	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	expl	24:expl	_
@@ -13825,7 +13825,7 @@
 16	talking	talk	VERB	VBG	VerbForm=Ger	17	amod	17:amod	_
 17	parakeets	parakeet	NOUN	NNS	Number=Plur	15	obj	15:obj|22:nsubj|26:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	22	nsubj	17:ref	_
-19	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
+19	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
 20	not	not	PART	RB	_	22	advmod	22:advmod	_
 21	just	just	ADV	RB	_	22	advmod	22:advmod	_
 22	mimicking	mimic	VERB	VBG	VerbForm=Ger	17	acl:relcl	17:acl:relcl	SpaceAfter=No
@@ -13885,7 +13885,7 @@
 # sent_id = newsgroup-groups.google.com_RagnarokOnlineII_5730bc7888fcee99_ENG_20051122_035600-0003
 # text = I got these pictures from tgs, look at all of them if you have time, they're preety cool...
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	these	this	DET	DT	Number=Plur|PronType=Dem	4	det	4:det	_
 4	pictures	picture	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	from	from	ADP	IN	_	6	case	6:case	_
@@ -13898,12 +13898,12 @@
 12	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	10	nmod	10:nmod:of	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
+15	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
 16	time	time	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	2	punct	2:punct	_
 18-19	they're	_	_	_	_	_	_	_	_
 18	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-19	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
+19	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
 20	preety	pretty	ADV	RB	_	21	advmod	21:advmod	_
 21	cool	cool	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	SpaceAfter=No
 22	...	...	PUNCT	,	_	2	punct	2:punct	_
@@ -13959,7 +13959,7 @@
 2	,	,	PUNCT	,	_	7	punct	7:punct	_
 3-4	they're	_	_	_	_	_	_	_	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-4	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+4	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 5	all	all	ADV	RB	_	7	advmod	7:advmod	_
 6	from	from	ADP	IN	_	7	case	7:case	_
 7	4gamer	4gamer	PROPN	NNP	Number=Sing	0	root	0:root	SpaceAfter=No
@@ -13994,7 +13994,7 @@
 # newpar id = newsgroup-groups.google.com_alt.animals.cat_04d718686843b577_ENG_20040713_101600-p0002
 # text = I have a friend that has to get rid of one of her cats because of allergies, he is the youngest at 3 years old black, long hair, incredibly friendly.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	friend	friend	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj|8:nsubj:xsubj|9:nsubj:xsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
@@ -14087,11 +14087,11 @@
 # text = Like you said "the kids egg him on".
 1	Like	like	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:like	_
+3	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:like	_
 4	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	kids	kid	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-7	egg	egg	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	egg	egg	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	_
 9	on	on	ADP	RP	_	7	compound:prt	7:compound:prt	SpaceAfter=No
 10	"	"	PUNCT	''	_	7	punct	7:punct	SpaceAfter=No
@@ -14127,7 +14127,7 @@
 7	play	play	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
+10	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 11	to	to	PART	TO	_	10	xcomp	10:xcomp	SpaceAfter=No
 12	..	..	PUNCT	.	_	5	punct	5:punct	_
 
@@ -14135,7 +14135,7 @@
 # text = He didn't take a dislike to the kids for "no" reason!
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	didn't	_	_	_	_	_	_	_	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -14153,15 +14153,15 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_119630d7ce2d2e9c_ENG_20051107_021600-0008
 # text = cats react to the treatment they receive, they are not toys.
 1	cats	cat	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
-2	react	react	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	react	react	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	treatment	treatment	NOUN	NN	Number=Sing	2	obl	2:obl:to	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	receive	receive	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+7	receive	receive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	not	not	PART	RB	_	12	advmod	12:advmod	_
 12	toys	toy	NOUN	NNS	Number=Plur	2	parataxis	2:parataxis	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -14202,7 +14202,7 @@
 13	D	D	PROPN	NNP	Number=Sing	11	conj	10:obj|11:conj	_
 14	3.5	3.5	NUM	CD	NumType=Card	11	compound	11:compound	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	conj	5:acl:relcl|8:conj:and	_
+16	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	conj	5:acl:relcl|8:conj:and	_
 17	in	in	ADP	IN	_	24	case	24:case	_
 18	or	or	CCONJ	CC	_	19	cc	19:cc	_
 19	around	around	ADP	IN	_	17	conj	17:conj:or|24:case	_
@@ -14216,7 +14216,7 @@
 # sent_id = newsgroup-groups.google.com_DungeonsDragonsChillicotheOH45601_022e6f4a0cd6fb61_ENG_20050829_233300-0002
 # text = We have two people so far, and I am able to DM...although DM's are welcome.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	two	two	NUM	CD	NumType=Card	4	nummod	4:nummod	_
 4	people	people	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	so	so	ADV	RB	_	6	advmod	6:advmod	_
@@ -14231,7 +14231,7 @@
 14	...	...	PUNCT	,	_	11	punct	11:punct	SpaceAfter=No
 15	although	although	SCONJ	IN	_	18	mark	18:mark	_
 16	DM's	dm'	NOUN	NNS	Number=Plur	18	nsubj	18:nsubj	_
-17	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+17	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 18	welcome	welcome	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:although	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -14267,7 +14267,7 @@
 10	and	and	CCONJ	CC	_	18	cc	18:cc	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:if	_
 14	any	any	DET	DT	_	15	det	15:det	_
 15	question	question	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	18	punct	18:punct	_
@@ -14277,13 +14277,13 @@
 
 # sent_id = newsgroup-groups.google.com_DungeonsDragonsChillicotheOH45601_022e6f4a0cd6fb61_ENG_20050829_233300-0005
 # text = Thank you very much and we hope to hear from you soon!
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	much	much	ADV	RB	_	1	advmod	1:advmod	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
-7	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
+7	hope	hope	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	hear	hear	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	from	from	ADP	IN	_	11	case	11:case	_
@@ -14359,7 +14359,7 @@
 # sent_id = newsgroup-groups.google.com_n3td3v_a04e0c855b022009_ENG_20051207_035500-0006
 # text = You have received this BBC Breaking News Alert because you subscribed to it or, someone forwarded it to you.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 5	BBC	BBC	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -14368,13 +14368,13 @@
 8	Alert	Alert	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 9	because	because	SCONJ	IN	_	11	mark	11:mark	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	subscribed	subscribe	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:because	_
+11	subscribed	subscribe	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:because	_
 12	to	to	ADP	IN	_	13	case	13:case	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obl	11:obl:to	_
 14	or	or	CCONJ	CC	_	17	cc	17:cc	SpaceAfter=No
 15	,	,	PUNCT	,	_	17	punct	17:punct	_
 16	someone	someone	PRON	NN	Number=Sing	17	nsubj	17:nsubj	_
-17	forwarded	forward	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	conj	3:advcl:because|11:conj:or	_
+17	forwarded	forward	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	conj	3:advcl:because|11:conj:or	_
 18	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	obj	17:obj	_
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	17	obl	17:obl:to	SpaceAfter=No
@@ -14413,7 +14413,7 @@
 # text = While there have been spasms of speculation about the Bush administration naming a replacement for O'Keefe, no nominee has been declared.
 1	While	while	SCONJ	IN	_	4	mark	4:mark	_
 2	there	there	PRON	EX	_	4	expl	4:expl	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	been	be	VERB	VBN	Tense=Past|VerbForm=Part	22	advcl	22:advcl:while	_
 5	spasms	spasm	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 6	of	of	ADP	IN	_	7	case	7:case	_
@@ -14533,7 +14533,7 @@
 2	multiple	multiple	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 3	planetary	planetary	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	afflictions	affliction	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	taking	take	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 7	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	toll	toll	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
@@ -14586,7 +14586,7 @@
 23	Saturn	Saturn	PROPN	NNP	Number=Sing	31	nsubj	31:nsubj	_
 24	and	and	CCONJ	CC	_	25	cc	25:cc	_
 25	Venus	Venus	PROPN	NNP	Number=Sing	23	conj	23:conj:and|31:nsubj	_
-26	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	31	cop	31:cop	_
+26	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	cop	31:cop	_
 27	also	also	ADV	RB	_	31	advmod	31:advmod	_
 28	under	under	ADP	IN	_	31	case	31:case	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
@@ -14642,7 +14642,7 @@
 18	Saturn	Saturn	PROPN	NNP	Number=Sing	26	nsubj	26:nsubj	_
 19	and	and	CCONJ	CC	_	20	cc	20:cc	_
 20	Venus	Venus	PROPN	NNP	Number=Sing	18	conj	18:conj:and|26:nsubj	_
-21	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	cop	26:cop	_
+21	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	cop	26:cop	_
 22	also	also	ADV	RB	_	26	advmod	26:advmod	_
 23	under	under	ADP	IN	_	26	case	26:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
@@ -14730,7 +14730,7 @@
 13	cats	cat	NOUN	NNS	Number=Plur	11	nmod	11:nmod:of	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
 15	kittens	kitten	NOUN	NNS	Number=Plur	13	conj	11:nmod:of|13:conj:and	_
-16	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux:pass	17:aux:pass	_
+16	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	17:aux:pass	_
 17	added	add	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 18	to	to	ADP	IN	_	21	case	21:case	_
 19	The	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
@@ -14765,7 +14765,7 @@
 # text = If you are new to "The Cat Album" I can tell you that you'll find more than 1100 pictures of cute cats at this site.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	new	new	ADJ	JJ	Degree=Pos	13	advcl	13:advcl:if	_
 5	to	to	ADP	IN	_	9	case	9:case	_
 6	"	"	PUNCT	``	_	9	punct	9:punct	SpaceAfter=No
@@ -14867,7 +14867,7 @@
 1	And	and	CCONJ	CC	_	12	cc	12:cc	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	send	send	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+4	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	iobj	4:iobj	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	story	story	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
@@ -14924,7 +14924,7 @@
 3	yep	yep	INTJ	UH	_	6	discourse	6:discourse	SpaceAfter=No
 4	,	,	PUNCT	,	_	6	punct	6:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj|8:nsubj:xsubj	_
-6	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	wear	wear	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	silk	silk	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -14941,7 +14941,7 @@
 # sent_id = newsgroup-groups.google.com_MeninLingerie_78adf09ead5e7e87_ENG_20041219_035800-0003
 # text = I feel great in it.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	great	great	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obl	2:obl:in	SpaceAfter=No
@@ -14952,7 +14952,7 @@
 1	First	first	ADJ	JJ	Degree=Pos|NumType=Ord	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	12	obl:tmod	12:obl:tmod	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|5:nsubj:xsubj	_
-4	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	wearing	wear	VERB	VBG	VerbForm=Ger	4	xcomp	4:xcomp	_
 6-7	woman's	_	_	_	_	_	_	_	_
 6	woman	woman	NOUN	NN	Number=Sing	8	nmod:poss	8:nmod:poss	_
@@ -14968,7 +14968,7 @@
 # text = I didn't fought is it good or not than.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	didn't	_	_	_	_	_	_	_	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	fought	fight	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -14984,7 +14984,7 @@
 1	Later	later	ADV	RB	_	2	advmod	2:advmod	_
 2	on	on	ADV	RB	_	4	advmod	4:advmod	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	red	red	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	red	red	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	somewhere	somewhere	ADV	RB	_	4	advmod	4:advmod	_
 6	that	that	SCONJ	IN	_	9	mark	9:mark	_
 7-8	it's	_	_	_	_	_	_	_	_
@@ -15007,7 +15007,7 @@
 10	...	...	PUNCT	,	_	3	punct	3:punct	_
 11	until	until	SCONJ	IN	_	13	mark	13:mark	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	undrstood	undrstood	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:until	_
+13	undrstood	undrstood	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:until	_
 14	that	that	SCONJ	IN	_	18	mark	18:mark	_
 15-16	it's	_	_	_	_	_	_	_	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
@@ -15033,7 +15033,7 @@
 # text = Now I have wife and son.
 1	Now	now	ADV	RB	_	3	advmod	3:advmod	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	wife	wife	NOUN	NN	Number=Sing	3	obj	3:obj	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	son	son	NOUN	NN	Number=Sing	4	conj	3:obj|4:conj:and	SpaceAfter=No
@@ -15043,7 +15043,7 @@
 # text = My wife know my harmless secret and supports me.
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	wife	wife	NOUN	NN	Number=Sing	3	nsubj	3:nsubj|8:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 5	harmless	harmless	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	secret	secret	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -15058,10 +15058,10 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3-4	I'm	_	_	_	_	_	_	_	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|7:nsubj|9:nsubj:xsubj	_
-4	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	Men	man	NOUN	NNS	Number=Plur	0	root	0:root	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+7	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	wear	wear	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10-11	women's	_	_	_	_	_	_	_	_
@@ -15100,7 +15100,7 @@
 9	,	,	PUNCT	,	_	2	punct	2:punct	_
 10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
+12	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
 13	home	home	ADV	RB	_	12	advmod	12:advmod	_
 14	at	at	ADP	IN	_	15	case	15:case	_
 15	night	night	NOUN	NN	Number=Sing	12	obl	12:obl:at	_
@@ -15108,7 +15108,7 @@
 17	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	18	amod	18:amod	_
 18	thing	thing	NOUN	NN	Number=Sing	21	nsubj	21:nsubj	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+20	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 21	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 22	change	change	VERB	VB	VerbForm=Inf	21	parataxis	21:parataxis	_
 23	into	into	ADP	IN	_	27	case	27:case	_
@@ -15119,7 +15119,7 @@
 28	or	or	CCONJ	CC	_	29	cc	29:cc	_
 29	nightie	nightie	NOUN	NN	Number=Sing	27	conj	22:obl:into|27:conj:or	SpaceAfter=No
 30	,	,	PUNCT	,	_	2	punct	2:punct	_
-31	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+31	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	feel	feel	NOUN	NN	Number=Sing	31	obj	31:obj	SpaceAfter=No
 34	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -15150,12 +15150,12 @@
 2	travelers	traveler	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	executives	executive	NOUN	NNS	Number=Plur	2	conj	2:conj:and|8:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 6	among	among	ADP	IN	_	8	case	8:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	masses	mass	NOUN	NNS	Number=Plur	0	root	0:root|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
@@ -15178,7 +15178,7 @@
 9	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	7	nmod	7:nmod:for	_
 10	since	since	SCONJ	IN	_	12	mark	12:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	travel	travel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
+12	travel	travel	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
 13	very	very	ADV	RB	_	14	advmod	14:advmod	_
 14	frequently	frequently	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -15205,7 +15205,7 @@
 9	tickets	ticket	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 10	because	because	SCONJ	IN	_	12	mark	12:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	tie	tie	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
+12	tie	tie	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
 13	up	up	ADP	RP	_	12	compound:prt	12:compound:prt	_
 14	with	with	ADP	IN	_	15	case	15:case	_
 15	some	some	DET	DT	_	12	obl	12:obl:with	_
@@ -15223,7 +15223,7 @@
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
 28	services	service	NOUN	NNS	Number=Plur	26	conj	12:obl:on|26:conj:and	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	_
+30	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	_
 31	from	from	ADP	IN	_	33	case	33:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	airlines	airline	NOUN	NNS	Number=Plur	30	obl	30:obl:from	SpaceAfter=No
@@ -15233,7 +15233,7 @@
 # text = Corporate plans are clubbed with other services through some agencies to provide better service for their staff.
 1	Corporate	corporate	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	plans	plan	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	clubbed	club	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 5	with	with	ADP	IN	_	7	case	7:case	_
 6	other	other	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -15265,7 +15265,7 @@
 4	Malaysia	Malaysia	PROPN	NNP	Number=Sing	2	nmod	2:nmod:like	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	Singapore	Singapore	PROPN	NNP	Number=Sing	4	conj	2:nmod:like|4:conj:and	_
-7	promote	promote	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	promote	promote	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	trading	trading	NOUN	NN	Number=Sing	7	obj	7:obj	_
 9	for	for	ADP	IN	_	11	case	11:case	_
 10	foreign	foreign	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -15285,7 +15285,7 @@
 3	period	period	NOUN	NN	Number=Sing	6	obl	6:obl:during	SpaceAfter=No
 4	,	,	PUNCT	,	_	6	punct	6:punct	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	offer	offer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	offer	offer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	cheap	cheap	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 8	air	air	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	tickets	ticket	NOUN	NNS	Number=Plur	6	obj	6:obj	_
@@ -15342,7 +15342,7 @@
 2	years	year	NOUN	NNS	Number=Plur	3	obl:npmod	3:obl:npmod	_
 3	ago	ago	ADV	RB	_	5	advmod	5:advmod	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	developed	develop	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	developed	develop	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 7	short	short	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 8	paper	paper	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -15358,7 +15358,7 @@
 18	pilot	pilot	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	study	study	NOUN	NN	Number=Sing	21	obl	21:obl:in	SpaceAfter=No
 20	,	,	PUNCT	,	_	21	punct	21:punct	_
-21	discriminated	discriminate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+21	discriminated	discriminate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 22	between	between	ADP	IN	_	23	case	23:case	_
 23	ADHD	adhd	NOUN	NN	Number=Sing	21	obl	21:obl:between	SpaceAfter=No
 24	,	,	PUNCT	,	_	25	punct	25:punct	_
@@ -15373,7 +15373,7 @@
 # text = I recently converted this test to an online test in order to norm it to a larger population and, subsequently, to make it available to any one who has access to a computer and the Internet.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	recently	recently	ADV	RB	_	3	advmod	3:advmod	_
-3	converted	convert	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	converted	convert	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	test	test	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	ADP	IN	_	9	case	9:case	_
@@ -15473,7 +15473,7 @@
 6	test	test	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	subjects	subject	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+9	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 11	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 12	take	take	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
@@ -15500,7 +15500,7 @@
 # sent_id = newsgroup-groups.google.com_homeopathyclinic_46a87f7e5ce279d5_ENG_20051107_133800-0007
 # text = I think a test like this one is much needed.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	test	test	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 5	like	like	ADP	IN	_	7	case	7:case	_
@@ -15541,7 +15541,7 @@
 # text = Perhaps you are willing to recommend this site and, if you have a website, place a link on your website.
 1	Perhaps	perhaps	ADV	RB	_	4	advmod	4:advmod	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj|17:nsubj:xsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	willing	willing	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	recommend	recommend	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
@@ -15551,7 +15551,7 @@
 10	,	,	PUNCT	,	_	17	punct	17:punct	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	website	website	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -15567,27 +15567,27 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-0001
 # newpar id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-p0001
 # text = are there any sadists out there who share the same tastes as i do ?
-1	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	_	4	det	4:det	_
 4	sadists	sadist	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|8:nsubj	_
 5	out	out	ADV	RB	_	6	advmod	6:advmod	_
 6	there	there	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 7	who	who	PRON	WP	PronType=Rel	8	nsubj	4:ref	_
-8	share	share	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+8	share	share	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	same	same	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	tastes	taste	NOUN	NNS	Number=Plur	8	obj	8:obj	_
 12	as	as	SCONJ	IN	_	14	mark	14:mark	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advmod	10:advmod	_
+14	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	advmod	10:advmod	_
 15	?	?	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-0002
 # text = i dont know what it is , but since a very young age i have had a strange but very gratifying urge to torture or maime animals.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	dont	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	nt	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	what	what	PRON	WP	PronType=Int	4	ccomp	4:ccomp	_
@@ -15601,7 +15601,7 @@
 13	young	young	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	age	age	NOUN	NN	Number=Sing	17	obl	17:obl:since	_
 15	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-16	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
+16	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 17	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:but	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 19	strange	strange	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
@@ -15625,7 +15625,7 @@
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 7	really	really	ADV	RB	_	9	advmod	9:advmod	_
-8	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	get	get	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 10	sexual	sexual	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	releif	releif	NOUN	NN	Number=Sing	9	obj	9:obj	_
@@ -15672,7 +15672,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	so	so	ADV	RB	_	12	advmod	12:advmod	_
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	conj	8:conj	_
+12	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	conj	8:conj	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	few	few	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	words	word	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	_
@@ -15830,7 +15830,7 @@
 # text = I'm a freelance journalist specializing in health, with 30 years experience.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	freelance	freelance	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	journalist	journalist	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -15848,7 +15848,7 @@
 # text = I'm the author of three books (including the 1.3 million seller ALTERNATIVE CURES) and hundreds of magazine articles, and worked for 20 years at Rodale Press, as a writer and as editor-in-chief of Prevention and Rodale Books.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|24:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	author	author	NOUN	NN	Number=Sing	0	root	0:root	_
 5	of	of	ADP	IN	_	7	case	7:case	_
@@ -15870,7 +15870,7 @@
 21	articles	article	NOUN	NNS	Number=Plur	18	nmod	18:nmod:of	SpaceAfter=No
 22	,	,	PUNCT	,	_	24	punct	24:punct	_
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
-24	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+24	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 25	for	for	ADP	IN	_	27	case	27:case	_
 26	20	20	NUM	CD	NumType=Card	27	nummod	27:nummod	_
 27	years	year	NOUN	NNS	Number=Plur	24	obl	24:obl:for	_
@@ -15959,7 +15959,7 @@
 13	dieters	dieter	NOUN	NNS	Number=Plur	3	obl	3:obl:from|16:nsubj	_
 14	who	who	PRON	WP	PronType=Rel	16	nsubj	13:ref	_
 15	successfully	successfully	ADV	RB	_	16	advmod	16:advmod	_
-16	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	natural	natural	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	supplement	supplement	NOUN	NN	Number=Sing	16	obj	16:obj|21:nsubj:xsubj	_
@@ -15974,7 +15974,7 @@
 28	agents	agent	NOUN	NNS	Number=Plur	31	nsubj	31:nsubj	_
 29	under	under	ADP	IN	_	30	case	30:case	_
 30	discussion	discussion	NOUN	NN	Number=Sing	28	nmod	28:nmod:under	_
-31	include	include	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+31	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 32	HCA	hca	NOUN	NN	Number=Sing	31	obj	31:obj	SpaceAfter=No
 33	,	,	PUNCT	,	_	34	punct	34:punct	_
 34	MCT	mct	NOUN	NN	Number=Sing	32	conj	31:obj|32:conj:and	SpaceAfter=No
@@ -16014,7 +16014,7 @@
 1	If	if	SCONJ	IN	_	5	mark	5:mark	_
 2-3	you've	_	_	_	_	_	_	_	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-3	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	successfully	successfully	ADV	RB	_	5	advmod	5:advmod	_
 5	used	use	VERB	VBN	Tense=Past|VerbForm=Part	16	advcl	16:advcl:if	_
 6	any	any	DET	DT	_	5	obj	5:obj|11:nsubj:xsubj	_
@@ -16045,7 +16045,7 @@
 
 # sent_id = newsgroup-groups.google.com_eHolistic_b8e32f451114ecc2_ENG_20051118_192000-0008
 # text = Thank you for your time and attention.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
@@ -16087,7 +16087,7 @@
 16	-	-	PUNCT	HYPH	_	17	punct	17:punct	SpaceAfter=No
 17	Cola	Cola	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	corporation	corporation	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	_
-19	built	build	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+19	built	build	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
 21	bottling	bottling	NOUN	NN	Number=Sing	22	compound	22:compound	_
 22	plant	plant	NOUN	NN	Number=Sing	19	obj	19:obj	_
@@ -16124,7 +16124,7 @@
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	mighty	mighty	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	corporation	corporation	NOUN	NN	Number=Sing	18	nsubj	18:nsubj|20:nsubj:xsubj	_
-18	promised	promise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+18	promised	promise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	bring	bring	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -16145,18 +16145,18 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	village	village	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	people	people	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-11	began	begin	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	began	begin	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	notice	notice	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	wells	well	NOUN	NNS	Number=Plur	17	nsubj	17:nsubj|18:nsubj:xsubj	_
-16	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
+16	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
 17	running	run	VERB	VBG	VerbForm=Ger	13	ccomp	13:ccomp	_
 18	dry	dry	ADJ	JJ	Degree=Pos	17	xcomp	17:xcomp	SpaceAfter=No
 19	,	,	PUNCT	,	_	22	punct	22:punct	_
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
-22	complained	complain	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	conj	11:conj	_
+22	complained	complain	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	conj	11:conj	_
 23	to	to	ADP	IN	_	25	case	25:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	corporation	corporation	NOUN	NN	Number=Sing	22	obl	22:obl:to	SpaceAfter=No
@@ -16167,14 +16167,14 @@
 1	Coca	Coca	PROPN	NNP	Number=Sing	3	compound	3:compound	SpaceAfter=No
 2	-	-	PUNCT	HYPH	_	3	punct	3:punct	SpaceAfter=No
 3	Cola	Cola	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj|11:nsubj|13:nsubj:xsubj	_
-4	calmed	calm	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	calmed	calm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	concerns	concern	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	people	people	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
-11	attempted	attempt	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+11	attempted	attempt	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	win	win	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	back	back	ADP	RP	_	13	compound:prt	13:compound:prt	_
@@ -16210,7 +16210,7 @@
 5	use	use	NOUN	NN	Number=Sing	3	nmod	3:nmod:of	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	arrive	arrive	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	arrive	arrive	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 9	at	at	ADP	IN	_	12	case	12:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 11	present	present	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
@@ -16219,7 +16219,7 @@
 14	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	village	village	NOUN	NN	Number=Sing	16	compound	16:compound	_
 16	people	people	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-17	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	suddenly	suddenly	ADV	RB	_	19	advmod	19:advmod	_
 19	discovered	discover	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
@@ -16257,7 +16257,7 @@
 3	soil	soil	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	water	water	NOUN	NN	Number=Sing	3	conj	3:conj:and|10:nsubj:pass	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
 7	now	now	ADV	RB	_	10	advmod	10:advmod	_
 8	too	too	ADV	RB	_	9	advmod	9:advmod	_
 9	heavily	heavily	ADV	RB	_	10	advmod	10:advmod	_
@@ -16335,7 +16335,7 @@
 9	(	(	PUNCT	-LRB-	_	10	punct	10:punct	SpaceAfter=No
 10	GNOFHAC	GNOFHAC	PROPN	NNP	Number=Sing	8	appos	8:appos	SpaceAfter=No
 11	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
-12	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+12	filed	file	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 14	housing	housing	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	discrimination	discrimination	NOUN	NN	Number=Sing	16	compound	16:compound	_
@@ -16427,7 +16427,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	current	current	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	complaints	complaint	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	allege	allege	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	allege	allege	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	that	that	SCONJ	IN	_	9	mark	9:mark	_
 6	HANO	HANO	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 7	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
@@ -16471,12 +16471,12 @@
 11	,	,	PUNCT	,	_	16	punct	16:punct	_
 12	former	former	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	residents	resident	NOUN	NNS	Number=Plur	16	nsubj:pass	16:nsubj:pass	_
-14	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+14	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 15	been	be	AUX	VBN	Tense=Past|VerbForm=Part	16	aux:pass	16:aux:pass	_
 16	informed	inform	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 17	that	that	SCONJ	IN	_	19	mark	19:mark	_
 18	there	there	PRON	EX	_	19	expl	19:expl	_
-19	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	ccomp	16:ccomp	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	ccomp	16:ccomp	_
 20	no	no	DET	DT	_	24	det	24:det	_
 21	available	available	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
 22	public	public	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
@@ -16488,7 +16488,7 @@
 28	because	because	SCONJ	IN	_	33	mark	33:mark	_
 29	those	that	DET	DT	Number=Plur|PronType=Dem	30	det	30:det	_
 30	units	unit	NOUN	NNS	Number=Plur	33	nsubj:pass	33:nsubj:pass	_
-31	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
+31	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
 32	been	be	AUX	VBN	Tense=Past|VerbForm=Part	33	aux:pass	33:aux:pass	_
 33	reserved	reserve	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	19	advcl	19:advcl:because	_
 34	for	for	ADP	IN	_	36	case	36:case	_
@@ -16503,7 +16503,7 @@
 3	public	public	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	housing	housing	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	residents	resident	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj|10:nsubj:xsubj|23:nsubj:pass|24:nsubj:xsubj	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	been	be	AUX	VBN	Tense=Past|VerbForm=Part	8	cop	8:cop	_
 8	unable	unable	ADJ	JJ	Degree=Pos	0	root	0:root	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -16513,13 +16513,13 @@
 13	for	for	ADP	IN	_	14	case	14:case	_
 14	which	which	PRON	WDT	PronType=Rel	16	obl	12:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	qualified	qualify	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+16	qualified	qualify	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 17	prior	prior	ADJ	JJ	Degree=Pos	20	case	20:case	_
 18	to	to	ADP	IN	_	17	fixed	17:fixed	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	storm	storm	NOUN	NN	Number=Sing	16	obl	16:obl:prior_to	_
 21	and	and	CCONJ	CC	_	23	cc	23:cc	_
-22	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux:pass	23:aux:pass	_
+22	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux:pass	23:aux:pass	_
 23	left	leave	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	conj	8:conj:and	_
 24	homeless	homeless	ADJ	JJ	Degree=Pos	23	xcomp	23:xcomp	SpaceAfter=No
 25	,	,	PUNCT	,	_	23	punct	23:punct	_
@@ -16567,7 +16567,7 @@
 13	agreement	agreement	NOUN	NN	Number=Sing	9	obl	9:obl:with	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	SpaceAfter=No
 15	"	"	PUNCT	''	_	16	punct	16:punct	_
-16	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+16	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 17	James	James	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj	_
 18	Perry	Perry	PROPN	NNP	Number=Sing	17	flat	17:flat	SpaceAfter=No
 19	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -16583,7 +16583,7 @@
 2	-	-	PUNCT	HYPH	_	3	punct	3:punct	SpaceAfter=No
 3	oil	oil	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	prices	price	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	rose	rise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	rose	rise	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	Wednesday	Wednesday	PROPN	NNP	Number=Sing	5	obl:tmod	5:obl:tmod	_
 7	as	as	SCONJ	IN	_	18	mark	18:mark	_
 8	strengthening	strengthen	VERB	VBG	VerbForm=Ger	10	amod	10:amod	_
@@ -16596,7 +16596,7 @@
 15	5	5	NUM	CD	NumType=Card	14	nummod	14:nummod	_
 16	storm	storm	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	18	punct	18:punct	_
-18	threatened	threaten	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	_
+18	threatened	threaten	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	disrupt	disrupt	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 21	oil	oil	NOUN	NN	Number=Sing	22	compound	22:compound	_
@@ -16624,7 +16624,7 @@
 11	delivery	delivery	NOUN	NN	Number=Sing	9	nmod	9:nmod:for	_
 12	in	in	ADP	IN	_	13	case	13:case	_
 13	November	November	PROPN	NNP	Number=Sing	11	nmod	11:nmod:in	_
-14	rose	rise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	rose	rise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	60	60	NUM	CD	NumType=Card	16	nummod	16:nummod	_
 16	cents	cent	NOUN	NNS	Number=Plur	14	obl:npmod	14:obl:npmod	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
@@ -16651,7 +16651,7 @@
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	November	November	PROPN	NNP	Number=Sing	13	compound	13:compound	_
 13	delivery	delivery	NOUN	NN	Number=Sing	10	nmod	10:nmod:for	_
-14	advanced	advance	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	advanced	advance	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	53	53	NUM	CD	NumType=Card	16	nummod	16:nummod	_
 16	cents	cent	NOUN	NNS	Number=Plur	14	obl:npmod	14:obl:npmod	_
 17	to	to	ADP	IN	_	19	case	19:case	_
@@ -16671,7 +16671,7 @@
 8	Tuesday	Tuesday	PROPN	NNP	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10	Rita	Rita	PROPN	NNP	Number=Sing	11	nsubj	11:nsubj	_
-11	packed	pack	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	packed	pack	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	winds	wind	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 13	of	of	ADP	IN	_	16	case	16:case	_
 14	about	about	ADV	RB	_	15	advmod	15:advmod	_
@@ -16681,7 +16681,7 @@
 18	hour	hour	NOUN	NN	Number=Sing	16	nmod:npmod	16:nmod:npmod	_
 19	as	as	SCONJ	IN	_	21	mark	21:mark	_
 20	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	headed	head	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:as	_
+21	headed	head	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:as	_
 22	across	across	ADP	IN	_	24	case	24:case	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	Gulf	Gulf	PROPN	NNP	Number=Sing	21	obl	21:obl:across	_
@@ -16696,7 +16696,7 @@
 3	National	National	ADJ	NNP	Degree=Pos	5	amod	5:amod	_
 4	Hurricane	Hurricane	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Center	Center	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	Rita	Rita	PROPN	NNP	Number=Sing	11	nsubj	11:nsubj|15:nsubj|22:nsubj:xsubj	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	cop	11:cop	_
 9	"	"	PUNCT	``	_	11	punct	11:punct	SpaceAfter=No
@@ -16725,7 +16725,7 @@
 # text = The storm threatened oil installations in the Gulf of Mexico where about one-quarter of US oil operations are based.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	storm	storm	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	threatened	threaten	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	threatened	threaten	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	oil	oil	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	installations	installation	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	in	in	ADP	IN	_	8	case	8:case	_
@@ -16742,7 +16742,7 @@
 17	US	US	PROPN	NNP	Number=Sing	19	compound	19:compound	_
 18	oil	oil	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	operations	operation	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
-20	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux:pass	21:aux:pass	_
+20	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux:pass	21:aux:pass	_
 21	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -16750,7 +16750,7 @@
 # text = Oil companies evacuated offshore facilities as the storm's progress kept global markets on tenterhooks.
 1	Oil	oil	NOUN	NN	Number=Sing	2	compound	2:compound	_
 2	companies	company	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	evacuated	evacuate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	offshore	offshore	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	facilities	facility	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	as	as	SCONJ	IN	_	11	mark	11:mark	_
@@ -16759,7 +16759,7 @@
 8	storm	storm	NOUN	NN	Number=Sing	10	nmod:poss	10:nmod:poss	_
 9	's	's	PART	POS	_	8	case	8:case	_
 10	progress	progress	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
-11	kept	keep	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:as	_
+11	kept	keep	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:as	_
 12	global	global	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	markets	market	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 14	on	on	ADP	IN	_	15	case	15:case	_
@@ -16772,7 +16772,7 @@
 2	Texas	Texas	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	BP	BP	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-5	shut	shut	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	shut	shut	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 7	460,000	460000	NUM	CD	NumType=Card	8	nummod	8:nummod	_
 8	barrels	barrel	NOUN	NNS	Number=Plur	11	compound	11:compound	_
@@ -16781,7 +16781,7 @@
 11	refinery	refinery	NOUN	NN	Number=Sing	5	obj	5:obj	_
 12	and	and	CCONJ	CC	_	14	cc	14:cc	_
 13	Marathon	Marathon	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
-14	shut	shut	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+14	shut	shut	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 15	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 16	72,000	72000	NUM	CD	NumType=Card	17	nummod	17:nummod	_
 17	bpd	bpd	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -16791,7 +16791,7 @@
 # sent_id = newsgroup-groups.google.com_marketplace_e019a6deff0a1c7f_ENG_20050922_024300-0009
 # text = Valero said it was reducing rates at its 243,000 bpd Texas City refinery and its 85,000 bpd Houston refinery.
 1	Valero	Valero	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 5	reducing	reduce	VERB	VBG	Tense=Pres|VerbForm=Part	2	ccomp	2:ccomp	_
@@ -16815,7 +16815,7 @@
 # text = Exxon Mobil released nonessential staff from two giant Texas plants.
 1	Exxon	Exxon	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	Mobil	Mobil	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	released	release	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	released	release	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	nonessential	nonessential	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	staff	staff	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	from	from	ADP	IN	_	10	case	10:case	_
@@ -16831,14 +16831,14 @@
 2	month	month	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	Katrina	Katrina	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj|12:nsubj	_
-5	devastated	devastate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	devastated	devastate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	refineries	refinery	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Louisiana	Louisiana	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	Mississippi	Mississippi	PROPN	NNP	Number=Sing	8	conj	6:nmod:in|8:conj:and	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
-12	sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+12	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 13	prices	price	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 14	to	to	ADP	IN	_	17	case	17:case	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
@@ -16907,7 +16907,7 @@
 17	Station	Station	PROPN	NNP	Number=Sing	8	obl	8:obl:to	SpaceAfter=No
 18	,	,	PUNCT	,	_	20	punct	20:punct	_
 19	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
-20	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+20	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 21	this	this	DET	DT	Number=Sing|PronType=Dem	22	det	22:det	_
 22	week	week	NOUN	NN	Number=Sing	20	obl:tmod	20:obl:tmod	SpaceAfter=No
 23	.	.	PUNCT	.	_	20	punct	20:punct	_
@@ -17070,7 +17070,7 @@
 6	administrator	administrator	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	Michael	Michael	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 8	Griffin	Griffin	PROPN	NNP	Number=Sing	7	flat	7:flat	_
-9	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 11	US	US	PROPN	NNP	Number=Sing	12	compound	12:compound	_
 12	house	house	PROPN	NNP	Number=Sing	14	compound	14:compound	_
@@ -17122,7 +17122,7 @@
 20	,	,	PUNCT	,	_	23	punct	23:punct	SpaceAfter=No
 21	"	"	PUNCT	''	_	23	punct	23:punct	_
 22	Griffin	Griffin	PROPN	NNP	Number=Sing	23	nsubj	23:nsubj	_
-23	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+23	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 24	.	.	PUNCT	.	_	23	punct	23:punct	_
 
 # sent_id = newsgroup-groups.google.com_hiddennook_edef226e24a57863_ENG_20051116_085200-0012
@@ -17130,7 +17130,7 @@
 # text = "I hope that industry, if put to the test, can do better [than the government], but I do not expect it," Griffin added.
 1	"	"	PUNCT	``	_	31	punct	31:punct	SpaceAfter=No
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	31	ccomp	31:ccomp	_
+3	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	31	ccomp	31:ccomp	_
 4	that	that	SCONJ	IN	_	14	mark	14:mark	_
 5	industry	industry	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	SpaceAfter=No
 6	,	,	PUNCT	,	_	14	punct	14:punct	_
@@ -17151,14 +17151,14 @@
 21	,	,	PUNCT	,	_	26	punct	26:punct	_
 22	but	but	CCONJ	CC	_	26	cc	26:cc	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-24	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
+24	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
 25	not	not	PART	RB	_	26	advmod	26:advmod	_
 26	expect	expect	VERB	VB	VerbForm=Inf	3	conj	3:conj:but|31:ccomp	_
 27	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	obj	26:obj	SpaceAfter=No
 28	,	,	PUNCT	,	_	31	punct	31:punct	SpaceAfter=No
 29	"	"	PUNCT	''	_	31	punct	31:punct	_
 30	Griffin	Griffin	PROPN	NNP	Number=Sing	31	nsubj	31:nsubj	_
-31	added	add	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+31	added	add	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 32	.	.	PUNCT	.	_	31	punct	31:punct	_
 
 # sent_id = newsgroup-groups.google.com_hiddennook_edef226e24a57863_ENG_20051116_085200-0013
@@ -17172,7 +17172,7 @@
 6	Griffin	Griffin	PROPN	NNP	Number=Sing	8	nmod:poss	8:nmod:poss	_
 7	's	's	PART	POS	_	6	case	6:case	_
 8	expectations	expectation	NOUN	NNS	Number=Plur	11	nsubj:pass	11:nsubj:pass|13:nsubj:pass	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux:pass	11:aux:pass	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux:pass	11:aux:pass	_
 10	either	either	CCONJ	CC	_	11	cc:preconj	11:cc:preconj	_
 11	exceeded	exceed	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	ccomp	4:ccomp	_
 12	or	or	CCONJ	CC	_	13	cc	13:cc	_
@@ -17423,7 +17423,7 @@
 7	legacy	legacy	NOUN	NN	Number=Sing	1	obl	1:obl:in	SpaceAfter=No
 8	,	,	PUNCT	,	_	10	punct	10:punct	_
 9	Abbas	Abbas	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-10	pledged	pledge	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+10	pledged	pledge	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	fulfill	fulfill	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	Palestinian	Palestinian	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -17463,7 +17463,7 @@
 5	claims	claim	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	that	that	SCONJ	IN	_	8	mark	8:mark	_
 7	Israel	Israel	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
-8	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl	5:acl:that	_
+8	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl	5:acl:that	_
 9	no	no	INTJ	UH	_	8	obj	8:obj	_
 10	to	to	ADP	IN	_	8	obl	8:obl	_
 11	not	not	ADV	RB	_	10	advmod	10:advmod	_
@@ -17484,7 +17484,7 @@
 3	priorities	priority	NOUN	NNS	Number=Plur	1	obj	1:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	6	punct	6:punct	_
 5	Abbas	Abbas	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	supporters	supporter	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 8	of	of	ADP	IN	_	12	case	12:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
@@ -17520,7 +17520,7 @@
 # text = Abbas also pledged to resolve the problem of millions of Palestinian refugees and their descendants.
 1	Abbas	Abbas	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	pledged	pledge	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	pledged	pledge	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	resolve	resolve	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -17553,7 +17553,7 @@
 14	of	of	ADP	IN	_	15	case	15:case	_
 15	Safed	Safed	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
 16	,	,	PUNCT	,	_	17	punct	17:punct	_
-17	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+17	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 19	refugee	refugee	NOUN	NN	Number=Sing	20	compound	20:compound	_
 20	issue	issue	NOUN	NN	Number=Sing	17	obj	17:obj|23:nsubj:xsubj|26:nsubj:xsubj	_
@@ -17715,7 +17715,7 @@
 2	to	to	ADP	IN	_	1	fixed	1:fixed	_
 3	40	40	NUM	CD	NumType=Card	4	nummod	4:nummod	_
 4	rockets	rocket	NOUN	NNS	Number=Plur	7	nsubj:pass	7:nsubj:pass	_
-5	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
+5	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 6	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	aux:pass	7:aux:pass	_
 7	fired	fire	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 8	at	at	ADP	IN	_	9	case	9:case	_
@@ -17725,7 +17725,7 @@
 12	after	after	SCONJ	IN	_	15	mark	15:mark	_
 13	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 14	military	military	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
-15	withdrew	withdraw	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:after	_
+15	withdrew	withdraw	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:after	_
 16	from	from	ADP	IN	_	18	case	18:case	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	territory	territory	NOUN	NN	Number=Sing	15	obl	15:obl:from	SpaceAfter=No
@@ -17741,7 +17741,7 @@
 5	rockets	rocket	NOUN	NNS	Number=Plur	2	nmod	2:nmod:to	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	Israel	Israel	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
-8	resumed	resume	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+8	resumed	resume	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 9	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	policy	policy	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	of	of	SCONJ	IN	_	12	mark	12:mark	_
@@ -17768,7 +17768,7 @@
 11	,	,	PUNCT	,	_	14	punct	14:punct	_
 12	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	military	military	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	_
-14	launched	launch	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	new	new	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 16	missile	missile	NOUN	NN	Number=Sing	17	compound	17:compound	_
 17	attacks	attack	NOUN	NNS	Number=Plur	14	obj	14:obj	_
@@ -17800,7 +17800,7 @@
 21	Israeli	Israeli	ADJ	NNP	Degree=Pos	23	amod	23:amod	_
 22	Defense	Defense	PROPN	NNP	Number=Sing	23	compound	23:compound	_
 23	Forces	Force	PROPN	NNPS	Number=Plur	25	nsubj	25:nsubj	_
-24	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
+24	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
 25	unleashed	unleash	VERB	VBN	Tense=Past|VerbForm=Part	19	acl:relcl	19:acl:relcl	_
 26	upon	upon	ADP	IN	_	29	case	29:case	_
 27	this	this	DET	DT	Number=Sing|PronType=Dem	29	det	29:det	_
@@ -17817,13 +17817,13 @@
 4	Hamas	Hamas	PROPN	NNP	Number=Sing	6	nmod:poss	6:nmod:poss	_
 5	's	's	PART	POS	_	4	case	4:case	_
 6	leader	leader	NOUN	NN	Number=Sing	1	appos	1:appos	_
-7	declared	declare	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	declared	declare	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	cease	cease	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	fire	fire	NOUN	NN	Number=Sing	7	obj	7:obj	_
 11	after	after	SCONJ	IN	_	13	mark	13:mark	_
 12	Israel	Israel	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
-13	killed	kill	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:after	_
+13	killed	kill	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:after	_
 14	it's	it's	PRON	PRP$	_	16	nmod:poss	16:nmod:poss	_
 15	former	former	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 16	leader	leader	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
@@ -17865,14 +17865,14 @@
 # sent_id = newsgroup-groups.google.com_hiddennook_5380fdd00f8e5e56_ENG_20050926_194800-0011
 # text = Egypt had a role to play as they convinced Hamas to end the attacks, although the same can not be said of Islamic Jihad .
 1	Egypt	Egypt	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	role	role	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	play	play	VERB	VB	VerbForm=Inf	4	acl	4:acl:to	_
 7	as	as	SCONJ	IN	_	9	mark	9:mark	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	convinced	convince	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:as	_
+9	convinced	convince	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:as	_
 10	Hamas	Hamas	PROPN	NNP	Number=Sing	9	obj	9:obj|12:nsubj:xsubj	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	end	end	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
@@ -17903,7 +17903,7 @@
 1	"	"	PUNCT	``	_	25	punct	25:punct	SpaceAfter=No
 2-3	We're	_	_	_	_	_	_	_	_
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-3	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	not	not	PART	RB	_	5	advmod	5:advmod	_
 5	happy	happy	ADJ	JJ	Degree=Pos	25	ccomp	25:ccomp	_
 6	with	with	ADP	IN	_	9	case	9:case	_
@@ -17926,7 +17926,7 @@
 22	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	19	nmod	19:nmod:against	SpaceAfter=No
 23	,	,	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
 24	"	"	PUNCT	''	_	25	punct	25:punct	_
-25	commented	comment	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+25	commented	comment	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 26	Khader	Khader	PROPN	NNP	Number=Sing	25	nsubj	25:nsubj	_
 27	Habib	Habib	PROPN	NNP	Number=Sing	26	flat	26:flat	SpaceAfter=No
 28	,	,	PUNCT	,	_	26	punct	26:punct	_
@@ -17988,7 +17988,7 @@
 22	,	,	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
 23	"	"	PUNCT	''	_	25	punct	25:punct	_
 24	Habib	Habib	PROPN	NNP	Number=Sing	25	nsubj	25:nsubj	_
-25	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+25	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 26	.	.	PUNCT	.	_	25	punct	25:punct	_
 
 # sent_id = newsgroup-groups.google.com_hiddennook_5380fdd00f8e5e56_ENG_20050926_194800-0017
@@ -18204,7 +18204,7 @@
 # text = What foods do you eat in Miramar?
 1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
 2	foods	food	NOUN	NNS	Number=Plur	5	obj	5:obj	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 5	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	in	in	ADP	IN	_	7	case	7:case	_
@@ -18236,11 +18236,11 @@
 # newpar id = answers-20090717131608AAqDfYJ_ans-p0004
 # text = you mean miramar florida theyy have good seafood there
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	miramar	miramar	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 4	florida	florida	PROPN	NNP	Number=Sing	3	appos	3:appos	_
 5	theyy	theyy	PRON	PRP	_	6	nsubj	6:nsubj	_
-6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 7	good	good	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	seafood	seafood	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	there	there	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
@@ -18249,7 +18249,7 @@
 # sent_id = answers-20111108003939AA3pvxF_ans-0001
 # newpar id = answers-20111108003939AA3pvxF_ans-p0001
 # text = Have you had any knowledgement about pearl pigment.?
-1	Have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	any	any	DET	DT	_	5	det	5:det	_
@@ -18275,7 +18275,7 @@
 11	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	teacher	teacher	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 13-14	havent	_	_	_	_	_	_	_	_
-13	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+13	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 14	nt	not	PART	RB	_	15	advmod	15:advmod	_
 15	taught	teach	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:because	_
 16	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	15	iobj	15:iobj	_
@@ -18315,7 +18315,7 @@
 # sent_id = answers-20100308180028AAHCoBv_ans-0004
 # text = There are several just off their beautiful beach.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	several	several	ADJ	JJ	Degree=Pos	2	nsubj	2:nsubj	_
 4	just	just	ADV	RB	_	8	advmod	8:advmod	_
 5	off	off	ADP	IN	_	8	case	8:case	_
@@ -18363,7 +18363,7 @@
 8	alone	alone	ADV	RB	_	5	advmod	5:advmod	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 12	tight	tight	ADJ	JJ	Degree=Pos	11	obj	11:obj	SpaceAfter=No
 13	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -18385,7 +18385,7 @@
 # newpar id = answers-20111108082957AAzQGgo_ans-p0001
 # text = What influenced Picasso's cubism style of painting?
 1	What	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	influenced	influence	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3-4	Picasso's	_	_	_	_	_	_	_	_
 3	Picasso	Picasso	PROPN	NNP	Number=Sing	6	nmod:poss	6:nmod:poss	_
 4	's	's	PART	POS	_	3	case	3:case	_
@@ -18400,7 +18400,7 @@
 # text = i've seen that.......that does not help me at all it says what cubism influenced not what influnced cubism
 1-2	i've	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	that	that	PRON	DT	Number=Sing|PronType=Dem	3	obj	3:obj	SpaceAfter=No
 5	.......	.......	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
@@ -18415,10 +18415,10 @@
 14	says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 15	what	what	PRON	WP	PronType=Int	14	obj	14:obj	_
 16	cubism	cubism	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
-17	influenced	influence	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	not	not	ADV	RB	_	19	advmod	19:advmod	_
 19	what	what	PRON	WP	PronType=Int	15	conj	15:conj	_
-20	influnced	influnce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	19	acl:relcl	19:acl:relcl	_
+20	influnced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	19	acl:relcl	19:acl:relcl	CorrectForm=influenced
 21	cubism	cubism	NOUN	NN	Number=Sing	20	obj	20:obj	_
 
 # sent_id = answers-20111108082957AAzQGgo_ans-0003
@@ -18431,7 +18431,7 @@
 # newpar id = answers-20080426141111AAgPUwU_ans-p0001
 # text = What do you eat in Miramar?
 1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	in	in	ADP	IN	_	6	case	6:case	_
@@ -18446,7 +18446,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	stuff	stuff	NOUN	NN	Number=Sing	1	nmod	1:nmod:like	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	eat	eat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	Spanish	Spanish	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	countries	country	NOUN	NNS	Number=Plur	6	obl	6:obl:in	_
@@ -18479,7 +18479,7 @@
 # newpar id = answers-20111106193025AA2h62V_ans-p0001
 # text = Anyone know of any HHa training in Delaware ?
 1	Anyone	anyone	PRON	NN	Number=Sing	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	of	of	ADP	IN	_	6	case	6:case	_
 4	any	any	DET	DT	_	6	det	6:det	_
 5	HHa	HHa	PROPN	NNP	Number=Sing	6	compound	6:compound	_
@@ -18492,7 +18492,7 @@
 # newpar id = answers-20111106193025AA2h62V_ans-p0002
 # text = I do hold a HHa certificate in the state of NY but I looking to move to Delaware anyone know how I can get certified in delaware?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	hold	hold	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	HHa	HHa	PROPN	NNP	Number=Sing	6	compound	6:compound	_
@@ -18510,7 +18510,7 @@
 17	to	to	ADP	IN	_	18	case	18:case	_
 18	Delaware	Delaware	PROPN	NNP	Number=Sing	16	obl	16:obl:to	_
 19	anyone	anyone	PRON	NN	Number=Sing	20	nsubj	20:nsubj	_
-20	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+20	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 21	how	how	ADV	WRB	PronType=Int	25	advmod	25:advmod	_
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj:pass	25:nsubj:pass	_
 23	can	can	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
@@ -18541,9 +18541,9 @@
 # sent_id = answers-20111108082040AAmrGJ5_ans-0003
 # text = I assume you mean the crazy horse memorial.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	assume	assume	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	assume	assume	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+4	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 6	crazy	crazy	ADJ	NNP	Degree=Pos	7	amod	7:amod	_
 7	horse	horse	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -18553,7 +18553,7 @@
 # sent_id = answers-20111108082040AAmrGJ5_ans-0004
 # text = they have their own website which you can easily find using any search engine.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	own	own	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	website	website	NOUN	NN	Number=Sing	2	obj	2:obj|10:obj	_
@@ -18666,7 +18666,7 @@
 4	DAYS	day	NOUN	NNS	Number=Plur	0	root	0:root	_
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 8	lucky	lucky	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	_
 9	on	on	ADP	IN	_	10	case	10:case	_
 10	average	average	ADJ	JJ	Degree=Pos	12	obl	12:obl:on	_
@@ -18720,7 +18720,7 @@
 2	South	South	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	Shropshire	Shropshire	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	Hills	Hill	PROPN	NNPS	Number=Plur	7	nsubj	7:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	far	far	ADV	RB	Degree=Pos	7	advmod	7:advmod	_
 7	closer	close	ADJ	JJR	Degree=Cmp	0	root	0:root	SpaceAfter=No
 8	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -18728,14 +18728,14 @@
 # sent_id = answers-20111108092417AAt9bST_ans-0004
 # text = They are not a national park, but are extremely beautiful.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj|11:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	not	not	PART	RB	_	6	advmod	6:advmod	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	national	national	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	park	park	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	11	punct	11:punct	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	extremely	extremely	ADV	RB	_	11	advmod	11:advmod	_
 11	beautiful	beautiful	ADJ	JJ	Degree=Pos	6	conj	6:conj:but	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -18818,7 +18818,7 @@
 # sent_id = answers-20111108033619AAb3VQ4_ans-0001
 # newpar id = answers-20111108033619AAb3VQ4_ans-p0001
 # text = Do people Bare-knuckle box in Ireland?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 2	people	people	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 3	Bare	bare	ADJ	JJ	Degree=Pos	5	amod	5:amod	SpaceAfter=No
 4	-	-	PUNCT	HYPH	_	5	punct	5:punct	SpaceAfter=No
@@ -18837,7 +18837,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	travelling	travelling	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	community	community	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
-7	engage	engage	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	engage	engage	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	in	in	ADP	IN	_	10	case	10:case	_
 9	this	this	DET	DT	Number=Sing|PronType=Dem	10	det	10:det	_
 10	activity	activity	NOUN	NN	Number=Sing	7	obl	7:obl:in	SpaceAfter=No
@@ -18868,7 +18868,7 @@
 6	community	community	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
 7	bare	bare	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	knuckle	knuckle	NOUN	NN	Number=Sing	9	obl:npmod	9:obl:npmod	_
-9	box	box	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+9	box	box	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 10	.	.	PUNCT	.	_	9	punct	9:punct	SpaceAfter=No
 
 # sent_id = answers-20111108033619AAb3VQ4_ans-0005
@@ -18878,7 +18878,7 @@
 3	that	that	PRON	DT	Number=Sing|PronType=Dem	1	obl	1:obl:than	_
 4	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 5-6	don't	_	_	_	_	_	_	_	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	_	7	advmod	7:advmod	_
 7	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 8	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -18888,7 +18888,7 @@
 # newpar id = answers-20111105145356AAtOJyP_ans-p0001
 # text = What are some GOOD 18+ clubs in the bay area?
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	_	7	det	7:det	_
 4	GOOD	good	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 5	18	18	NUM	CD	NumType=Card	7	compound	7:compound	SpaceAfter=No
@@ -18927,7 +18927,7 @@
 # sent_id = answers-20111105145356AAtOJyP_ans-0004
 # text = I want to party hardy for my birthday :)
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	party	party	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	hardy	hardy	ADV	RB	_	4	advmod	4:advmod	_
@@ -18941,7 +18941,7 @@
 # text = when you turn 21 you can party any were you want
 1	when	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	turn	turn	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
+3	turn	turn	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 4	21	21	NUM	CD	NumType=Card	3	obj	3:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	can	can	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -18949,14 +18949,14 @@
 8	any	any	ADV	GW	_	7	advmod	7:advmod	_
 9	were	where	X	RB	_	8	goeswith	8:goeswith	Typo=Yes
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 
 # newdoc id = answers-20100605133330AAeW6nm_ans
 # sent_id = answers-20100605133330AAeW6nm_ans-0001
 # newpar id = answers-20100605133330AAeW6nm_ans-p0001
 # text = I have hundreds of VHS movies lying around... what should I do with them?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	hundreds	hundred	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	VHS	vhs	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -18976,7 +18976,7 @@
 # newpar id = answers-20100605133330AAeW6nm_ans-p0002
 # text = They bulk up too much space
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	bulk	bulk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	bulk	bulk	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	up	up	ADP	RP	_	2	compound:prt	2:compound:prt	_
 4	too	too	ADV	RB	_	5	advmod	5:advmod	_
 5	much	much	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -18986,7 +18986,7 @@
 # newpar id = answers-20100605133330AAeW6nm_ans-p0003
 # text = I gave mine to a rest home for senior citizens and an old soldiers' home.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	mine	mine	PRON	PRP	_	2	obj	2:obj	_
 4	to	to	ADP	IN	_	7	case	7:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -19054,7 +19054,7 @@
 # newpar id = answers-20111108102900AA9qsc8_ans-p0003
 # text = I have a cat named GummiBear, so no, R2D2 is not a stupid name.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	cat	cat	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	named	name	VERB	VBN	Tense=Past|VerbForm=Part	4	acl	4:acl	_
@@ -19085,7 +19085,7 @@
 8	and	a	DET	DT	Typo=Yes	9	det	9:det	CorrectForm=a
 9	name	name	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 
 # sent_id = answers-20111108102900AA9qsc8_ans-0005
 # newpar id = answers-20111108102900AA9qsc8_ans-p0005
@@ -19128,7 +19128,7 @@
 1	okay	okay	INTJ	UH	_	4	discourse	4:discourse	_
 2	so	so	ADV	RB	_	4	advmod	4:advmod	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	in	in	ADP	IN	_	8	case	8:case	_
 6	San	San	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 7	Rafael	Rafael	PROPN	NNP	Number=Sing	6	flat	6:flat	_
@@ -19144,7 +19144,7 @@
 17	Depot	Depot	PROPN	NNP	Number=Sing	13	conj	4:obl:by|13:conj:and	SpaceAfter=No
 18	..	..	PUNCT	,	_	4	punct	4:punct	_
 19	what	what	PRON	WP	PronType=Int	4	parataxis	4:parataxis	_
-20	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
+20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 21	fun	fun	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
 22	things	thing	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
@@ -19164,7 +19164,7 @@
 # text = im 15 btw
 1-2	im	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	15	15	NUM	CD	NumType=Card	0	root	0:root	_
 4	btw	btw	ADV	RB	_	3	discourse	3:discourse	_
 
@@ -19193,7 +19193,7 @@
 1	Which	which	PRON	WDT	PronType=Int	6	obj	6:obj	_
 2	of	of	ADP	IN	_	3	case	3:case	_
 3	these	this	PRON	DT	Number=Plur|PronType=Dem	1	nmod	1:nmod:of	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 6	like	like	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 7	:	:	PUNCT	:	_	6	punct	6:punct	_
@@ -19225,7 +19225,7 @@
 3	like	like	SCONJ	IN	_	9	mark	9:mark	_
 4-5	I'm	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-5	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+5	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 6	at	at	ADP	IN	_	9	case	9:case	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	real	real	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -19259,7 +19259,7 @@
 1	the	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	one	one	NUM	CD	NumType=Card	9	nsubj	9:nsubj	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	most	most	ADV	RBS	_	4	advmod	4:advmod	_
 7	would	would	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -19291,7 +19291,7 @@
 # text = actually i have an project on it so please give meas much as you have information about migratory birds in punjab
 1	actually	actually	ADV	RB	_	3	advmod	3:advmod	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	project	project	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	on	on	ADP	IN	_	7	case	7:case	_
@@ -19299,12 +19299,12 @@
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	please	please	INTJ	UH	_	10	discourse	10:discourse	_
 10	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
-11	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	10	obj	10:obj	SpaceAfter=No|CorrectSpaceAfter=Yes
+11	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	10	obj	10:obj	CorrectSpaceAfter=Yes|SpaceAfter=No
 12	as	as	ADV	RB	_	13	advmod	13:advmod	_
 13	much	much	ADV	RB	_	17	amod	17:amod	_
 14	as	as	SCONJ	IN	_	16	mark	16:mark	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:as	_
+16	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:as	_
 17	information	information	NOUN	NN	Number=Sing	10	obj	10:obj	_
 18	about	about	ADP	IN	_	20	case	20:case	_
 19	migratory	migratory	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
@@ -19317,7 +19317,7 @@
 # text = I don't know about birding in that part of the world but you might possibly find help at this site: http://www.wildlifeofpakistan.com/PakistanBirdClub/index.html
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	about	about	ADP	IN	_	6	case	6:case	_
@@ -19372,7 +19372,7 @@
 7	22nd	22nd	NOUN	NN	Number=Sing	6	nummod	6:nummod	_
 8	and	and	CCONJ	CC	_	11	cc	11:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	going	go	VERB	VBG	VerbForm=Ger	6	conj	6:conj:and	_
 12	to	to	ADP	IN	_	13	case	13:case	_
 13	Del	Del	PROPN	NNP	Number=Sing	11	obl	11:obl:to	_
@@ -19560,7 +19560,7 @@
 4	casual	casual	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	but	but	CCONJ	CC	_	7	cc	7:cc	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
+7	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
 8	this	this	PRON	DT	Number=Sing|PronType=Dem	11	nsubj:pass	11:nsubj:pass	_
 9	can	can	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 10	be	be	AUX	VB	VerbForm=Inf	11	aux:pass	11:aux:pass	_
@@ -19607,13 +19607,13 @@
 10	art	art	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	works	work	NOUN	NNS	Number=Plur	7	obj	7:obj|15:nsubj:pass	_
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj:pass	11:ref	_
-13	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
+13	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
 14	never	never	ADV	RB	_	15	advmod	15:advmod	_
 15	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
 16	after	after	SCONJ	IN	_	19	mark	19:mark	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	Natzi	Natzi	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj	_
-19	stole	steal	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:after	_
+19	stole	steal	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:after	_
 20	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	19	obj	19:obj	SpaceAfter=No
 21	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -19651,13 +19651,13 @@
 20	..	..	PUNCT	,	_	23	punct	23:punct	SpaceAfter=No
 21	and	and	CCONJ	CC	_	23	cc	23:cc	_
 22	there	there	PRON	EX	_	23	expl	23:expl	_
-23	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	conj	18:xcomp|19:conj:and	_
+23	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	conj	18:xcomp|19:conj:and	_
 24	thousands	thousand	NOUN	NNS	Number=Plur	23	nsubj	23:nsubj|31:nsubj:pass	_
 25	in	in	ADP	IN	_	26	case	26:case	_
 26	musems	musem	NOUN	NNS	Number=Plur	24	nmod	24:nmod:in	_
 27	that	that	PRON	WDT	PronType=Rel	31	nsubj:pass	24:ref	_
 28-29	haven't	_	_	_	_	_	_	_	_
-28	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
+28	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
 29	n't	not	PART	RB	_	31	advmod	31:advmod	_
 30	been	be	AUX	VBN	Tense=Past|VerbForm=Part	31	aux:pass	31:aux:pass	_
 31	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	acl:relcl	24:acl:relcl	_
@@ -19679,7 +19679,7 @@
 
 # sent_id = answers-20070723111604AAzUvhb_ans-0002
 # text = are they just making these places up?
-1	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+1	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
 4	making	make	VERB	VBG	VerbForm=Ger	0	root	0:root	_
@@ -19693,10 +19693,10 @@
 # text = Well you say Miramar I say Piramar
 1	Well	well	INTJ	UH	_	3	discourse	3:discourse	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	Miramar	Miramar	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj	_
+6	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj	_
 7	Piramar	Piramar	PROPN	NNP	Number=Sing	6	obj	6:obj	_
 
 # sent_id = answers-20070723111604AAzUvhb_ans-0004
@@ -19729,11 +19729,11 @@
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	but	but	CCONJ	CC	_	8	cc	8:cc	_
 7	there	there	PRON	EX	_	8	expl	8:expl	_
-8	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
-9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+8	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 10	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|12:nsubj	_
 11	that	that	PRON	WDT	PronType=Rel	12	nsubj	10:ref	_
-12	make	make	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+12	make	make	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 13	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	12	obj	12:obj|14:nsubj:xsubj	_
 14	wonder	wonder	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -19742,7 +19742,7 @@
 # newpar id = answers-20070723111604AAzUvhb_ans-p0004
 # text = There are way more stranger names in the U.S for areas than Miramar.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	way	way	ADV	RB	_	4	advmod	4:advmod	_
 4	more	more	ADV	RBR	_	5	advmod	5:advmod	_
 5	stranger	strange	ADJ	JJR	Degree=Cmp	6	amod	6:amod	_
@@ -19759,7 +19759,7 @@
 # sent_id = answers-20070723111604AAzUvhb_ans-0009
 # text = i think Miramar was a famous goat trainer or something.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Miramar	Miramar	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|10:nsubj	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -19773,7 +19773,7 @@
 # sent_id = answers-20070723111604AAzUvhb_ans-0010
 # text = He deserved respect
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	deserved	deserve	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	deserved	deserve	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	respect	respect	NOUN	NN	Number=Sing	2	obj	2:obj	_
 
 # newdoc id = answers-20081229195853AAYQ8mR_ans
@@ -19899,7 +19899,7 @@
 # newpar id = answers-20111108084227AAtbjAp_ans-p0001
 # text = I sent a phone to Mobile Phone Exchange and it failed a test due to lost or stolen what should I do?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	phone	phone	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	to	to	ADP	IN	_	8	case	8:case	_
@@ -19908,7 +19908,7 @@
 8	Exchange	Exchange	PROPN	NNP	Number=Sing	2	obl	2:obl:to	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-11	failed	fail	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+11	failed	fail	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	test	test	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	due	due	ADP	IN	_	16	case	16:case	_
@@ -19934,7 +19934,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	friend	friend	NOUN	NN	Number=Sing	3	obl	3:obl:by	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+10	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 11	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	obj	10:obj	_
 12	off	off	ADP	RP	_	10	compound:prt	10:compound:prt	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -19961,7 +19961,7 @@
 1	hope	hope	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj|9:nsubj	_
 3-4	don't	_	_	_	_	_	_	_	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	call	call	VERB	VB	VerbForm=Inf	1	ccomp	1:ccomp	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -19985,7 +19985,7 @@
 10	if	if	SCONJ	IN	_	14	mark	14:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
 12-13	don't	_	_	_	_	_	_	_	_
-12	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	_	14	advmod	14:advmod	_
 14	know	know	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:if	_
 15-16	its	_	_	_	_	_	_	_	_
@@ -20025,7 +20025,7 @@
 # text = They don't show it on RTE Player
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	show	show	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
@@ -20089,10 +20089,10 @@
 
 # sent_id = answers-20111107180248AAnQ3aE_ans-0007
 # text = Hope you don't miss it too much.
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 3-4	don't	_	_	_	_	_	_	_	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	miss	miss	VERB	VB	VerbForm=Inf	1	ccomp	1:ccomp	_
 6	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	obj	5:obj	_
@@ -20106,14 +20106,14 @@
 # text = Im in school for photography and i want to work in forensic so what else do i need to do.?
 1-2	Im	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	in	in	ADP	IN	_	4	case	4:case	_
 4	school	school	NOUN	NN	Number=Sing	0	root	0:root	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	photography	photography	NOUN	NN	Number=Sing	4	nmod	4:nmod:for	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj|11:nsubj:xsubj	_
-9	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+9	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	work	work	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
 12	in	in	ADP	IN	_	13	case	13:case	_
@@ -20121,7 +20121,7 @@
 14	so	so	ADV	RB	_	19	advmod	19:advmod	_
 15	what	what	PRON	WP	PronType=Int	21	obj	21:obj	_
 16	else	else	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
-17	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj|21:nsubj:xsubj	_
 19	need	need	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 20	to	to	PART	TO	_	21	mark	21:mark	_
@@ -20144,7 +20144,7 @@
 # newpar id = answers-20111108083850AAzIsFI_ans-p0003
 # text = You need a background in law enforcement.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	background	background	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	in	in	ADP	IN	_	7	case	7:case	_
@@ -20176,7 +20176,7 @@
 7	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
 8	what	what	PRON	WP	PronType=Int	10	obj	10:obj	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	SpaceAfter=No
+10	recommend	recommend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = answers-20111108083850AAzIsFI_ans-0006
@@ -20219,7 +20219,7 @@
 # text = I'm writing an essay for school and I need to know if the iPhone was the first Smart Phone.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	writing	write	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	essay	essay	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -20227,7 +20227,7 @@
 7	school	school	NOUN	NN	Number=Sing	5	nmod	5:nmod:for	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-10	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	know	know	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	if	if	SCONJ	IN	_	20	mark	20:mark	_
@@ -20298,12 +20298,12 @@
 # text = But it did revolutionize the way we think of as a smartphone.
 1	But	but	CCONJ	CC	_	4	cc	4:cc	_
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-3	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 4	revolutionize	revolutionize	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	way	way	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	of	of	ADP	IN	_	12	case	12:case	_
 10	as	as	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -20479,7 +20479,7 @@
 # text = If you are unsure whether or not you need your passport then Faz will be able to help!
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	unsure	unsure	ADJ	JJ	Degree=Pos	16	advcl	16:advcl:if	_
 5	whether	whether	SCONJ	IN	_	9	mark	9:mark	_
 6	or	or	CCONJ	CC	_	5	fixed	5:fixed	_
@@ -20519,7 +20519,7 @@
 1	depends	depend	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	where	where	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 3	u	u	PRON	PRP	_	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	1	advcl	1:advcl:where	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -20528,7 +20528,7 @@
 1	If	if	SCONJ	IN	_	6	mark	6:mark	_
 2-3	your	_	_	_	_	_	_	_	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|8:nsubj	_
-3	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+3	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	in	in	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	USA	USA	PROPN	NNP	Number=Sing	13	advcl	13:advcl:in	_
@@ -20538,7 +20538,7 @@
 10	Cuba	Cuba	PROPN	NNP	Number=Sing	8	obl	8:obl:into	_
 11	then	then	ADV	RB	PronType=Dem	13	advmod	13:advmod	_
 12	u	u	PRON	PRP	_	13	nsubj	13:nsubj	_
-13	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+13	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	passport	passport	NOUN	NN	Number=Sing	13	obj	13:obj	_
 
@@ -20583,7 +20583,7 @@
 5	or	or	CCONJ	CC	_	6	cc	6:cc	_
 6	something	something	PRON	NN	Number=Sing	4	conj	1:obj|4:conj:or	_
 7	please	please	INTJ	UH	_	1	discourse	1:discourse	_
-8	idk	idk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	discourse	1:discourse	SpaceAfter=No
+8	idk	idk	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	discourse	1:discourse	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = answers-20111106210027AAhMxfE_ans-0004
@@ -20604,7 +20604,7 @@
 # text = You've already asked this.
 1-2	You've	_	_	_	_	_	_	_	_
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	already	already	ADV	RB	_	4	advmod	4:advmod	_
 4	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	this	this	PRON	DT	Number=Sing|PronType=Dem	4	obj	4:obj	SpaceAfter=No
@@ -20644,7 +20644,7 @@
 # text = You're an idiot.
 1-2	You're	_	_	_	_	_	_	_	_
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-2	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	an	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	idiot	idiot	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -20688,7 +20688,7 @@
 4	Reel	reel	NOUN	NN	Number=Sing	0	root	0:root	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-7	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+7	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 8	danced	dance	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:and	_
 9	to	to	ADP	IN	_	10	case	10:case	_
 10	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obl	8:obl:to	_
@@ -20705,13 +20705,13 @@
 6	but	but	CCONJ	CC	_	8	cc	8:cc	_
 7	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 8-9	didn't	_	_	_	_	_	_	_	_
-8	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
+8	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:but	_
 9	n't	not	PART	RB	_	8	advmod	8:advmod	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 11	only	only	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	line	line	NOUN	NN	Number=Sing	16	nsubj	16:nsubj|21:nsubj	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	remember	remember	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	de	de	X	FW	_	4	parataxis	4:parataxis	_
 17	lunde	lunde	X	FW	_	16	flat:foreign	16:flat:foreign	_
@@ -20835,7 +20835,7 @@
 # newpar id = answers-20111107080027AA9zCIG_ans-p0003
 # text = I like Hayes Street Grill....another plus, it's right by Civic Center, so you can take a romantic walk around the Opera House, City Hall, Symphony Auditorium...all very beautiful.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Hayes	Hayes	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	Street	Street	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Grill	Grill	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -20901,7 +20901,7 @@
 3	happen	happen	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	flew	fly	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	_
+6	flew	fly	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	flag	flag	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -21021,7 +21021,7 @@
 # sent_id = answers-20111106213308AA5Nh2g_ans-0002
 # text = Where do we vote?
 1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -21039,7 +21039,7 @@
 # newpar id = answers-20111106213308AA5Nh2g_ans-p0002
 # text = Where do we vote?
 1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -21049,7 +21049,7 @@
 1	Obviously	obviously	ADV	RB	_	0	root	0:root	_
 2	because	because	SCONJ	IN	_	4	mark	4:mark	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-4	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:because	_
+4	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:because	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	vote	vote	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -21064,7 +21064,7 @@
 6	voted	vote	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl	12:advcl:if	SpaceAfter=No
 7	,	,	PUNCT	,	_	12	punct	12:punct	_
 8	what	what	PRON	WP	PronType=Int	12	obj	12:obj	_
-9	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	aux	12:aux	_
+9	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux	12:aux	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	det	11:det	_
 11	guys	guy	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 12	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -21075,7 +21075,7 @@
 # newpar id = answers-20111106213308AA5Nh2g_ans-p0003
 # text = It closed on Sunday...
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	closed	close	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	closed	close	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	on	on	ADP	IN	_	4	case	4:case	_
 4	Sunday	Sunday	PROPN	NNP	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
 5	...	...	PUNCT	.	_	2	punct	2:punct	_
@@ -21083,7 +21083,7 @@
 # sent_id = answers-20111106213308AA5Nh2g_ans-0008
 # text = You voted on the Dominion Posts website.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	voted	vote	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	voted	vote	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	on	on	ADP	IN	_	8	case	8:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 5	Dominion	Dominion	PROPN	NNP	Number=Sing	6	compound	6:compound	_
@@ -21159,7 +21159,7 @@
 3	,	,	PUNCT	,	_	7	punct	7:punct	SpaceAfter=No
 4-5	I'm	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-5	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	foreigner	foreigner	NOUN	NN	Number=Sing	0	root	0:root	_
 8	living	live	VERB	VBG	VerbForm=Ger	7	acl	7:acl	_
@@ -21192,7 +21192,7 @@
 # text = I've tried calling them a week ago,they said they can't give me those details over the phone, or let me know,keep asking me to go to some website,but there's nothing useful on it
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	calling	call	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	obj	4:obj	_
@@ -21201,7 +21201,7 @@
 8	ago	ago	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 9	,	,	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-11	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
+11	said	say	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj|24:nsubj	_
 13-14	can't	_	_	_	_	_	_	_	_
 13	ca	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
@@ -21219,7 +21219,7 @@
 25	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	24	obj	24:obj|26:nsubj:xsubj	_
 26	know	know	VERB	VB	VerbForm=Inf	24	xcomp	24:xcomp	SpaceAfter=No
 27	,	,	PUNCT	,	_	28	punct	28:punct	SpaceAfter=No
-28	keep	keep	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+28	keep	keep	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 29	asking	ask	VERB	VBG	VerbForm=Ger	28	xcomp	28:xcomp	_
 30	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	29	obj	29:obj|32:nsubj:xsubj	_
 31	to	to	PART	TO	_	32	mark	32:mark	_
@@ -21264,7 +21264,7 @@
 2	kind	kind	NOUN	NN	Number=Sing	9	obj	9:obj	_
 3	of	of	ADP	IN	_	4	case	4:case	_
 4	Meal	meal	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 6	peopel	peopel	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Argentina	Argentina	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	_
@@ -21280,7 +21280,7 @@
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	project	project	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	know	know	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	what	what	DET	WDT	PronType=Int	11	det	11:det	_
@@ -21288,7 +21288,7 @@
 12	food	food	NOUN	NN	Number=Sing	11	nmod:npmod	11:nmod:npmod	_
 13	Argentina	Argentina	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	people	people	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
-15	eat	eat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
+15	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
 16	for	for	ADP	IN	_	17	case	17:case	_
 17	breakfast	breakfast	NOUN	NN	Number=Sing	15	obl	15:obl:for	SpaceAfter=No
 18	,	,	PUNCT	,	_	19	punct	19:punct	_
@@ -21332,7 +21332,7 @@
 3	what	what	DET	WDT	PronType=Int	4	det	4:det	_
 4	time	time	NOUN	NN	Number=Sing	6	obl	6:obl:around	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	eat	eat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	each	each	DET	DT	_	6	obj	6:obj	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -21346,7 +21346,7 @@
 2	ones	one	NOUN	NNS	Number=Plur	5	obj	5:obj	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	-	-	PUNCT	,	_	5	punct	5:punct	_
 7	beef	beef	NOUN	NN	Number=Sing	5	parataxis	5:parataxis	SpaceAfter=No
 8	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -21370,7 +21370,7 @@
 # newpar id = answers-20101109081414AAZ3hSI_ans-p0004
 # text = they eat lots of grilled meat,chorizo,and such,with potatoes
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	eat	eat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	lots	lot	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	grilled	grill	VERB	VBN	Tense=Past|VerbForm=Part	6	amod	6:amod	_
@@ -21389,7 +21389,7 @@
 # newpar id = answers-20111108103447AAI7MDa_ans-p0001
 # text = why do i want to do work experience at an animal center?
 1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -21412,14 +21412,14 @@
 # newpar id = answers-20111108103447AAI7MDa_ans-p0003
 # text = How are strangers supposed to know why YOU want to do that sort of job?
 1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	strangers	stranger	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 4	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	know	know	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	why	why	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	YOU	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|11:nsubj:xsubj	_
-9	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl	_
+9	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	do	do	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
 12	that	that	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
@@ -21438,7 +21438,7 @@
 6	reasons	reason	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of	_
 7	why	why	SCONJ	WRB	PronType=Rel	9	mark	9:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+9	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	job	job	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -21453,7 +21453,7 @@
 21	see	see	VERB	VB	VerbForm=Inf	13	advcl	13:advcl:to	_
 22	what	what	PRON	WP	PronType=Int	26	obj	26:obj	_
 23	people	people	NOUN	NNS	Number=Plur	24	nsubj	24:nsubj	_
-24	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	ccomp	21:ccomp	_
+24	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	ccomp	21:ccomp	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	say	say	VERB	VB	VerbForm=Inf	24	advcl	24:advcl:to	_
 27	about	about	SCONJ	IN	_	31	mark	31:mark	_
@@ -21467,7 +21467,7 @@
 # text = Hope you find out soon :)
 1	Hope	hope	VERB	VB	VerbForm=Inf	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	find	find	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
+3	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	soon	soon	ADV	RB	Degree=Pos	3	advmod	3:advmod	_
 6	:)	:)	SYM	NFP	_	1	discourse	1:discourse	_
@@ -21493,7 +21493,7 @@
 3	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	beacuse	because	SCONJ	IN	Typo=Yes	6	mark	6:mark	CorrectForm=because
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|8:nsubj:xsubj	_
-6	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:beacuse	_
+6	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:beacuse	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	work	work	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	with	with	ADP	IN	_	10	case	10:case	_
@@ -21509,7 +21509,7 @@
 18	if	if	SCONJ	IN	_	22	mark	22:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj	_
 20-21	weren't	_	_	_	_	_	_	_	_
-20	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	aux	22:aux	_
+20	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	22	aux	22:aux	_
 21	n't	not	PART	RB	_	22	advmod	22:advmod	_
 22	soing	so	VERB	VBG	Tense=Pres|VerbForm=Part	17	advcl	17:advcl:if	_
 23	that	that	DET	DT	Number=Sing|PronType=Dem	24	det	24:det	_
@@ -21541,7 +21541,7 @@
 7	orchestra	orchestra	NOUN	NN	Number=Sing	4	nmod	4:nmod:with	SpaceAfter=No
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 12	to	to	ADP	IN	_	16	case	16:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
@@ -21556,7 +21556,7 @@
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	6	obl	6:obl:before	SpaceAfter=No
 3	,	,	PUNCT	,	_	6	punct	6:punct	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj:pass	6:nsubj:pass|7:nsubj:xsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 6	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 7	loose	loose	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
@@ -21573,7 +21573,7 @@
 5	,	,	PUNCT	,	_	10	punct	10:punct	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 7-8	don't	_	_	_	_	_	_	_	_
-7	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+7	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 8	n't	not	PART	RB	_	10	advmod	10:advmod	_
 9	really	really	ADV	RB	_	10	advmod	10:advmod	_
 10	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -21622,7 +21622,7 @@
 # text = I don't know.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -21632,7 +21632,7 @@
 1	Maybe	maybe	ADV	RB	_	11	advmod	11:advmod	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	post	post	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
+4	post	post	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	question	question	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	again	again	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
@@ -21665,7 +21665,7 @@
 # text = I'm suppose to start a job at Cracker Barrel, but I can't risk losing the job because I have two visible tattoos on my arm.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	suppose	suppose	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	start	start	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
@@ -21686,7 +21686,7 @@
 19	job	job	NOUN	NN	Number=Sing	17	obj	17:obj	_
 20	because	because	SCONJ	IN	_	22	mark	22:mark	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-22	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:because	_
+22	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:because	_
 23	two	two	NUM	CD	NumType=Card	25	nummod	25:nummod	_
 24	visible	visible	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	tattoos	tattoo	NOUN	NNS	Number=Plur	22	obj	22:obj	_
@@ -21699,9 +21699,9 @@
 # text = If you know or work there could you enlighten me?
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	or	or	CCONJ	CC	_	5	cc	5:cc	_
-5	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:or|9:advcl:if	_
+5	work	work	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	conj	3:conj:or|9:advcl:if	_
 6	there	there	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
 7	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
@@ -21714,7 +21714,7 @@
 # text = Why don't you phone another location and ask♥
 1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	n't	not	PART	RB	_	5	advmod	5:advmod	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj|9:nsubj	_
 5	phone	phone	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -21729,16 +21729,16 @@
 # text = I don't think they ban if the tats aren't offensive and you should make them not noticeable at the time of the interview but once you got the job there nothing they can really say if so you have a sue/case against them
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	ban	ban	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+6	ban	ban	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 7	if	if	SCONJ	IN	_	12	mark	12:mark	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	tats	tat	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 10-11	aren't	_	_	_	_	_	_	_	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	n't	not	PART	RB	_	12	advmod	12:advmod	_
 12	offensive	offensive	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	_
 13	and	and	CCONJ	CC	_	16	cc	16:cc	_
@@ -21757,7 +21757,7 @@
 26	but	but	CCONJ	CC	_	33	cc	33:cc	_
 27	once	once	SCONJ	IN	_	29	mark	29:mark	_
 28	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	29	nsubj	29:nsubj	_
-29	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	33	advcl	33:advcl:once	_
+29	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	33	advcl	33:advcl:once	_
 30	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 31	job	job	NOUN	NN	Number=Sing	29	obj	29:obj	_
 32	there	there	PRON	EX	_	33	expl	33:expl	_
@@ -21769,7 +21769,7 @@
 38	if	if	SCONJ	IN	_	39	mark	39:mark	_
 39	so	so	ADV	RB	_	41	advcl	41:advcl:if	_
 40	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	41	nsubj	41:nsubj	_
-41	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	33	parataxis	33:parataxis	_
+41	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	33	parataxis	33:parataxis	_
 42	a	a	DET	DT	Definite=Ind|PronType=Art	43	det	43:det	_
 43	sue	sue	NOUN	NN	Number=Sing	41	obj	41:obj	SpaceAfter=No
 44	/	/	SYM	,	_	45	cc	45:cc	SpaceAfter=No
@@ -21793,7 +21793,7 @@
 # newpar id = answers-20111108104636AAw51HV_ans-p0002
 # text = i need to hav sm good time spent with my gf..in kerala..in which all places in kerala shal i expect ambience and privacy for making love..pls help .thank you
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	hav	have	VERB	VB	Abbr=Yes|VerbForm=Inf	2	xcomp	2:xcomp	_
 5	sm	some	DET	DT	Abbr=Yes	7	det	7:det	_
@@ -21826,7 +21826,7 @@
 32	pls	pls	INTJ	UH	_	33	discourse	33:discourse	_
 33	help	help	VERB	VB	Mood=Imp|VerbForm=Fin	2	parataxis	2:parataxis	_
 34	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
-35	thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+35	thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 36	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	35	obj	35:obj	_
 
 # sent_id = answers-20111108104636AAw51HV_ans-0003
@@ -21896,7 +21896,7 @@
 # sent_id = answers-20111108104636AAw51HV_ans-0006
 # text = People are open minded thr since the place is frequented by Firangs.
 1	People	people	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	open	open	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	minded	minded	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	thr	there	ADV	RB	Typo=Yes	4	advmod	4:advmod	CorrectForm=there
@@ -21914,7 +21914,7 @@
 # newpar id = answers-20111108102531AAqeDhx_ans-p0001
 # text = I have a male and female cockatiel, and there are 2 eggs in the bottom of the cage, will they hatch?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 4	male	male	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
@@ -21923,7 +21923,7 @@
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	there	there	PRON	EX	_	11	expl	11:expl	_
-11	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+11	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 12	2	2	NUM	CD	NumType=Card	13	nummod	13:nummod	_
 13	eggs	egg	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	_
 14	in	in	ADP	IN	_	16	case	16:case	_
@@ -21983,7 +21983,7 @@
 1	Just	just	ADV	RB	_	4	advmod	4:advmod	_
 2	because	because	SCONJ	IN	_	4	mark	4:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:because	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:because	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	male	male	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
@@ -22024,7 +22024,7 @@
 # text = If you see a dark spot in the egg, that means it is fertilized and will hatch if cared for properly.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	see	see	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	dark	dark	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	spot	spot	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -22069,7 +22069,7 @@
 # text = I'm not sure about the origin of the name but they are a lot of different cities with different and unique names like Miramar so it's just a name.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	about	about	ADP	IN	_	7	case	7:case	_
@@ -22080,7 +22080,7 @@
 10	name	name	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	_
 11	but	but	CCONJ	CC	_	13	cc	13:cc	_
 12	they	there	PRON	EX	Typo=Yes	13	expl	13:expl	CorrectForm=there
-13	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+13	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	lot	lot	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
 16	of	of	ADP	IN	_	18	case	18:case	_
@@ -22118,11 +22118,11 @@
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	'd	would	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 11	help	help	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
-12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 13	lot	lot	NOUN	NN	Number=Sing	11	obl:npmod	11:obl:npmod	_
 14	if	if	SCONJ	IN	_	16	mark	16:mark	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	listed	list	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:if	_
+16	listed	list	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:if	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	state	state	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	or	or	CCONJ	CC	_	21	cc	21:cc	_
@@ -22132,7 +22132,7 @@
 23	context	context	NOUN	NN	Number=Sing	21	nmod	21:nmod:of	_
 24-25	you're	_	_	_	_	_	_	_	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
-25	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
+25	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
 26	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	23	acl:relcl	23:acl:relcl	_
 27	for	for	ADP	IN	_	28	case	28:case	_
 28	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	obl	26:obl:for	_
@@ -22213,7 +22213,7 @@
 1	ok	ok	INTJ	UH	_	4	discourse	4:discourse	_
 2	well	well	INTJ	UH	_	4	discourse	4:discourse	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	crush	crush	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	on	on	ADP	IN	_	9	case	9:case	_
@@ -22231,20 +22231,20 @@
 18	afnd	and	CCONJ	CC	_	21	cc	21:cc	_
 19	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	just	just	ADV	RB	_	21	advmod	21:advmod	_
-21	broke	break	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	conj	17:conj:afnd	_
+21	broke	break	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	17	conj	17:conj:afnd	_
 22	up	up	ADP	RP	_	21	compound:prt	21:compound:prt	_
 23	with	with	ADP	IN	_	24	case	24:case	_
 24	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	21	obl	21:obl:with	_
 25	and	and	CCONJ	CC	_	28	cc	28:cc	_
 26	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	28	nsubj	28:nsubj	_
-27	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
+27	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
 28	dated	date	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:and	_
 29	one	one	NUM	CD	NumType=Card	28	obj	28:obj	_
 30	of	of	ADP	IN	_	32	case	32:case	_
-31	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+31	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 32	guys	guy	NOUN	NNS	Number=Plur	29	nmod	29:nmod:of	_
 33	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	34	nsubj	34:nsubj	_
-34	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
+34	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
 35	and	and	CCONJ	CC	_	38	cc	38:cc	_
 36	one	one	NUM	CD	NumType=Card	37	nummod	37:nummod	_
 37	guy	guy	NOUN	NN	Number=Sing	38	nsubj	38:nsubj	_
@@ -22254,7 +22254,7 @@
 41	naborhood	neighborhood	NOUN	NN	Number=Sing	38	obl	38:obl:in	_
 42	guy	guy	NOUN	NN	Number=Sing	44	vocative	44:vocative	_
 43	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	44	nsubj	44:nsubj	_
-44	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+44	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 45	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	46	nmod:poss	46:nmod:poss	_
 46	help	help	NOUN	NN	Number=Sing	44	obj	44:obj	_
 47	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	50	nsubj	50:nsubj	_
@@ -22263,7 +22263,7 @@
 50	girl	girl	NOUN	NN	Number=Sing	44	parataxis	44:parataxis	_
 51	but	but	CCONJ	CC	_	53	cc	53:cc	_
 52	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	53	nsubj	53:nsubj	_
-53	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	50	conj	50:conj:but	_
+53	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	50	conj	50:conj:but	_
 54	a	a	DET	DT	Definite=Ind|PronType=Art	55	det	55:det	_
 55-56	guys	_	_	_	_	_	_	_	_
 55	guy	guy	NOUN	NN	Number=Sing	57	nmod:poss	57:nmod:poss	_
@@ -22279,7 +22279,7 @@
 # text = amd i like 2 guys
 1	amd	and	CCONJ	CC	Typo=Yes	3	cc	3:cc	CorrectForm=and
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	2	2	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	guys	guy	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 
@@ -22299,7 +22299,7 @@
 10	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	9	obj	9:obj	_
 11	how	how	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
+13	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
 
 # sent_id = answers-20090205181308AAZghOH_ans-0005
 # text = it may sound like a bad idea
@@ -22330,7 +22330,7 @@
 2	saying	say	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 3	most	most	ADJ	JJS	Degree=Sup	4	amod	4:amod	_
 4	men	man	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	suck	suck	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	suck	suck	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	!	!	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20090205181308AAZghOH_ans-0008
@@ -22381,11 +22381,11 @@
 # text = because i have read that there are times its not available.
 1	because	because	SCONJ	IN	_	4	mark	4:mark	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	read	read	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	that	that	SCONJ	IN	_	7	mark	7:mark	_
 6	there	there	PRON	EX	_	7	expl	7:expl	_
-7	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 8	times	time	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 9-10	its	_	_	_	_	_	_	_	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
@@ -22416,7 +22416,7 @@
 # text = im traveling to lourdes for a day
 1-2	im	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	traveling	travel	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	lourdes	lourdes	PROPN	NNP	Number=Sing	3	obl	3:obl:to	_
@@ -22456,7 +22456,7 @@
 3	,	,	PUNCT	,	_	1	punct	1:punct	_
 4	altough	although	SCONJ	IN	Typo=Yes	6	mark	6:mark	CorrectForm=although
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:altough	_
+6	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:altough	_
 7	automatic	automatic	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	storage	storage	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	SpaceAfter=No
 9	,	,	PUNCT	,	_	13	punct	13:punct	_
@@ -22469,7 +22469,7 @@
 16	(	(	PUNCT	-LRB-	_	13	punct	13:punct	SpaceAfter=No
 17-18	they're	_	_	_	_	_	_	_	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
-18	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+18	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 19	now	now	ADV	RB	_	20	advmod	20:advmod	_
 20	installing	install	VERB	VBG	Tense=Pres|VerbForm=Part	13	parataxis	13:parataxis	_
 21	some	some	DET	DT	_	20	obj	20:obj	_
@@ -22521,7 +22521,7 @@
 # text = i wanna meet girls from san francisco i am from mexico?
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
 2-3	wanna	_	_	_	_	_	_	_	_
-2	wan	want	VERB	VBP	Abbr=Yes|Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wan	want	VERB	VBP	Abbr=Yes|Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	na	to	PART	TO	Abbr=Yes	4	mark	4:mark	_
 4	meet	meet	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	girls	girl	NOUN	NNS	Number=Plur	4	obj	4:obj	_
@@ -22550,7 +22550,7 @@
 11	week	week	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	_
 12	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj|15:nsubj:xsubj	_
 13-14	wanna	_	_	_	_	_	_	_	_
-13	wan	want	VERB	VBP	Abbr=Yes|Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+13	wan	want	VERB	VBP	Abbr=Yes|Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 14	na	to	PART	TO	Abbr=Yes	15	mark	15:mark	_
 15	meet	meet	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
 16	american	American	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -22566,7 +22566,7 @@
 # sent_id = answers-20111108110008AA7xHnL_ans-0003
 # text = they r open mind for talk?
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	r	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	open	open	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	mind	mind	NOUN	NN	Number=Sing	0	root	0:root	_
 5	for	for	ADP	IN	_	6	case	6:case	_
@@ -22606,11 +22606,11 @@
 2	long	long	ADV	RB	Degree=Pos	16	advmod	16:advmod	_
 3	as	as	SCONJ	IN	_	7	mark	7:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj|9:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	gentleman	gentleman	NOUN	NN	Number=Sing	1	advcl	1:advcl:as	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	treat	treat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	1:advcl:as|7:conj:and	_
+9	treat	treat	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	conj	1:advcl:as|7:conj:and	_
 10	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	9	obj	9:obj	_
 11	with	with	ADP	IN	_	12	case	12:case	_
 12	respect	respect	NOUN	NN	Number=Sing	9	obl	9:obl:with	_
@@ -22635,7 +22635,7 @@
 30	with	with	SCONJ	IN	_	33	mark	33:mark	_
 31	how	how	SCONJ	WRB	PronType=Int	33	mark	33:mark	_
 32	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
-33	treat	treat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	29	advcl	29:advcl:with	_
+33	treat	treat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	advcl	29:advcl:with	_
 34	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	33	obj	33:obj	SpaceAfter=No
 35	.	.	PUNCT	.	_	16	punct	16:punct	_
 
@@ -22799,7 +22799,7 @@
 1	3	3	NUM	LS	_	4	nummod	4:nummod	SpaceAfter=No
 2	)	)	PUNCT	-RRB-	_	1	punct	1:punct	_
 3	also	also	ADV	RB	_	4	advmod	4:advmod	_
-4	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	an	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	island	island	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	where	where	SCONJ	WRB	PronType=Rel	10	mark	10:mark	_
@@ -22818,7 +22818,7 @@
 # newpar id = answers-20111107203006AA9ojw8_ans-p0003
 # text = you need to bring me next time
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	bring	bring	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	obj	4:obj	_
@@ -22875,7 +22875,7 @@
 # newpar id = answers-20070404104007AAY1Chs_ans-p0002
 # text = I searched all over the internet, but I could not find one place in Tampa Bay that sells morcillas, also known as blood pudding, black pudding and blood sausages.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	searched	search	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	searched	search	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	all	all	ADV	RB	_	6	advmod	6:advmod	_
 4	over	over	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -22911,10 +22911,10 @@
 # sent_id = answers-20070404104007AAY1Chs_ans-0003
 # text = I learned that morcillas are basically impossible to find all across the North American region.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	learned	learn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	7	mark	7:mark	_
 4	morcillas	morcilla	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	basically	basically	ADV	RB	_	7	advmod	7:advmod	_
 7	impossible	impossible	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
@@ -22931,7 +22931,7 @@
 # text = But I did find this website, www.igourmet.com, where they sell all types of sausages, including blood sausages!
 1	But	but	CCONJ	CC	_	4	cc	4:cc	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 4	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
 6	website	website	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
@@ -22940,7 +22940,7 @@
 9	,	,	PUNCT	,	_	6	punct	6:punct	_
 10	where	where	SCONJ	WRB	PronType=Rel	12	mark	12:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	sell	sell	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+12	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 13	all	all	DET	DT	_	14	det	14:det	_
 14	types	type	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	of	of	ADP	IN	_	16	case	16:case	_
@@ -22983,7 +22983,7 @@
 # text = I don't know, and it is because I don't like them, do you know that, morcillas is coagulated blood from animals, ewww
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
@@ -22993,12 +22993,12 @@
 9	because	because	SCONJ	IN	_	13	mark	13:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 11-12	don't	_	_	_	_	_	_	_	_
-11	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
+11	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	_	13	advmod	13:advmod	_
 13	like	like	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:because	_
 14	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	13	obj	13:obj	SpaceAfter=No
 15	,	,	PUNCT	,	_	4	punct	4:punct	_
-16	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+16	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 17	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 18	know	know	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 19	that	that	SCONJ	IN	_	24	mark	24:mark	SpaceAfter=No
@@ -23037,7 +23037,7 @@
 1	UP	UP	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	Roadways	Roadway	PROPN	NNPS	Number=Plur	3	compound	3:compound	_
 3	buses	bus	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	ply	ply	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	ply	ply	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	frequently	frequently	ADV	RB	_	4	advmod	4:advmod	_
 6	between	between	ADP	IN	_	10	case	10:case	_
 7	Sector	Sector	PROPN	NNP	Number=Sing	10	compound	10:compound	SpaceAfter=No
@@ -23064,11 +23064,11 @@
 2	from	from	ADP	IN	_	3	case	3:case	_
 3	these	this	PRON	DT	Number=Plur|PronType=Dem	1	obl	1:obl:from	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	numerous	numerous	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	cabs	cab	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj|9:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	ferry	ferry	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	ferry	ferry	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	passengers	passenger	NOUN	NNS	Number=Plur	9	obj	9:obj	_
 11	between	between	ADP	IN	_	15	case	15:case	_
 12	Sector	Sector	PROPN	NNP	Number=Sing	15	compound	15:compound	SpaceAfter=No
@@ -23127,7 +23127,7 @@
 # sent_id = answers-20111108093942AAYF9Dn_ans-0008
 # text = There are UP Govt.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	UP	UP	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	Govt	Govt	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -23211,7 +23211,7 @@
 # newpar id = answers-20111108081748AAkQhGe_ans-p0002
 # text = I have wifi at my house, but thats just at my house...is there anyway i can buy some card to make the ipod itself have wifi?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	wifi	wifi	NOUN	NN	Number=Sing	2	obj	2:obj	_
 4	at	at	ADP	IN	_	6	case	6:case	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -23228,7 +23228,7 @@
 15	...	...	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 16	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 17	there	there	PRON	EX	_	16	expl	16:expl	_
-18	any	any	DET	DT	_	19	det	19:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+18	any	any	DET	DT	_	19	det	19:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 19	way	way	NOUN	NN	Number=Sing	16	nsubj	16:nsubj	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
@@ -23247,7 +23247,7 @@
 # sent_id = answers-20111108081748AAkQhGe_ans-0003
 # text = i want to be able to use it in my car, out n about etc...i guess like an iphone, but thats later on and ,i know what they are so no suggestions on just goin out to buy one im talking about right now just for an ipod??.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|5:nsubj:xsubj|7:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	5	mark	5:mark	_
 4	be	be	AUX	VB	VerbForm=Inf	5	cop	5:cop	_
 5	able	able	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
@@ -23264,7 +23264,7 @@
 16	etc	etc	X	FW	_	11	conj	7:obl:in|11:conj	SpaceAfter=No
 17	...	...	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 18	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
-19	guess	guess	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+19	guess	guess	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 20	like	like	ADP	IN	_	22	case	22:case	_
 21	an	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
 22	iphone	iphone	NOUN	NN	Number=Sing	19	obl	19:obl:like	SpaceAfter=No
@@ -23278,10 +23278,10 @@
 29	and	and	CCONJ	CC	_	32	cc	32:cc	_
 30	,	,	PUNCT	,	_	32	punct	32:punct	SpaceAfter=No
 31	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	32	nsubj	32:nsubj	_
-32	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	conj	26:conj:and	_
+32	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	26	conj	26:conj:and	_
 33	what	what	PRON	WP	PronType=Int	32	ccomp	32:ccomp	_
 34	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
-35	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	33	cop	33:cop	_
+35	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	cop	33:cop	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
 37	no	no	DET	DT	_	38	det	38:det	_
 38	suggestions	suggestion	NOUN	NNS	Number=Plur	26	advcl	26:advcl	_
@@ -23294,7 +23294,7 @@
 45	one	one	NUM	CD	NumType=Card	44	obj	44:obj	_
 46-47	im	_	_	_	_	_	_	_	_
 46	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	48	nsubj	48:nsubj	_
-47	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	48	aux	48:aux	_
+47	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	48	aux	48:aux	_
 48	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	38	parataxis	38:parataxis	_
 49	about	about	ADP	IN	_	51	case	51:case	_
 50	right	right	ADV	RB	_	51	advmod	51:advmod	_
@@ -23310,7 +23310,7 @@
 # text = You gotta get an iPhone for 3G...only way...actually there is a thing that you pay for monthly that gets wifi from satellite and you can connect to it anywhere but you have to Cary it with you
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
 2-3	gotta	_	_	_	_	_	_	_	_
-2	got	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	got	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	ta	to	PART	TO	Abbr=Yes	4	mark	4:mark	_
 4	get	get	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	an	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -23328,7 +23328,7 @@
 17	thing	thing	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|20:obl|24:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	20	obl	17:ref	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
-20	pay	pay	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+20	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 21	for	for	ADP	IN	_	18	case	18:case	_
 22	monthly	monthly	ADV	RB	_	20	advmod	20:advmod	_
 23	that	that	PRON	WDT	PronType=Rel	24	nsubj	17:ref	_
@@ -23345,7 +23345,7 @@
 34	anywhere	anywhere	ADV	RB	_	31	advmod	31:advmod	_
 35	but	but	CCONJ	CC	_	37	cc	37:cc	_
 36	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	37	nsubj	37:nsubj|39:nsubj:xsubj	_
-37	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	conj	17:acl:relcl|24:conj:and	_
+37	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	conj	17:acl:relcl|24:conj:and	_
 38	to	to	PART	TO	_	39	mark	39:mark	_
 39	Cary	cary	VERB	VB	VerbForm=Inf	37	xcomp	37:xcomp	_
 40	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	39	obj	39:obj	_
@@ -23357,7 +23357,7 @@
 # newpar id = answers-20111107115952AAqfsHV_ans-p0001
 # text = how are vietnam and Afghanistan alike?
 1	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	vietnam	Vietnam	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	Afghanistan	Afghanistan	PROPN	NNP	Number=Sing	3	conj	3:conj:and|6:nsubj	_
@@ -23375,7 +23375,7 @@
 # text = i'm doing a report on how afghanistan and Vietam are different and alike.
 1-2	i'm	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	doing	do	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	report	report	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -23384,7 +23384,7 @@
 8	afghanistan	Afghanistan	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj|14:nsubj	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	Vietam	Vietam	PROPN	NNP	Number=Sing	8	conj	8:conj:and|12:nsubj	_
-11	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+11	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 12	different	different	ADJ	JJ	Degree=Pos	5	acl	5:acl:on	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	alike	alike	ADJ	JJ	Degree=Pos	12	conj	5:acl:on|12:conj:and	SpaceAfter=No
@@ -23394,7 +23394,7 @@
 # text = ive been on the internet for 3 hours but so far i've got nothing.
 1-2	ive	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-2	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+2	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
 4	on	on	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -23407,7 +23407,7 @@
 12	far	far	ADV	RB	Degree=Pos	15	advmod	15:advmod	_
 13-14	i've	_	_	_	_	_	_	_	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
-14	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+14	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 15	got	get	VERB	VBN	Tense=Past|VerbForm=Part	6	conj	6:conj:but	_
 16	nothing	nothing	PRON	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
 17	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -23415,12 +23415,12 @@
 # sent_id = answers-20111107115952AAqfsHV_ans-0005
 # text = i need to know how they are different and alike in these area's
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	how	how	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|10:nsubj	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 8	different	different	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	alike	alike	ADJ	JJ	Degree=Pos	8	conj	4:ccomp|8:conj:and	_
@@ -23456,7 +23456,7 @@
 # sent_id = answers-20111107115952AAqfsHV_ans-0009
 # text = who fought the wars?
 1	who	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	fought	fight	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	fought	fight	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	wars	war	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -23551,7 +23551,7 @@
 17	liberal	liberal	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 18	revisionist	revisionist	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	historians	historian	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	_
-20	tell	tell	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	ccomp	14:ccomp	_
+20	tell	tell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	14:ccomp	_
 21	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	20	iobj	20:iobj	SpaceAfter=No
 22	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 23	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -23569,7 +23569,7 @@
 6	name	name	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	_
 7	and	and	CCONJ	CC	_	11	cc	11:cc	_
 8	why	why	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
-9	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
+9	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
 11	name	name	VERB	VB	VerbForm=Inf	1	conj	1:conj:and	_
 12	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj|15:nsubj:xsubj	SpaceAfter=No
@@ -23583,7 +23583,7 @@
 # text = If you HAVE a cat of course.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	HAVE	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	HAVE	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	cat	cat	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	of	of	ADP	IN	_	3	advmod	3:advmod	_
@@ -23611,7 +23611,7 @@
 6	little	little	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	kitten	kitten	NOUN	NN	Number=Sing	9	advcl	9:advcl:when	_
 8	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	like	like	ADP	IN	_	14	case	14:case	_
 11	those	that	DET	DT	Number=Plur|PronType=Dem	14	det	14:det	_
 12	twinky	twinky	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -23629,7 +23629,7 @@
 6	and	and	CCONJ	CC	_	9	cc	9:cc	_
 7-8	I've	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-8	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	5	conj	5:conj:and	_
 10	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj	_
 11	for	for	ADP	IN	_	14	case	14:case	_
@@ -23643,14 +23643,14 @@
 # newpar id = answers-20111108105146AAtiEx7_ans-p0003
 # text = I have a siamese lynx name Star we called her that because she has a star pattern on her face.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	siamese	Siamese	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	lynx	lynx	NOUN	NN	Number=Sing	2	obj	2:obj	_
 6	name	name	VERB	VBN	Tense=Past|VerbForm=Part	5	acl	5:acl	_
 7	Star	Star	PROPN	NNP	Number=Sing	6	xcomp	6:xcomp	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
+9	called	call	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 10	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj|11:nsubj:xsubj	_
 11	that	that	PRON	DT	Number=Sing|PronType=Dem	9	xcomp	9:xcomp	_
 12	because	because	SCONJ	IN	_	14	mark	14:mark	_
@@ -23679,7 +23679,7 @@
 # sent_id = answers-20111108105146AAtiEx7_ans-0008
 # text = I love her. :)
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	2:punct	_
 5	:)	:)	SYM	NFP	_	2	discourse	2:discourse	_
@@ -23688,7 +23688,7 @@
 # newpar id = answers-20111108105146AAtiEx7_ans-p0004
 # text = I have a Norwegian Forest Cat that is named Achilles bc as a kitten he always attacked your feet when you walked by!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	Norwegian	Norwegian	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	Forest	forest	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -23703,12 +23703,12 @@
 14	kitten	kitten	NOUN	NN	Number=Sing	17	obl	17:obl:as	_
 15	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
 16	always	always	ADV	RB	_	17	advmod	17:advmod	_
-17	attacked	attack	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:bc	_
+17	attacked	attack	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:bc	_
 18	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 19	feet	foot	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	when	when	SCONJ	WRB	PronType=Int	22	mark	22:mark	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj	_
-22	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	advcl	17:advcl:when	_
+22	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	17	advcl	17:advcl:when	_
 23	by	by	ADV	RB	_	22	advmod	22:advmod	SpaceAfter=No
 24	!	!	PUNCT	.	_	2	punct	2:punct	_
 
@@ -23725,27 +23725,27 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	year	year	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obj	10:obj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	year	year	NOUN	NN	Number=Sing	4	advcl	4:advcl:because	_
 15	Frank	Frank	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj	_
 16	Sinatra	Sinatra	PROPN	NNP	Number=Sing	15	flat	15:flat	_
-17	died	die	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+17	died	die	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 
 # sent_id = answers-20111108105146AAtiEx7_ans-0011
 # text = He also had bright blue eyes like Frank Sinatra did :)
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	bright	bright	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	blue	blue	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	eyes	eye	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 7	like	like	SCONJ	IN	_	10	mark	10:mark	_
 8	Frank	Frank	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
 9	Sinatra	Sinatra	PROPN	NNP	Number=Sing	8	flat	8:flat	_
-10	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:like	_
+10	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:like	_
 11	:)	:)	SYM	NFP	_	3	discourse	3:discourse	_
 
 # newdoc id = answers-20111108104131AAWUQHU_ans
@@ -23772,7 +23772,7 @@
 2	female	female	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	chameleon	chameleon	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	just	just	ADV	RB	_	5	advmod	5:advmod	_
-5	laid	lay	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	laid	lay	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	eggs	egg	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 7	yesterday	yesterday	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	_
 8	and	and	CCONJ	CC	_	15	cc	15:cc	_
@@ -23785,10 +23785,10 @@
 15	soft	soft	ADJ	JJ	Degree=Pos	5	conj	5:conj:and	_
 16	when	when	SCONJ	WRB	PronType=Int	18	mark	18:mark	_
 17	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj|19:nsubj:xsubj	_
-18	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
+18	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:when	_
 19	soft	soft	ADJ	JJ	Degree=Pos	18	xcomp	18:xcomp	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
+21	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
 22	like	like	INTJ	UH	_	21	discourse	21:discourse	_
 23	not	not	PART	RB	_	27	advmod	27:advmod	_
 24	like	like	ADP	IN	_	27	case	27:case	_
@@ -23801,7 +23801,7 @@
 # newpar id = answers-20111108104131AAWUQHU_ans-p0003
 # text = They are probably infertile.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	probably	probably	ADV	RB	_	4	advmod	4:advmod	_
 4	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -23814,7 +23814,7 @@
 4	no	no	DET	DT	_	5	det	5:det	_
 5	male	male	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 8	probably	probably	ADV	RB	_	9	advmod	9:advmod	_
 9	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 10	!	!	PUNCT	.	_	9	punct	9:punct	_
@@ -23823,19 +23823,19 @@
 # text = If you take a flash light and shine it through the eggs and you see nothing throw them away!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|8:nsubj	_
-3	take	take	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+3	take	take	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	flash	flash	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	light	light	NOUN	NN	Number=Sing	3	obj	3:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	shine	shine	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|17:advcl:if	_
+8	shine	shine	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|17:advcl:if	_
 9	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obj	8:obj	_
 10	through	through	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	eggs	egg	NOUN	NNS	Number=Plur	8	obl	8:obl:through	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	see	see	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|17:advcl:if	_
+15	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|17:advcl:if	_
 16	nothing	nothing	PRON	NN	Number=Sing	15	obj	15:obj	_
 17	throw	throw	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 18	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	17	obj	17:obj	_
@@ -23846,7 +23846,7 @@
 # text = If you do not they will start to rot!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
 4	not	not	PART	RB	_	3	advmod	3:advmod	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -23879,13 +23879,13 @@
 # text = if you do have a male but they are not in the same cage or breeding but you touch him then her she will smell his sent and probably lay eggs.
 1	if	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	have	have	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:if	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	male	male	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	but	but	CCONJ	CC	_	14	cc	14:cc	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj|16:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 10	not	not	PART	RB	_	14	advmod	14:advmod	_
 11	in	in	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -23895,7 +23895,7 @@
 16	breeding	breed	VERB	VBG	VerbForm=Ger	14	conj	14:conj:or	_
 17	but	but	CCONJ	CC	_	19	cc	19:cc	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
-19	touch	touch	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but|25:advcl:if	_
+19	touch	touch	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but|25:advcl:if	_
 20	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	obj	19:obj	_
 21	then	then	ADV	RB	PronType=Dem	22	advmod	22:advmod	_
 22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	conj	19:obj|20:conj	_
@@ -23912,7 +23912,7 @@
 
 # sent_id = answers-20111108104131AAWUQHU_ans-0009
 # text = Hope she stops laying eggs because she will get really skinny!
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
 3	stops	stop	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
 4	laying	lay	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
@@ -23934,7 +23934,7 @@
 
 # sent_id = answers-20111108104131AAWUQHU_ans-0011
 # text = Hope this helps
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	this	this	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
 3	helps	help	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	ccomp	1:ccomp	_
 
@@ -23943,7 +23943,7 @@
 # newpar id = answers-20111107155302AAXXuM1_ans-p0001
 # text = I have 24hrs in San Francisco - what are the best sights to see in my short time?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	24	24	NUM	CD	NumType=Card	4	nummod	4:nummod	SpaceAfter=No
 4	hrs	hour	NOUN	NNS	Abbr=Yes|Number=Plur	2	obj	2:obj	_
 5	in	in	ADP	IN	_	6	case	6:case	_
@@ -23951,7 +23951,7 @@
 7	Francisco	Francisco	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 8	-	-	PUNCT	:	_	2	punct	2:punct	_
 9	what	what	PRON	WP	PronType=Int	2	parataxis	2:parataxis	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	best	good	ADJ	JJS	Degree=Sup	13	amod	13:amod	_
 13	sights	sight	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
@@ -23967,7 +23967,7 @@
 # newpar id = answers-20111107155302AAXXuM1_ans-p0002
 # text = I have a day stop-over in San Francisco and my wife want to see some of the key sites.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 4	day	day	NOUN	NN	Number=Sing	7	compound	7:compound	_
 5	stop	stop	NOUN	NN	Number=Sing	7	compound	7:compound	SpaceAfter=No
@@ -23979,7 +23979,7 @@
 11	and	and	CCONJ	CC	_	14	cc	14:cc	_
 12	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	wife	wife	NOUN	NN	Number=Sing	14	nsubj	14:nsubj|16:nsubj:xsubj	_
-14	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 15	to	to	PART	TO	_	16	mark	16:mark	_
 16	see	see	VERB	VB	VerbForm=Inf	14	xcomp	14:xcomp	_
 17	some	some	DET	DT	_	16	obj	16:obj	_
@@ -23992,7 +23992,7 @@
 # sent_id = answers-20111107155302AAXXuM1_ans-0003
 # text = We are staying next to the airport which is located next to BARTrail.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	staying	stay	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	next	next	ADV	RB	_	3	advmod	3:advmod	_
 5	to	to	ADP	IN	_	7	case	7:case	_
@@ -24009,11 +24009,11 @@
 # sent_id = answers-20111107155302AAXXuM1_ans-0004
 # text = We have limited time What are the best sights to see, geiven that we only have a short time?
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	limited	limited	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	time	time	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	What	what	PRON	WP	PronType=Int	9	nsubj	9:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	best	good	ADJ	JJS	Degree=Sup	9	amod	9:amod	_
 9	sights	sight	NOUN	NNS	Number=Plur	2	parataxis	2:parataxis	_
@@ -24024,7 +24024,7 @@
 14	that	that	SCONJ	IN	_	17	mark	17:mark	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	only	only	ADV	RB	_	17	advmod	17:advmod	_
-17	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:that	_
+17	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:that	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 19	short	short	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 20	time	time	NOUN	NN	Number=Sing	17	obj	17:obj	SpaceAfter=No
@@ -24034,13 +24034,13 @@
 # text = (We check in early afternoon and we fly next day. )
 1	(	(	PUNCT	-LRB-	_	3	punct	3:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	check	check	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	check	check	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	in	in	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	early	early	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	afternoon	afternoon	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	fly	fly	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+9	fly	fly	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 10	next	next	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	day	day	NOUN	NN	Number=Sing	9	obl:tmod	9:obl:tmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -24088,7 +24088,7 @@
 24	off	off	ADV	RB	_	23	advmod	23:advmod	_
 25	anyplace	anyplace	ADV	RB	_	23	advmod	23:advmod	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
-27	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
+27	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	spend	spend	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	_
 30	more	more	ADJ	JJR	Degree=Cmp	31	amod	31:amod	_
@@ -24181,7 +24181,7 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
@@ -24212,7 +24212,7 @@
 # sent_id = answers-20111107201700AAKdymq_ans-0004
 # text = I have not had good experience with travel agents.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -24226,7 +24226,7 @@
 # text = They don't seem to know anything but the hype they are told and the packages they have available to them.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	seem	seem	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -24236,13 +24236,13 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	hype	hype	NOUN	NN	Number=Sing	7	nmod	7:nmod:but	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj:pass	13:nsubj:pass	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux:pass	13:aux:pass	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux:pass	13:aux:pass	_
 13	told	tell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	_
 14	and	and	CCONJ	CC	_	16	cc	16:cc	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	packages	package	NOUN	NNS	Number=Plur	10	conj	10:conj:and	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj|19:nsubj:xsubj	_
-18	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
+18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
 19	available	available	ADJ	JJ	Degree=Pos	18	xcomp	18:xcomp	_
 20	to	to	ADP	IN	_	21	case	21:case	_
 21	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	19	obl	19:obl:to	SpaceAfter=No
@@ -24255,13 +24255,13 @@
 3	time	time	NOUN	NN	Number=Sing	14	obl:tmod	14:obl:tmod	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	actually	actually	ADV	RB	_	6	advmod	6:advmod	_
-6	booked	book	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+6	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 7	through	through	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	travel	travel	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	agent	agent	NOUN	NN	Number=Sing	6	obl	6:obl:through	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
+12	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
 13	not	not	PART	RB	_	14	advmod	14:advmod	_
 14	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
 15	all	all	DET	DT	_	14	obj	14:obj	_
@@ -24269,7 +24269,7 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	amenities	amenity	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-20	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	21	aux	21:aux	_
+20	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	21	aux	21:aux	_
 21	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part	18	acl:relcl	18:acl:relcl	_
 22	for	for	ADP	IN	_	21	obl	21:obl	SpaceAfter=No
 23	.	.	PUNCT	.	_	14	punct	14:punct	_
@@ -24280,7 +24280,7 @@
 2	few	few	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	times	time	NOUN	NNS	Number=Plur	13	obl:tmod	13:obl:tmod	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-5	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	consulted	consult	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
 7	with	with	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
@@ -24305,7 +24305,7 @@
 27	than	than	SCONJ	IN	_	28	case	28:case	_
 28	what	what	PRON	WP	PronType=Int	25	obl	25:obl:than	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	31	nsubj	31:nsubj	_
-30	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
+30	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
 31	selling	sell	VERB	VBG	Tense=Pres|VerbForm=Part	28	acl:relcl	28:acl:relcl	SpaceAfter=No
 32	.	.	PUNCT	.	_	13	punct	13:punct	_
 
@@ -24314,7 +24314,7 @@
 1	So	so	ADV	RB	_	6	advmod	6:advmod	_
 2	now	now	ADV	RB	_	6	advmod	6:advmod	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
 6	bother	bother	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	with	with	ADP	IN	_	8	case	8:case	_
@@ -24340,9 +24340,9 @@
 # text = My Hamster escaped.... NEED HELP NOW!?
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	Hamster	Hamster	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	escaped	escape	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	escaped	escape	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	....	....	PUNCT	,	_	3	punct	3:punct	_
-5	NEED	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+5	NEED	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 6	HELP	help	NOUN	NN	Number=Sing	5	obj	5:obj	_
 7	NOW	now	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 8	!?	!?	PUNCT	.	_	3	punct	3:punct	_
@@ -24353,7 +24353,7 @@
 1	okay	okay	INTJ	UH	_	4	discourse	4:discourse	SpaceAfter=No
 2	....	....	PUNCT	,	_	4	punct	4:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	dog	dog	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -24379,7 +24379,7 @@
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	hamster	hamster	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
-11	escaped	escape	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	escaped	escape	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	from	from	ADP	IN	_	14	case	14:case	_
 13	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 14	cage	cage	NOUN	NN	Number=Sing	11	obl	11:obl:from	SpaceAfter=No
@@ -24395,7 +24395,7 @@
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
 7	but	but	CCONJ	CC	_	9	cc	9:cc	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
+9	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
 10	so	so	ADV	RB	_	11	advmod	11:advmod	_
 11	many	many	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	things	thing	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
@@ -24404,7 +24404,7 @@
 15	,	,	PUNCT	,	_	5	punct	5:punct	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 17-19	dunno	_	_	_	_	_	_	_	_
-17	du	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	du	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	n	not	PART	RB	_	19	advmod	19:advmod	_
 19	no	know	VERB	VB	VerbForm=Inf	5	parataxis	5:parataxis	_
 20	what	what	PRON	WP	PronType=Int	22	nsubj	22:nsubj	_
@@ -24415,7 +24415,7 @@
 # sent_id = answers-20111108105022AA0Q5wb_ans-0005
 # text = I have lots of containers in there.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	lots	lot	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	of	of	ADP	IN	_	5	case	5:case	_
 5	containers	container	NOUN	NNS	Number=Plur	3	nmod	3:nmod:of	_
@@ -24453,13 +24453,13 @@
 # text = I'm not kidding , I once lost a hamster in my house 3 months later I walk down in the basement and it was as big as a rat.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	kidding	kid	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	once	once	ADV	RB	NumType=Mult	8	advmod	8:advmod	_
-8	lost	lose	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
+8	lost	lose	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 10	hamster	hamster	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	in	in	ADP	IN	_	13	case	13:case	_
@@ -24469,7 +24469,7 @@
 15	months	month	NOUN	NNS	Number=Plur	16	obl:npmod	16:obl:npmod	_
 16	later	late	ADV	RBR	Degree=Cmp	18	advmod	18:advmod	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	walk	walk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+18	walk	walk	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 19	down	down	ADV	RB	_	18	advmod	18:advmod	_
 20	in	in	ADP	IN	_	22	case	22:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -24487,7 +24487,7 @@
 # sent_id = answers-20111108105022AA0Q5wb_ans-0009
 # text = It had been eating dog food the whole time.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	eating	eat	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	dog	dog	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -24503,7 +24503,7 @@
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
 3	huge	huge	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
-5	scared	scare	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+5	scared	scare	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	crap	crap	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	out	out	ADP	IN	_	10	case	10:case	_
@@ -24567,7 +24567,7 @@
 # newpar id = answers-20111108102204AAIivYN_ans-p0002
 # text = i want a small indoor pet that my mother will let me have please help
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	small	small	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	indoor	indoor	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -24585,7 +24585,7 @@
 # sent_id = answers-20111108102204AAIivYN_ans-0003
 # text = i want something cheap east to take care of and something to hopefully fit in my room
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	something	something	PRON	NN	Number=Sing	2	obj	2:obj	_
 4	cheap	cheap	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 5	east	east	ADJ	JJ	Degree=Pos	4	conj	3:amod|4:conj	_
@@ -24620,7 +24620,7 @@
 # text = they all need love and attn , food, proper surroundings etc.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	all	all	DET	DT	_	1	det	1:det	_
-3	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	love	love	NOUN	NN	Number=Sing	3	obj	3:obj	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	attn	attn	NOUN	NN	Number=Sing	4	conj	3:obj|4:conj:and	_
@@ -24644,7 +24644,7 @@
 8	-	-	PUNCT	,	_	7	punct	7:punct	_
 9	but	but	CCONJ	CC	_	11	cc	11:cc	_
 10	u	u	PRON	PRP	_	11	nsubj	11:nsubj|13:nsubj:xsubj|18:nsubj:xsubj	_
-11	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	7:conj:but	_
+11	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	conj	7:conj:but	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	clean	clean	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
@@ -24687,17 +24687,17 @@
 # sent_id = answers-20111108102204AAIivYN_ans-0009
 # text = They require a lot of attention or they get fussy and tear stuff up.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	require	require	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	require	require	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	lot	lot	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	attention	attention	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
 7	or	or	CCONJ	CC	_	10	cc	10:cc	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj:pass	10:nsubj:pass|12:nsubj:pass	_
-9	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
+9	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
 10	fussy	fussy	ADJ	JJ	Degree=Pos	2	conj	2:conj:or	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
-12	tear	tear	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	conj	10:conj:and	_
+12	tear	tear	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	conj	10:conj:and	_
 13	stuff	stuff	NOUN	NN	Number=Sing	12	obj	12:obj	_
 14	up	up	ADP	RP	_	12	compound:prt	12:compound:prt	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -24706,7 +24706,7 @@
 # text = If you want easy then go with a gold fish or hamster.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
 4	easy	easy	ADJ	JJ	Degree=Pos	3	obj	3:obj	_
 5	then	then	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
 6	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
@@ -24740,7 +24740,7 @@
 17	gerbil	gerbil	NOUN	NN	Number=Sing	11	conj	7:nmod:such_as|11:conj:or	_
 18	if	if	SCONJ	IN	_	20	mark	20:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
 21	something	something	PRON	NN	Number=Sing	20	obj	20:obj	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj|26:nsubj	_
 23	can	can	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
@@ -24752,7 +24752,7 @@
 # sent_id = answers-20111108102204AAIivYN_ans-0012
 # text = Fish are probably the easiest to take care of though.
 1	Fish	fish	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	probably	probably	ADV	RB	_	5	advmod	5:advmod	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	easiest	easy	ADJ	JJS	Degree=Sup	0	root	0:root	_
@@ -24777,7 +24777,7 @@
 # text = Ive been dating a man from brittany france for a couple of months now.
 1-2	Ive	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	dating	date	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -24834,7 +24834,7 @@
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10-11	havent	_	_	_	_	_	_	_	_
-10	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+10	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	nt	not	PART	RB	_	12	advmod	12:advmod	_
 12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	7	conj	7:conj:and	_
 13	sex	sex	NOUN	NN	Number=Sing	12	obj	12:obj	_
@@ -24855,7 +24855,7 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj|11:nsubj:xsubj	_
 2	just	just	ADV	RB	_	5	advmod	5:advmod	_
 3-4	dont	_	_	_	_	_	_	_	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	nt	not	PART	RB	_	5	advmod	5:advmod	_
 5	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -24890,7 +24890,7 @@
 # sent_id = answers-20111108071348AAWu2FU_ans-0007
 # text = What do french men find sexy?
 1	What	what	PRON	WP	PronType=Int	5	obj	5:obj|6:nsubj:xsubj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	french	French	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	men	man	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
 5	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -24902,7 +24902,7 @@
 # text = French women are the ones to say yes, the way we say it is not usually as straigthforward as you propose to do.
 1	French	French	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	women	woman	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	ones	one	NOUN	NNS	Number=Plur	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -24912,7 +24912,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	way	way	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 16	not	not	PART	RB	_	19	advmod	19:advmod	_
@@ -24921,7 +24921,7 @@
 19	straigthforward	straightforward	ADJ	JJ	Degree=Pos|Typo=Yes	5	parataxis	5:parataxis	CorrectForm=straightforward
 20	as	as	SCONJ	IN	_	22	mark	22:mark	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj|24:nsubj:xsubj	_
-22	propose	propose	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:as	_
+22	propose	propose	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:as	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	do	do	VERB	VB	VerbForm=Inf	22	xcomp	22:xcomp	SpaceAfter=No
 25	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -24955,7 +24955,7 @@
 # text = And you take it up from there.
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	take	take	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	take	take	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	_
 5	up	up	ADV	RB	_	3	advmod	3:advmod	_
 6	from	from	ADP	IN	_	7	case	7:case	_
@@ -25019,7 +25019,7 @@
 # newpar id = reviews-128908-p0001
 # text = I love the meat!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	meat	meat	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -25134,7 +25134,7 @@
 # text = The food tasted like rat feces
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	food	food	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	tasted	taste	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	tasted	taste	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	like	like	ADP	IN	_	6	case	6:case	_
 5	rat	rat	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	feces	feces	NOUN	NNS	Number=Plur	3	obl	3:obl:like	_
@@ -25217,7 +25217,7 @@
 # text = Responsive, kept me apprised of status.
 1	Responsive	responsive	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 2	,	,	PUNCT	,	_	3	punct	3:punct	_
-3	kept	keep	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
+3	kept	keep	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	3:obj|5:nsubj:xsubj	_
 5	apprised	apprised	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 6	of	of	ADP	IN	_	7	case	7:case	_
@@ -25230,7 +25230,7 @@
 # text = Whatever you order, you will LOVE!
 1	Whatever	whatever	PRON	WP	PronType=Int	7	obj	7:obj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	order	order	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	SpaceAfter=No
+3	order	order	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	SpaceAfter=No
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -25498,14 +25498,14 @@
 # sent_id = reviews-115566-0001
 # newpar id = reviews-115566-p0001
 # text = Retired
-1	Retired	retire	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Retired	retire	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 
 # sent_id = reviews-115566-0002
 # newpar id = reviews-115566-p0002
 # text = Dr Joseph retired.
 1	Dr	Dr	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	Joseph	Joseph	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-3	retired	retire	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	retired	retire	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-115566-0003
@@ -25660,7 +25660,7 @@
 # newpar id = reviews-356705-p0001
 # text = You were extremely polite and professional.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|6:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 3	extremely	extremely	ADV	RB	_	4	advmod	4:advmod	_
 4	polite	polite	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
@@ -25693,7 +25693,7 @@
 # sent_id = reviews-372582-0002
 # text = Staff were pleasant.
 1	Staff	staff	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
 3	pleasant	pleasant	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -25743,7 +25743,7 @@
 # sent_id = reviews-317326-0002
 # text = Really enjoyed it.
 1	Really	really	ADV	RB	_	2	advmod	2:advmod	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obj	2:obj	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -25772,7 +25772,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2-3	you're	_	_	_	_	_	_	_	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	looking	look	VERB	VBG	VerbForm=Ger	13	advcl	13:advcl:if	_
 5	for	for	ADP	IN	_	8	case	8:case	_
 6	homestyle	homestyle	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -25824,7 +25824,7 @@
 1	Mercedes	Mercedes	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj|9:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	Dan	Dan	PROPN	NNP	Number=Sing	1	conj	1:conj:and|6:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	very	very	ADV	RB	_	6	advmod	6:advmod	_
 6	thorough	thorough	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
@@ -25838,7 +25838,7 @@
 # sent_id = reviews-309168-0001
 # newpar id = reviews-309168-p0001
 # text = love this park
-1	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	this	this	DET	DT	Number=Sing|PronType=Dem	3	det	3:det	_
 3	park	park	NOUN	NN	Number=Sing	1	obj	1:obj	_
 
@@ -25872,12 +25872,12 @@
 # sent_id = reviews-138699-0002
 # text = I get Microdermabrasions regularly and I love the environment
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Microdermabrasions	microdermabrasion	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	regularly	regularly	ADV	RB	_	2	advmod	2:advmod	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+7	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	environment	environment	NOUN	NN	Number=Sing	7	obj	7:obj	_
 
@@ -26077,7 +26077,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	twelve	twelve	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
+6	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 7	an	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	amazing	amazing	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	job	job	NOUN	NN	Number=Sing	6	obj	6:obj	_
@@ -26127,7 +26127,7 @@
 # newpar id = reviews-087176-p0002
 # text = They are by far the best salon in 50 miles, Trust me I know!!
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 3	by	by	ADP	IN	_	4	case	4:case	_
 4	far	far	ADV	RB	Degree=Pos	7	obl	7:obl:by	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -26140,7 +26140,7 @@
 12	Trust	trust	VERB	VB	Mood=Imp|VerbForm=Fin	7	parataxis	7:parataxis	_
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	obj	12:obj	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
-15	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	parataxis	12:parataxis	SpaceAfter=No
+15	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	parataxis	12:parataxis	SpaceAfter=No
 16	!!	!!	PUNCT	.	_	7	punct	7:punct	_
 
 # newdoc id = reviews-287501
@@ -26155,7 +26155,7 @@
 1	A	a	DET	DT	Definite=Ind|PronType=Art	2	det	2:det	_
 2	company	company	NOUN	NN	Number=Sing	0	root	0:root|4:nsubj	_
 3	which	which	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	provide	provide	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	provide	provide	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	quality	quality	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	portals	portal	NOUN	NNS	Number=Plur	4	obj	4:obj	SpaceAfter=No
@@ -26173,7 +26173,7 @@
 # sent_id = reviews-255736-0001
 # newpar id = reviews-255736-p0001
 # text = Remember seeing "Stop Making Sense" at Cinema 21 multiple times!
-1	Remember	remember	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	seeing	see	VERB	VBG	VerbForm=Ger	1	xcomp	1:xcomp	_
 3	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 4	Stop	stop	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -26232,7 +26232,7 @@
 5	to	to	ADP	IN	_	10	case	10:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 7	morse	morse	PROPN	NNP	Number=Sing	10	compound	10:compound	_
-8	red	red	ADJ	NNP	Number=Sing	9	amod	9:amod	SpaceAfter=No|CorrectSpaceAfter=Yes
+8	red	red	ADJ	NNP	Number=Sing	9	amod	9:amod	CorrectSpaceAfter=Yes|SpaceAfter=No
 9	line	line	PROPN	NNP	Number=Sing	10	compound	10:compound	_
 10	stop	stop	NOUN	NN	Number=Sing	4	obl	4:obl:to	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -26257,18 +26257,18 @@
 
 # sent_id = reviews-099279-0002
 # text = answered all my questions, and called me back when I needed something.
-1	answered	answer	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	all	all	DET	PDT	_	4	det:predet	4:det:predet	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	questions	question	NOUN	NNS	Number=Plur	1	obj	1:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+7	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 8	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	7:obj	_
 9	back	back	ADV	RB	_	7	advmod	7:advmod	_
 10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	needed	need	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
+12	needed	need	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	_
 13	something	something	PRON	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -26283,7 +26283,7 @@
 # newpar id = reviews-231724-p0001
 # text = Rooms were outdated, dirty, and small.
 1	Rooms	room	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|5:nsubj|8:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
 3	outdated	outdated	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
 5	dirty	dirty	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	SpaceAfter=No
@@ -26387,7 +26387,7 @@
 # sent_id = reviews-022900-0002
 # newpar id = reviews-022900-p0002
 # text = Brilll.
-1	Brilll	brill	ADJ	JJ	Degree=Pos|Style=Expr	0	root	0:root	SpaceAfter=No|CorrectForm=Brill
+1	Brilll	brill	ADJ	JJ	Degree=Pos|Style=Expr	0	root	0:root	CorrectForm=Brill|SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-022900-0003
@@ -26408,7 +26408,7 @@
 # newpar id = reviews-243369-p0001
 # text = You are the best!
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	SpaceAfter=No
 5	!	!	PUNCT	.	_	4	punct	4:punct	_
@@ -26417,7 +26417,7 @@
 # newpar id = reviews-243369-p0002
 # text = Just received from your flower store.
 1	Just	just	ADV	RB	_	2	advmod	2:advmod	_
-2	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	from	from	ADP	IN	_	6	case	6:case	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 5	flower	flower	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -26427,14 +26427,14 @@
 # sent_id = reviews-243369-0003
 # text = They are sooooo beautiful.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	sooooo	so	ADV	RB	Style=Expr	4	advmod	4:advmod	CorrectForm=so
 4	beautiful	beautiful	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-243369-0004
 # text = Thank you guys.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	guys	guy	NOUN	NNS	Number=Plur	1	vocative	1:vocative	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -26468,7 +26468,7 @@
 
 # sent_id = reviews-117893-0004
 # text = Loved every bit of it. :)
-1	Loved	love	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Loved	love	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	every	every	DET	DT	_	3	det	3:det	_
 3	bit	bit	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	of	of	ADP	IN	_	5	case	5:case	_
@@ -26554,7 +26554,7 @@
 # newpar id = reviews-389136-p0002
 # text = I go Disco dancing and Cheerleading.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Disco	disco	NOUN	NN	Number=Sing	4	obl:npmod	4:obl:npmod	_
 4	dancing	dance	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
@@ -26572,7 +26572,7 @@
 # sent_id = reviews-389136-0004
 # text = so goand get dancing!!!!!!!!!!!!!!!!!!!!!!!!!
 1	so	so	ADV	RB	_	2	advmod	2:advmod	_
-2	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	SpaceAfter=No|CorrectSpaceAfter=Yes
+2	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	CorrectSpaceAfter=Yes|SpaceAfter=No
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	get	get	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj:and	_
 5	dancing	dance	VERB	VBG	VerbForm=Ger	4	xcomp	4:xcomp	SpaceAfter=No
@@ -26644,7 +26644,7 @@
 # sent_id = reviews-307250-0003
 # text = I want my money back!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	money	money	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	back	back	ADV	RB	_	2	advmod	2:advmod	SpaceAfter=No
@@ -26655,7 +26655,7 @@
 # newpar id = reviews-088914-p0001
 # text = They did a vehicle wrap for my Toyota Venza that looks amazing.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	vehicle	vehicle	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	wrap	wrap	NOUN	NN	Number=Sing	2	obj	2:obj|11:nsubj|12:nsubj:xsubj	_
@@ -26672,7 +26672,7 @@
 # text = They also do banners, billboards and lots more.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	do	do	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	banners	banner	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
 6	billboards	billboard	NOUN	NNS	Number=Plur	4	conj	3:obj|4:conj:and	_
@@ -26697,10 +26697,10 @@
 10	Valley	Valley	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	SpaceAfter=No
 11	,	,	PUNCT	,	_	6	punct	6:punct	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
 14	friend	friend	NOUN	NN	Number=Sing	13	obj	13:obj|16:nsubj	_
 15	who	who	PRON	WP	PronType=Rel	16	nsubj	14:ref	_
-16	drive	drive	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	drive	drive	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	from	from	ADP	IN	_	19	case	19:case	_
 18	central	central	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	Phx	Phoenix	PROPN	NNP	Abbr=Yes|Number=Sing	16	obl	16:obl:from	_
@@ -26719,12 +26719,12 @@
 4	ever	ever	ADV	RB	_	3	advmod	3:advmod	_
 5-6	im	_	_	_	_	_	_	_	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-6	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	fat	fat	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	_
 8	so	so	ADV	RB	_	11	advmod	11:advmod	_
 9-10	ive	_	_	_	_	_	_	_	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	had	have	VERB	VBN	Tense=Past|VerbForm=Part	7	parataxis	7:parataxis	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	ton	ton	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -26752,7 +26752,7 @@
 # sent_id = reviews-395149-0002
 # text = I have used them once and will use them in the future.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|8:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	used	use	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	obj	3:obj	_
 5	once	once	ADV	RB	NumType=Mult	3	advmod	3:advmod	_
@@ -26782,7 +26782,7 @@
 # newpar id = reviews-125522-p0001
 # text = They are out of business.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	out	out	ADP	IN	_	5	case	5:case	_
 4	of	of	ADP	IN	_	5	case	5:case	_
 5	business	business	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
@@ -26794,13 +26794,13 @@
 2	people	people	NOUN	NNS	Number=Plur	0	root	0:root	SpaceAfter=No
 3	...	...	PUNCT	,	_	2	punct	2:punct	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	hear	hear	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	SpaceAfter=No
+5	hear	hear	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	SpaceAfter=No
 6	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-125522-0003
 # text = Calls are now forwarded to Malcolm Smith Motorsports down the road.
 1	Calls	call	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 3	now	now	ADV	RB	_	4	advmod	4:advmod	_
 4	forwarded	forward	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	to	to	ADP	IN	_	6	case	6:case	_
@@ -26830,14 +26830,14 @@
 # sent_id = reviews-134741-0003
 # text = It made me feel good to see people work so hard to take care of others belongings.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	2:expl	_
-2	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj|4:nsubj:xsubj|5:nsubj:xsubj	_
-4	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	xcomp	2:xcomp	_
+4	feel	feel	VERB	VBP	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	good	good	ADJ	JJ	Degree=Pos	4	xcomp	4:xcomp	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	see	see	VERB	VB	VerbForm=Inf	2	csubj	2:csubj	_
 8	people	people	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
-9	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	_
+9	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	_
 10	so	so	ADV	RB	_	11	advmod	11:advmod	_
 11	hard	hard	ADV	RB	Degree=Pos	9	advmod	9:advmod	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
@@ -26865,7 +26865,7 @@
 3	careful	careful	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	write	write	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
+6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	reviews	review	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
 8	-	-	PUNCT	,	_	3	punct	3:punct	_
 9	this	this	PRON	DT	Number=Sing|PronType=Dem	13	nsubj	13:nsubj|16:nsubj	_
@@ -26895,7 +26895,7 @@
 3	curry	curry	NOUN	NN	Number=Sing	0	root	0:root|8:obj	_
 4	that	that	PRON	WDT	PronType=Rel	8	obj	3:ref	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	_	8	advmod	8:advmod	_
 8	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -26965,7 +26965,7 @@
 # newpar id = reviews-041925-p0001
 # text = I heard the libido band play live and they are out of site!!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	heard	hear	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	heard	hear	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	libido	libido	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	band	band	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj:xsubj	_
@@ -26973,7 +26973,7 @@
 7	live	live	ADV	RB	_	6	advmod	6:advmod	_
 8	and	and	CCONJ	CC	_	13	cc	13:cc	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	out	out	ADP	IN	_	13	case	13:case	_
 12	of	of	ADP	IN	_	13	case	13:case	_
 13	site	site	NOUN	NN	Number=Sing	2	conj	2:conj:and	SpaceAfter=No
@@ -27022,7 +27022,7 @@
 # sent_id = reviews-154113-0003
 # text = I go to see her to have my hair cut.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	see	see	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:to	_
 5	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
@@ -27099,7 +27099,7 @@
 5	check	check	VERB	VB	VerbForm=Inf	1	ccomp	1:ccomp	_
 6	before	before	SCONJ	IN	_	8	mark	8:mark	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	buy	buy	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:before	SpaceAfter=No
+8	buy	buy	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:before	SpaceAfter=No
 9	!!!!	!!!!	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-001961-0004
@@ -27135,13 +27135,13 @@
 # sent_id = reviews-162662-0003
 # text = I purchased four gift items there and had them all embroidered within a week.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|8:nsubj	_
-2	purchased	purchase	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	purchased	purchase	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	four	four	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 4	gift	gift	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	items	item	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 6	there	there	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+8	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 9	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	all	all	DET	DT	_	9	det	9:det	_
 11	embroidered	embroider	VERB	VBN	Tense=Past|VerbForm=Part	8	ccomp	8:ccomp	_
@@ -27155,7 +27155,7 @@
 # newpar id = reviews-124552-p0001
 # text = They have good sushi for a good price.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	good	good	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	sushi	sushi	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	for	for	ADP	IN	_	8	case	8:case	_
@@ -27282,7 +27282,7 @@
 # text = Not only are these people completely inefficient and ineffective, but they just don't give a darn.
 1	Not	not	ADV	RB	_	7	advmod	7:advmod	_
 2	only	only	ADV	RB	_	7	cc:preconj	7:cc:preconj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 4	these	this	DET	DT	Number=Plur|PronType=Dem	5	det	5:det	_
 5	people	people	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj|9:nsubj	_
 6	completely	completely	ADV	RB	_	7	advmod	7:advmod	_
@@ -27294,7 +27294,7 @@
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 13	just	just	ADV	RB	_	16	advmod	16:advmod	_
 14-15	don't	_	_	_	_	_	_	_	_
-14	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+14	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 15	n't	not	PART	RB	_	16	advmod	16:advmod	_
 16	give	give	VERB	VB	VerbForm=Inf	7	conj	7:conj:and	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
@@ -27361,7 +27361,7 @@
 # text = I'm very happy with the piano lessons Mrs. Lynda Mcmanus taught me.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	happy	happy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	with	with	ADP	IN	_	8	case	8:case	_
@@ -27371,7 +27371,7 @@
 9	Mrs.	Mrs.	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	Lynda	Lynda	PROPN	NNP	Number=Sing	9	flat	9:flat	_
 11	Mcmanus	Mcmanus	PROPN	NNP	Number=Sing	9	flat	9:flat	_
-12	taught	teach	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+12	taught	teach	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	obj	12:obj	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -27380,7 +27380,7 @@
 1	Now	now	ADV	RB	_	4	advmod	4:advmod	_
 2-3	I'm	_	_	_	_	_	_	_	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-3	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	play	play	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
@@ -27409,7 +27409,7 @@
 5	pizza	pizza	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	place	place	NOUN	NN	Number=Sing	0	root	0:root	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	in	in	ADP	IN	_	11	case	11:case	_
 10	Woodland	Woodland	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	Hills	Hill	PROPN	NNPS	Number=Plur	6	obl	6:obl:in	SpaceAfter=No
@@ -27447,13 +27447,13 @@
 2	place	place	NOUN	NN	Number=Sing	0	root	0:root	_
 3	flour	flour	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	tortillas	tortilla	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	always	always	ADV	RB	_	7	advmod	7:advmod	_
 7	hard	hard	ADJ	JJ	Degree=Pos	2	list	2:list	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	beef	beef	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	enchiladas	enchilada	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-11	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 12	discussing	discussing	ADJ	JJ	Degree=Pos	2	list	2:list	_
 13	meat	meat	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	_
 14	all	all	ADV	RB	_	16	advmod	16:advmod	_
@@ -27477,7 +27477,7 @@
 # text = I'm really surprised by the negative reviews.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 3	really	really	ADV	RB	_	4	advmod	4:advmod	_
 4	surprised	surprise	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	by	by	ADP	IN	_	8	case	8:case	_
@@ -27490,7 +27490,7 @@
 # text = We've had about 5 repairs done on 3 different laptops.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	about	about	ADV	RB	_	5	advmod	5:advmod	_
 5	5	5	NUM	CD	NumType=Card	6	nummod	6:nummod	_
@@ -27506,7 +27506,7 @@
 # text = They've always been timely and inexpensive.
 1-2	They've	_	_	_	_	_	_	_	_
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj|7:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	always	always	ADV	RB	_	5	advmod	5:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	cop	5:cop	_
 5	timely	timely	ADJ	JJ	Degree=Pos	0	root	0:root	_
@@ -27541,14 +27541,14 @@
 # text = Fish tacos are my fave simple and filling Highly recommend Mi Pueblo.
 1	Fish	fish	NOUN	NN	Number=Sing	2	compound	2:compound	_
 2	tacos	taco	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	fave	fave	NOUN	NN	Number=Sing	0	root	0:root	_
 6	simple	simple	ADJ	JJ	Degree=Pos	5	parataxis	5:parataxis	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	filling	filling	ADJ	JJ	Degree=Pos	6	conj	6:conj:and	_
 9	Highly	highly	ADV	RB	_	10	advmod	10:advmod	_
-10	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
+10	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
 11	Mi	Mi	PROPN	NNP	Number=Sing	12	compound	12:compound	_
 12	Pueblo	Pueblo	PROPN	NNP	Number=Sing	10	obj	10:obj	SpaceAfter=No
 13	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -27567,7 +27567,7 @@
 # text = Good local bikeshop
 1	Good	good	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 2	local	local	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
-3	bike	bike	NOUN	NN	Number=Sing	4	compound	4:compound	SpaceAfter=No|CorrectSpaceAfter=Yes
+3	bike	bike	NOUN	NN	Number=Sing	4	compound	4:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
 4	shop	shop	NOUN	NN	Number=Sing	0	root	0:root	_
 
 # sent_id = reviews-262422-0002
@@ -27590,7 +27590,7 @@
 7	about	about	ADV	RB	_	8	advmod	8:advmod	_
 8	anything	anything	PRON	NN	Number=Sing	6	obj	6:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 11	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-262422-0004
@@ -27636,7 +27636,7 @@
 4	superb	superb	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj:pass	8:nsubj:pass	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux:pass	8:aux:pass	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	aux:pass	8:aux:pass	_
 8	delivered	deliver	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:and	_
 9	nice	nice	ADJ	JJ	Degree=Pos	8	acl	8:acl	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
@@ -27647,7 +27647,7 @@
 # text = I highly recommend this place!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	place	place	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -27675,7 +27675,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	fresh	fresh	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	taste	taste	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+6	taste	taste	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 7	great	great	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	SpaceAfter=No
 8	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -27707,7 +27707,7 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	hairstyles	hairstyle	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	last	last	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+6	last	last	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-162992-0002
@@ -27721,7 +27721,7 @@
 6	service	service	NOUN	NN	Number=Sing	3	obl	3:obl:with|9:obj	_
 7	that	that	PRON	WDT	PronType=Rel	9	obj	6:ref	_
 8	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 10	at	at	ADP	IN	_	11	case	11:case	_
 11	Luxe	Luxe	PROPN	NNP	Number=Sing	9	obl	9:obl:at	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -27754,7 +27754,7 @@
 # newpar id = reviews-263830-p0002
 # text = They are very good teachers and nice people to meet here.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj|8:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	teachers	teacher	NOUN	NNS	Number=Plur	0	root	0:root	_
@@ -27769,7 +27769,7 @@
 # sent_id = reviews-263830-0003
 # text = I enjoyed very much to study here.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|6:nsubj:xsubj	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	much	much	ADV	RB	_	2	advmod	2:advmod	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -27852,10 +27852,10 @@
 6	next	next	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	pool	pool	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	service	service	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
-9	found	find	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	found	find	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	filters	filter	NOUN	NNS	Number=Plur	15	nsubj:pass	15:nsubj:pass	_
-12	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
+12	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux	15:aux	_
 13	not	not	PART	RB	_	15	advmod	15:advmod	_
 14	been	be	AUX	VBN	Tense=Past|VerbForm=Part	15	aux:pass	15:aux:pass	_
 15	cleaned	clean	VERB	VBN	Tense=Past|VerbForm=Part	9	ccomp	9:ccomp	_
@@ -27913,13 +27913,13 @@
 
 # sent_id = reviews-015573-0004
 # text = Lied right to my face then denied it.
-1	Lied	lie	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Lied	lie	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	right	right	ADV	RB	_	5	advmod	5:advmod	_
 3	to	to	ADP	IN	_	5	case	5:case	_
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	face	face	NOUN	NN	Number=Sing	1	obl	1:obl:to	_
 6	then	then	ADV	RB	PronType=Dem	7	advmod	7:advmod	_
-7	denied	deny	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
+7	denied	deny	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -27940,23 +27940,23 @@
 # newpar id = reviews-198455-p0002
 # text = I had a dead battery last week and called this company since they were the closest they had very quick service for a Monday morning, thanks again guys.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|9:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	dead	dead	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	battery	battery	NOUN	NN	Number=Sing	2	obj	2:obj	_
 6	last	last	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	week	week	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+9	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 10	this	this	DET	DT	Number=Sing|PronType=Dem	11	det	11:det	_
 11	company	company	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	since	since	SCONJ	IN	_	16	mark	16:mark	_
 13	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-14	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	cop	16:cop	_
+14	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	cop	16:cop	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	closest	close	ADJ	JJS	Degree=Sup	9	advcl	9:advcl:since	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
-18	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
+18	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 19	very	very	ADV	RB	_	20	advmod	20:advmod	_
 20	quick	quick	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	service	service	NOUN	NN	Number=Sing	18	obj	18:obj	_
@@ -27975,7 +27975,7 @@
 # newpar id = reviews-267982-p0001
 # text = I won a golf lesson certificate with Adz through a charity auction.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	won	win	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	won	win	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	golf	golf	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	lesson	lesson	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -28004,11 +28004,11 @@
 # text = So i booked the lesson and loved it.
 1	So	so	ADV	RB	_	3	advmod	3:advmod	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|7:nsubj	_
-3	booked	book	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	lesson	lesson	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	loved	love	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+7	loved	love	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -28030,10 +28030,10 @@
 1	When	when	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
 3	server	server	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
-4	crashed	crash	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	SpaceAfter=No
+4	crashed	crash	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:when	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
 6	Greg	Greg	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj|15:nsubj	_
-7	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	from	from	ADP	IN	_	10	case	10:case	_
 9	7	7	NUM	CD	NumType=Card	10	nummod	10:nummod	_
 10	PM	pm	NOUN	NN	Number=Sing	7	obl	7:obl:from	_
@@ -28041,7 +28041,7 @@
 12	4	4	NUM	CD	NumType=Card	13	nummod	13:nummod	_
 13	AM	am	NOUN	NN	Number=Sing	7	obl	7:obl:until	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
-15	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
+15	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
 16	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
 17	company	company	NOUN	NN	Number=Sing	15	obj	15:obj|18:nsubj:xsubj|20:nsubj:xsubj	_
 18	up	up	ADV	RB	_	15	xcomp	15:xcomp	_
@@ -28059,7 +28059,7 @@
 2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	what	what	PRON	WP	PronType=Int	5	obj	5:obj|7:nsubj:xsubj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	call	call	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	customer	customer	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	service	service	NOUN	NN	Number=Sing	5	xcomp	5:xcomp	SpaceAfter=No
 8	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -28135,12 +28135,12 @@
 # sent_id = reviews-147825-0004
 # text = Don't think I've ever been charged before.
 1-2	Don't	_	_	_	_	_	_	_	_
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	n't	not	PART	RB	_	3	advmod	3:advmod	_
 3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4-5	I've	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj:pass	8:nsubj:pass	_
-5	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+5	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 6	ever	ever	ADV	RB	_	8	advmod	8:advmod	_
 7	been	be	AUX	VBN	Tense=Past|VerbForm=Part	8	aux:pass	8:aux:pass	_
 8	charged	charge	VERB	VBN	Tense=Past|VerbForm=Part	3	ccomp	3:ccomp	_
@@ -28220,9 +28220,9 @@
 # sent_id = reviews-379701-0001
 # newpar id = reviews-379701-p0001
 # text = VERYYYY!!!! VERYYY!! Good auto repair men.
-1	VERYYYY	very	ADV	RB	Style=Expr	5	advmod	5:advmod	SpaceAfter=No|CorrectForm=Very
+1	VERYYYY	very	ADV	RB	Style=Expr	5	advmod	5:advmod	CorrectForm=Very|SpaceAfter=No
 2	!!!!	!!!!	PUNCT	.	_	5	punct	5:punct	_
-3	VERYYY	very	ADV	RB	Style=Expr	5	advmod	5:advmod	SpaceAfter=No|CorrectForm=very
+3	VERYYY	very	ADV	RB	Style=Expr	5	advmod	5:advmod	CorrectForm=very|SpaceAfter=No
 4	!!	!!	PUNCT	.	_	5	punct	5:punct	_
 5	Good	good	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 6	auto	auto	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -28232,7 +28232,7 @@
 
 # sent_id = reviews-379701-0002
 # text = Do the job honest and quickly as possible.
-1	Do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	job	job	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	honest	honest	ADV	RB	_	1	advmod	1:advmod	_
@@ -28258,7 +28258,7 @@
 
 # sent_id = reviews-379701-0004
 # text = Thank You Barrys Auto Tech!
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	obj	1:obj	_
 3-4	Barrys	_	_	_	_	_	_	_	_
 3	Barry	Barry	PROPN	NNP	Number=Sing	6	nmod:poss	6:nmod:poss	_
@@ -28282,7 +28282,7 @@
 1	Ashdown	Ashdown	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 2	Horse	Horse	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	Transport	Transport	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-4	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
+4	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 5	fantastic	fantastic	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	5:punct	_
 
@@ -28318,7 +28318,7 @@
 # sent_id = reviews-205014-0006
 # text = PS. Love the new website!
 1	PS.	ps.	NOUN	NN	Number=Sing	0	root	0:root	_
-2	Love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	appos	1:appos	_
+2	Love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	appos	1:appos	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	website	website	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -28398,7 +28398,7 @@
 2	-	-	PUNCT	:	_	1	punct	1:punct	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	workers	worker	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 6	usually	usually	ADV	RB	_	7	advmod	7:advmod	_
 7	pleasant	pleasant	ADJ	JJ	Degree=Pos	1	appos	1:appos	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -28445,7 +28445,7 @@
 # sent_id = reviews-158740-0003
 # text = I had so many strawberries right on the field...strongly recomend...dont forget to try their great ice cream
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	so	so	ADV	RB	_	4	advmod	4:advmod	_
 4	many	many	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	strawberries	strawberry	NOUN	NNS	Number=Plur	2	obj	2:obj	_
@@ -28455,7 +28455,7 @@
 9	field	field	NOUN	NN	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
 10	...	...	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 11	strongly	strongly	ADV	RB	_	12	advmod	12:advmod	_
-12	recomend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|Typo=Yes|VerbForm=Fin	2	parataxis	2:parataxis	CorrectForm=recommend|SpaceAfter=No
+12	recomend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	2	parataxis	2:parataxis	CorrectForm=recommend|SpaceAfter=No
 13	...	...	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 14-15	dont	_	_	_	_	_	_	_	_
 14	do	do	AUX	VB	Mood=Imp|VerbForm=Fin	16	aux	16:aux	_
@@ -28556,7 +28556,7 @@
 8	moving	moving	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	experience	experience	NOUN	NN	Number=Sing	0	root	0:root	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-11	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+11	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	9	punct	9:punct	_
 
@@ -28638,7 +28638,7 @@
 # text = If you mention the name Amir you will receive %10 off at time of purchase
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	mention	mention	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	mention	mention	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	name	name	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	Amir	Amir	PROPN	NNP	Number=Sing	5	appos	5:appos	_
@@ -28710,7 +28710,7 @@
 # sent_id = reviews-016861-0001
 # newpar id = reviews-016861-p0001
 # text = Stayed in the Seaview room here in December 2009!
-1	Stayed	stay	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Stayed	stay	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	in	in	ADP	IN	_	5	case	5:case	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	Seaview	seaview	NOUN	NN	Number=Sing	5	compound	5:compound	_
@@ -28735,7 +28735,7 @@
 2	furnishing	furnishing	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	finishes	finish	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -28743,12 +28743,12 @@
 # text = I highly recommend Bay View if you are looking for Accommodation in Camps Bay.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	Bay	Bay	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	View	View	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 6	if	if	SCONJ	IN	_	9	mark	9:mark	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	looking	look	VERB	VBG	VerbForm=Ger	3	advcl	3:advcl:if	_
 10	for	for	ADP	IN	_	11	case	11:case	_
 11	Accommodation	accommodation	NOUN	NN	Number=Sing	9	obl	9:obl:for	_
@@ -28774,7 +28774,7 @@
 11	sushi	sushi	NOUN	NN	Number=Sing	8	obj	8:obj	_
 12-13	I've	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-13	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+13	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 14	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
 15	in	in	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
@@ -28822,7 +28822,7 @@
 # newpar id = reviews-380048-p0002
 # text = We had a fantastic time.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	fantastic	fantastic	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	time	time	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -28859,7 +28859,7 @@
 
 # sent_id = reviews-380048-0006
 # text = Thank-You for sharing your cottage!
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 2	-	-	PUNCT	HYPH	_	1	punct	1:punct	SpaceAfter=No
 3	You	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 4	for	for	SCONJ	IN	_	5	mark	5:mark	_
@@ -28891,7 +28891,7 @@
 2	since	since	SCONJ	IN	_	7	mark	7:mark	_
 3-4	I'm	_	_	_	_	_	_	_	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-4	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+4	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 5	on	on	ADP	IN	_	7	case	7:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	budget	budget	NOUN	NN	Number=Sing	1	advcl	1:advcl:on	SpaceAfter=No
@@ -28909,17 +28909,17 @@
 8	for	for	SCONJ	IN	_	9	case	9:case	_
 9	what	what	PRON	WP	PronType=Int	6	obl	6:obl:for	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-148012-0005
 # text = Like the sushi, don't like the pad thai.
-1	Like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	sushi	sushi	NOUN	NN	Number=Sing	1	obj	1:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5-6	don't	_	_	_	_	_	_	_	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	_	7	advmod	7:advmod	_
 7	like	like	VERB	VB	VerbForm=Inf	1	conj	1:conj	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
@@ -28942,7 +28942,7 @@
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	make	make	VERB	VB	VerbForm=Inf	6	ccomp	6:ccomp	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj|13:nsubj:xsubj	_
-12	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+12	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
 13	beautiful	beautiful	ADJ	JJ	Degree=Pos	12	xcomp	12:xcomp	_
 14	in	in	ADP	IN	_	15	case	15:case	_
 15	clothes	clothes	NOUN	NNS	Number=Plur	12	obl	12:obl:in	SpaceAfter=No
@@ -28973,7 +28973,7 @@
 5	+	+	SYM	SYM	_	4	amod	4:amod	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
 7	so	so	ADV	RB	_	4	conj	4:conj:and	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 9	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	clothes	clothes	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	SpaceAfter=No
 11	!	!	PUNCT	.	_	4	punct	4:punct	_
@@ -28991,7 +28991,7 @@
 # sent_id = reviews-335815-0002
 # text = There are a couple decent people working there, but the rest are VERY dishonest, as well as rude, I have yet to hear the truth come out of their mouths.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	couple	couple	NOUN	NN	Number=Sing	6	compound	6:compound	_
 5	decent	decent	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -29012,7 +29012,7 @@
 20	rude	rude	ADJ	JJ	Degree=Pos	15	conj	15:conj:as_well_as	SpaceAfter=No
 21	,	,	PUNCT	,	_	23	punct	23:punct	_
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj|26:nsubj:xsubj	_
-23	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
+23	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
 24	yet	yet	ADV	RB	_	23	advmod	23:advmod	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	hear	hear	VERB	VB	VerbForm=Inf	23	xcomp	23:xcomp	_
@@ -29040,7 +29040,7 @@
 # text = The pizzas are huge and super delicious.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	pizzas	pizza	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj|7:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	huge	huge	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	super	super	ADV	RB	_	7	advmod	7:advmod	_
@@ -29051,7 +29051,7 @@
 # text = They're our favorite pizza place to order from... and they're a local, family owned company!
 1-2	They're	_	_	_	_	_	_	_	_
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-2	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+2	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 4	favorite	favorite	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	pizza	pizza	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -29063,7 +29063,7 @@
 11	and	and	CCONJ	CC	_	19	cc	19:cc	_
 12-13	they're	_	_	_	_	_	_	_	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	19	nsubj	19:nsubj	_
-13	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
+13	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 15	local	local	ADJ	JJ	Degree=Pos	19	amod	19:amod	SpaceAfter=No
 16	,	,	PUNCT	,	_	19	punct	19:punct	_
@@ -29087,7 +29087,7 @@
 # newpar id = reviews-077034-p0001
 # text = I loved the atmosphere here and the food is good, however the tables are so close together that it feels very cramped.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	loved	love	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	loved	love	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	atmosphere	atmosphere	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	here	here	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
@@ -29100,7 +29100,7 @@
 12	however	however	ADV	RB	_	18	advmod	18:advmod	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	tables	table	NOUN	NNS	Number=Plur	18	nsubj	18:nsubj	_
-15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+15	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 16	so	so	ADV	RB	_	18	advmod	18:advmod	_
 17	close	close	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	together	together	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
@@ -29114,7 +29114,7 @@
 # sent_id = reviews-077034-0002
 # text = We were made to feel very welcome.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj:pass	3:nsubj:pass|5:nsubj:xsubj|7:nsubj:xsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux:pass	3:aux:pass	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	3	aux:pass	3:aux:pass	_
 3	made	make	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	feel	feel	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
@@ -29163,7 +29163,7 @@
 9	best	good	ADJ	JJS	Degree=Sup	10	amod	10:amod	_
 10	service	service	NOUN	NN	Number=Sing	7	obj	7:obj	_
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	ever	ever	ADV	RB	_	14	advmod	14:advmod	_
 14	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -29171,14 +29171,14 @@
 # sent_id = reviews-173944-0004
 # text = I have a new born daughter and she helped me with a lot.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	born	born	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	daughter	daughter	NOUN	NN	Number=Sing	2	obj	2:obj	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	helped	help	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+9	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
 11	with	with	ADP	IN	_	13	case	13:case	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
@@ -29196,17 +29196,17 @@
 # sent_id = reviews-047007-0001
 # newpar id = reviews-047007-p0001
 # text = Called to check if they had a product I've been using on my dog for years... the boy who answered the phone couldn't possibly have been ruder to me.
-1	Called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	to	to	PART	TO	_	3	mark	3:mark	_
 3	check	check	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	_
+6	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	product	product	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9-10	I've	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-10	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	aux	12:aux	_
 12	using	use	VERB	VBG	VerbForm=Ger	8	acl:relcl	8:acl:relcl	_
 13	on	on	ADP	IN	_	15	case	15:case	_
@@ -29218,7 +29218,7 @@
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	boy	boy	NOUN	NN	Number=Sing	30	nsubj	22:nsubj|30:nsubj	_
 21	who	who	PRON	WP	PronType=Rel	22	nsubj	20:ref	_
-22	answered	answer	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
+22	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	phone	phone	NOUN	NN	Number=Sing	22	obj	22:obj	_
 25-26	couldn't	_	_	_	_	_	_	_	_
@@ -29256,7 +29256,7 @@
 # sent_id = reviews-291088-0002
 # text = I have visited Dr. Cooper's office twice and I am very impressed with how friendly and polite the staff is.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	visited	visit	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Dr.	Dr.	PROPN	NNP	Number=Sing	7	nmod:poss	7:nmod:poss	_
 5-6	Cooper's	_	_	_	_	_	_	_	_
@@ -29282,7 +29282,7 @@
 # sent_id = reviews-291088-0003
 # text = I found the office to be very clean and professional-looking.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	found	find	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	found	find	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	office	office	NOUN	NN	Number=Sing	2	obj	2:obj|8:nsubj:xsubj|12:nsubj:xsubj	_
 5	to	to	PART	TO	_	8	mark	8:mark	_
@@ -29351,7 +29351,7 @@
 # sent_id = reviews-009775-0005
 # text = I crave those.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	crave	crave	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	crave	crave	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	those	that	PRON	DT	Number=Plur|PronType=Dem	2	obj	2:obj	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -29365,7 +29365,7 @@
 4	BEST	good	ADJ	JJS	Degree=Sup	5	amod	5:amod	_
 5	photographer	photographer	NOUN	NN	Number=Sing	0	root	0:root	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-7	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+7	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	ever	ever	ADV	RB	_	9	advmod	9:advmod	_
 9	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
 10	with	with	ADP	IN	_	9	obl	9:obl	SpaceAfter=No
@@ -29435,7 +29435,7 @@
 # sent_id = reviews-368431-0003
 # text = I wish I could have a slice for every single meal.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	could	could	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 5	have	have	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -29451,7 +29451,7 @@
 # text = Luckily I live very close, so I can abuse it during week-ends...
 1	Luckily	luckily	ADV	RB	_	3	advmod	3:advmod	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	close	close	ADV	RB	Degree=Pos	3	advmod	3:advmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
@@ -29484,7 +29484,7 @@
 12	now	now	ADV	RB	_	11	advmod	11:advmod	_
 13	and	and	CCONJ	CC	_	18	cc	18:cc	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
-15	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+15	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 16	been	be	AUX	VBN	Tense=Past|VerbForm=Part	18	cop	18:cop	_
 17	extremely	extremely	ADV	RB	_	18	advmod	18:advmod	_
 18	thorough	thorough	ADJ	JJ	Degree=Pos	5	conj	5:conj:and	SpaceAfter=No
@@ -29494,7 +29494,7 @@
 # text = We've only had one urgent issue to deal with and they were very prompt in their response.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	only	only	ADV	RB	_	4	advmod	4:advmod	_
 4	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	one	one	NUM	CD	NumType=Card	7	nummod	7:nummod	_
@@ -29505,7 +29505,7 @@
 10	with	with	ADP	IN	_	9	obl	9:obl	_
 11	and	and	CCONJ	CC	_	15	cc	15:cc	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-13	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
+13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
 14	very	very	ADV	RB	_	15	advmod	15:advmod	_
 15	prompt	prompt	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	_
 16	in	in	ADP	IN	_	18	case	18:case	_
@@ -29516,7 +29516,7 @@
 # sent_id = reviews-351840-0003
 # text = Highly recommend!
 1	Highly	highly	ADV	RB	_	2	advmod	2:advmod	_
-2	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	!	!	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-048198
@@ -29619,7 +29619,7 @@
 # sent_id = reviews-163703-0003
 # text = We had a great stay, your service was excellent and we will use you again!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	great	great	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	stay	stay	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -29680,7 +29680,7 @@
 # text = The images turned out amazing.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	images	image	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	turned	turn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	turned	turn	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	amazing	amazing	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -29689,7 +29689,7 @@
 # text = I definitely recommend him :)
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	definitely	definitely	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	_
 5	:)	:)	SYM	NFP	_	3	discourse	3:discourse	_
 
@@ -29703,7 +29703,7 @@
 # sent_id = reviews-279070-0002
 # newpar id = reviews-279070-p0002
 # text = Happened on to this place while out of town on business, and it was great!
-1	Happened	happen	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Happened	happen	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	on	on	ADP	IN	_	5	case	5:case	_
 3	to	to	ADP	IN	_	5	case	5:case	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
@@ -29747,7 +29747,7 @@
 9	,	,	PUNCT	,	_	14	punct	14:punct	_
 10	but	but	CCONJ	CC	_	14	cc	14:cc	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	discourse	14:discourse	_
+12	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	discourse	14:discourse	_
 13	well	well	ADV	RB	Degree=Pos	14	advmod	14:advmod	_
 14	worth	worth	ADJ	JJ	Degree=Pos	6	conj	6:conj:but	_
 15	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	obj	14:obj	SpaceAfter=No
@@ -29789,7 +29789,7 @@
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	friendly	friendly	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	treat	treat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+6	treat	treat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	obj	6:obj	_
 8	like	like	ADP	IN	_	11	case	11:case	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
@@ -29843,7 +29843,7 @@
 10	website	website	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
 12	everything	everything	PRON	NN	Number=Sing	13	nsubj	13:nsubj	_
-13	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+13	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 14	smooth	smooth	ADV	RB	_	13	advmod	13:advmod	_
 15	and	and	CCONJ	CC	_	17	cc	17:cc	_
 16	on	on	ADP	IN	_	17	case	17:case	_
@@ -29880,7 +29880,7 @@
 3	To	to	PART	TO	_	4	mark	4:mark	_
 4	Use	use	VERB	VB	VerbForm=Inf	2	acl	2:acl:to	_
 5	The	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
-6	Fix	fix	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	appos	2:appos	_
+6	Fix	fix	VERB	VBP	VerbForm=Inf	2	appos	2:appos	_
 7	appliances	appliance	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 8	Plumbing	Plumbing	PROPN	NNP	Number=Sing	13	compound	13:compound	_
 9	Air	Air	PROPN	NNP	Number=Sing	10	compound	10:compound	_
@@ -29893,7 +29893,7 @@
 # sent_id = reviews-359433-0002
 # text = We have used them for plumbing & A/C and they are affordable and get the work done right.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	used	use	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	obj	3:obj	_
 5	for	for	ADP	IN	_	6	case	6:case	_
@@ -29904,10 +29904,10 @@
 10	C	c	NOUN	NN	Number=Sing	6	conj	3:obl:for|6:conj	_
 11	and	and	CCONJ	CC	_	14	cc	14:cc	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj|16:nsubj	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 14	affordable	affordable	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	conj	14:conj:and	_
+16	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	conj	14:conj:and	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	work	work	NOUN	NN	Number=Sing	16	obj	16:obj|19:nsubj:xsubj|20:nsubj:xsubj	_
 19	done	do	VERB	VBN	Tense=Past|VerbForm=Part	16	xcomp	16:xcomp	_
@@ -29935,7 +29935,7 @@
 # newpar id = reviews-229142-p0001
 # text = I used Birdies for our Annual Walk Against Drugs and Alcohol event.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Birdies	Birdies	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 4	for	for	ADP	IN	_	12	case	12:case	_
 5	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
@@ -29951,7 +29951,7 @@
 # sent_id = reviews-229142-0002
 # text = They were very professional, neat and clean.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj|6:nsubj|8:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	professional	professional	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -29963,7 +29963,7 @@
 # sent_id = reviews-229142-0003
 # text = They came through on all of their promises and we had a very successful day.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	came	come	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	through	through	ADV	RB	_	2	advmod	2:advmod	_
 4	on	on	ADP	IN	_	5	case	5:case	_
 5	all	all	DET	DT	_	2	obl	2:obl:on	_
@@ -29972,7 +29972,7 @@
 8	promises	promise	NOUN	NNS	Number=Plur	5	nmod	5:nmod:of	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 13	very	very	ADV	RB	_	14	advmod	14:advmod	_
 14	successful	successful	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
@@ -30018,7 +30018,7 @@
 # sent_id = reviews-096340-0003
 # text = We have Hobby Lobby, Just for Fun Fabrics, Walmart, and Interior Mall just inside Barling.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Hobby	Hobby	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	Lobby	Lobby	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -30040,7 +30040,7 @@
 # sent_id = reviews-096340-0004
 # text = They do have a good selection of fabric and notions.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -30063,7 +30063,7 @@
 6	management	management	NOUN	NN	Number=Sing	3	list	3:list	SpaceAfter=No
 7	,	,	PUNCT	,	_	3	punct	3:punct	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	let	let	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	list	3:list	_
+9	let	let	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	list	3:list	_
 10	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	9	obj	9:obj|11:nsubj:xsubj	_
 11	check	check	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
 12	in	in	ADP	RP	_	11	compound:prt	11:compound:prt	_
@@ -30134,7 +30134,7 @@
 13	but	but	CCONJ	CC	_	17	cc	17:cc	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
 15	really	really	ADV	RB	_	17	advmod	17:advmod	_
-16	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
+16	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
 17	do	do	VERB	VB	VerbForm=Inf	3	conj	3:conj:but	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 19	good	good	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
@@ -30151,7 +30151,7 @@
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
 7	tasty	tasty	ADJ	JJ	Degree=Pos	0	root	0:root	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
+9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
 10	in	in	ADP	IN	_	14	case	14:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 12	huge	huge	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -30217,7 +30217,7 @@
 5	on	on	ADP	IN	_	7	case	7:case	_
 6	one	one	NUM	CD	NumType=Card	7	nummod	7:nummod	_
 7	bed	bed	NOUN	NN	Number=Sing	4	nmod	4:nmod:on	_
-8	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
+8	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
 9	not	not	PART	RB	_	10	advmod	10:advmod	_
 10	heat	heat	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 11	.	.	PUNCT	.	_	10	punct	10:punct	_
@@ -30272,7 +30272,7 @@
 1	Hyatt	Hyatt	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 2	web	web	NOUN	NN	Number=Sing	3	compound	3:compound	_
 3	site	site	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
-4	improved	improve	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+4	improved	improve	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-262722-0005
@@ -30368,7 +30368,7 @@
 12	other	other	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	services	service	NOUN	NNS	Number=Plur	7	obj	7:obj|9:obj	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-15	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
+15	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
 16	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-323248-0004
@@ -30409,11 +30409,11 @@
 # text = He cross examined witnesses relentlessly and had them break down and tell the truth.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj|7:nsubj	_
 2	cross	cross	VERB	VB	VerbForm=Inf	3	advmod	3:advmod	_
-3	examined	examine	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	examined	examine	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	witnesses	witness	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	relentlessly	relentlessly	ADV	RB	_	3	advmod	3:advmod	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 8	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	7	obj	7:obj|9:nsubj:xsubj|12:nsubj:xsubj	_
 9	break	break	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	down	down	ADP	RP	_	9	compound:prt	9:compound:prt	_
@@ -30427,7 +30427,7 @@
 # text = If you want an attorney who will defend your right, contact Law Offices of Armando Villega
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 4	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	attorney	attorney	NOUN	NN	Number=Sing	3	obj	3:obj|8:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
@@ -30447,7 +30447,7 @@
 # sent_id = reviews-327766-0001
 # newpar id = reviews-327766-p0001
 # text = Checked in real late, but staff was very kind and helpful.
-1	Checked	check	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Checked	check	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	in	in	ADP	RP	_	1	compound:prt	1:compound:prt	_
 3	real	real	ADV	RB	_	4	advmod	4:advmod	_
 4	late	late	ADV	RB	Degree=Pos	1	advmod	1:advmod	SpaceAfter=No
@@ -30467,7 +30467,7 @@
 2	very	very	ADV	RB	_	3	advmod	3:advmod	_
 3	clean	clean	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
-5	smelled	smell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+5	smelled	smell	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 6	very	very	ADV	RB	_	7	advmod	7:advmod	_
 7	fresh	fresh	ADJ	JJ	Degree=Pos	5	xcomp	5:xcomp	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -30486,7 +30486,7 @@
 # sent_id = reviews-327766-0004
 # text = I loved my stay here and if ever back in the area, I will be staying here again.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	loved	love	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	loved	love	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	stay	stay	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	here	here	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
@@ -30529,7 +30529,7 @@
 # text = I don't steal, I wasn't acting suspiciously.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	steal	steal	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
@@ -30564,7 +30564,7 @@
 19	belts	belt	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 20	and	and	CCONJ	CC	_	22	cc	22:cc	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-22	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+22	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 23	out	out	ADV	RB	_	22	advmod	22:advmod	_
 24	because	because	ADP	IN	_	28	case	28:case	_
 25	of	of	ADP	IN	_	24	fixed	24:fixed	_
@@ -30587,7 +30587,7 @@
 # text = If you are looking for authentic British meat pies, then look know further.
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	looking	look	VERB	VBG	VerbForm=Ger	12	advcl	12:advcl:if	_
 5	for	for	ADP	IN	_	9	case	9:case	_
 6	authentic	authentic	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -30605,7 +30605,7 @@
 # text = I especially like the Chicken Curry pie.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	especially	especially	ADV	RB	_	3	advmod	3:advmod	_
-3	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 5	Chicken	chicken	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	Curry	curry	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -30699,7 +30699,7 @@
 # text = It clearly had been prepared from fresh ingredients.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
 2	clearly	clearly	ADV	RB	_	5	advmod	5:advmod	_
-3	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+3	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	aux:pass	5:aux:pass	_
 5	prepared	prepare	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 6	from	from	ADP	IN	_	8	case	8:case	_
@@ -30742,7 +30742,7 @@
 10	And	and	CCONJ	CC	_	12	cc	12:cc	_
 11	Your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	Boys	boy	NOUN	NNS	Number=Plur	9	conj	9:conj:and|14:nsubj	_
-13	Have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+13	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 14	Done	do	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
 15	On	on	ADP	IN	_	19	case	19:case	_
 16	Our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -30755,13 +30755,13 @@
 23	On	on	ADP	IN	_	25	case	25:case	_
 24	The	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	Roof	roof	NOUN	NN	Number=Sing	22	nmod	22:nmod:on	_
-26	Look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
+26	Look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
 27	Great	great	ADJ	JJ	Degree=Pos	26	xcomp	26:xcomp	_
 28	And	and	CCONJ	CC	_	40	cc	40:cc	_
 29	The	the	DET	DT	Definite=Def|PronType=Art	30	det	30:det	_
 30	Power	power	NOUN	NN	Number=Sing	40	nsubj	40:nsubj	_
 31	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	33	nsubj	33:nsubj	_
-32	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
+32	Are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
 33	Putting	put	VERB	VBG	VerbForm=Ger	30	acl:relcl	30:acl:relcl	_
 34	Back	back	ADV	RB	_	33	advmod	33:advmod	_
 35	In	in	ADP	GW	_	38	case	38:case	_
@@ -30790,7 +30790,7 @@
 2	First	first	ADJ	JJ	Degree=Pos|NumType=Ord	3	amod	3:amod	_
 3	time	time	NOUN	NN	Number=Sing	14	obl:tmod	14:obl:tmod	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	there	there	ADV	RB	PronType=Dem	5	obl	5:obl:in	_
 8	with	with	ADP	IN	_	12	case	12:case	_
@@ -30799,7 +30799,7 @@
 11	chihuahua	chihuahua	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	puppy	puppy	NOUN	NN	Number=Sing	5	obl	5:obl:with	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	knew	know	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15-16	I'd	_	_	_	_	_	_	_	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
 16	'd	would	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
@@ -30825,7 +30825,7 @@
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	everything	everything	PRON	NN	Number=Sing	5	conj	3:obj|5:conj:and	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj|17:nsubj:xsubj	_
-15	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+15	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	keep	keep	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -30854,7 +30854,7 @@
 5	that	that	SCONJ	IN	_	8	mark	8:mark	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	now	now	ADV	RB	_	8	advmod	8:advmod	_
-8	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+8	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 10	good	good	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 11	nail	nail	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -30888,7 +30888,7 @@
 2	Tina	Tina	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	Vicky	Vicky	PROPN	NNP	Number=Sing	2	conj	2:conj:and|6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	excellent	excellent	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -30915,7 +30915,7 @@
 # sent_id = reviews-288930-0002
 # text = you get a really good view of the city and there is also attractions like simulator, short movies.
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	really	really	ADV	RB	_	5	advmod	5:advmod	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -30942,7 +30942,7 @@
 3	360	360	NUM	CD	NumType=Card	4	nummod	4:nummod	_
 4	restraunt	restaurant	NOUN	NN	Number=Sing|Typo=Yes	1	obj	1:obj	CorrectForm=restaurant
 5	u	you	PRON	PRP	Abbr=Yes|Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	spin	spin	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
+6	spin	spin	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
 7	in	in	ADP	IN	_	10	case	10:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	cn	cn	PROPN	NNP	Number=Sing	10	compound	10:compound	_
@@ -30988,7 +30988,7 @@
 # sent_id = reviews-374000-0003
 # text = I love walking in and not being hassled.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj|8:nsubj:xsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	walking	walk	VERB	VBG	VerbForm=Ger	2	xcomp	2:xcomp	_
 4	in	in	ADV	RB	_	3	advmod	3:advmod	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
@@ -31004,7 +31004,7 @@
 3	there	there	ADV	RB	PronType=Dem	0	root	0:root	_
 4	when	when	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:when	_
+6	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:when	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	free	free	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	raffle	raffle	NOUN	NN	Number=Sing	6	obj	6:obj	_
@@ -31012,7 +31012,7 @@
 11	August	August	PROPN	NNP	Number=Sing	6	obl	6:obl:in	_
 12	and	and	CCONJ	CC	_	14	cc	14:cc	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	won	win	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+14	won	win	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 16	hard	hard	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	drive	drive	NOUN	NN	Number=Sing	14	obj	14:obj	SpaceAfter=No
@@ -31023,13 +31023,13 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	reason	reason	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	back	back	ADV	RB	_	4	advmod	4:advmod	_
 6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	because	because	SCONJ	IN	_	12	mark	12:mark	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	employees	employee	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	sooooo	so	ADV	RB	Style=Expr	12	advmod	12:advmod	CorrectForm=so
 12	nice	nice	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:because	SpaceAfter=No
 13	.	.	PUNCT	.	_	6	punct	6:punct	SpaceAfter=No
@@ -31047,7 +31047,7 @@
 # sent_id = reviews-061768-0002
 # text = I came in to get a nice gift for my wife.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	in	in	ADV	RB	_	2	advmod	2:advmod	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	get	get	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:to	_
@@ -31070,7 +31070,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-9	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+9	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 10	guessing	guess	VERB	VBG	VerbForm=Ger	3	appos	3:appos	_
 11	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
@@ -31084,7 +31084,7 @@
 20	person	person	NOUN	NN	Number=Sing	0	root	0:root	_
 21-22	I've	_	_	_	_	_	_	_	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
-22	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
+22	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	ever	ever	ADV	RB	_	24	advmod	24:advmod	_
 24	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	20	acl:relcl	20:acl:relcl	SpaceAfter=No
 25	.	.	PUNCT	.	_	20	punct	20:punct	_
@@ -31094,7 +31094,7 @@
 1	But	but	CCONJ	CC	_	4	cc	4:cc	_
 2	thankfully	thankfully	ADV	RB	_	4	advmod	4:advmod	_
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	other	other	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	flowers	flower	NOUN	NNS	Number=Plur	7	compound	7:compound	_
 7	shops	shop	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
@@ -31143,7 +31143,7 @@
 3	's	's	PART	POS	_	2	case	2:case	_
 4	metal	metal	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	sculptures	sculpture	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
-6	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
+6	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	cop	8:cop	_
 7	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	favorite	favorite	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 9	.	.	PUNCT	.	_	8	punct	8:punct	SpaceAfter=No
@@ -31199,7 +31199,7 @@
 # sent_id = reviews-308297-0003
 # text = They offer a good portions at a great price, it's enough food to fill you up, but you don't ever feel like you ate too much.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	offer	offer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	offer	offer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	portions	portion	NOUN	NNS	Number=Plur	2	obj	2:obj	_
@@ -31221,13 +31221,13 @@
 20	but	but	CCONJ	CC	_	25	cc	25:cc	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	25	nsubj	25:nsubj	_
 22-23	don't	_	_	_	_	_	_	_	_
-22	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
+22	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
 23	n't	not	PART	RB	_	25	advmod	25:advmod	_
 24	ever	ever	ADV	RB	_	25	advmod	25:advmod	_
 25	feel	feel	VERB	VB	VerbForm=Inf	2	conj	2:conj:but	_
 26	like	like	SCONJ	IN	_	28	mark	28:mark	_
 27	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	28	nsubj	28:nsubj	_
-28	ate	eat	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	25	advcl	25:advcl:like	_
+28	ate	eat	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	25	advcl	25:advcl:like	_
 29	too	too	ADV	RB	_	30	advmod	30:advmod	_
 30	much	much	ADJ	JJ	Degree=Pos	28	obj	28:obj	SpaceAfter=No
 31	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -31305,7 +31305,7 @@
 # text = If you want cheaply made glass from India and China, this is not your place.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
 4	cheaply	cheaply	ADV	RB	_	5	advmod	5:advmod	_
 5	made	make	VERB	VBN	Tense=Past|VerbForm=Part	6	acl	6:acl	_
 6	glass	glass	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -31326,7 +31326,7 @@
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	people	people	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 3	only	only	ADV	RB	_	4	advmod	4:advmod	_
-4	carry	carry	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	carry	carry	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 6	very	very	ADV	RB	_	7	advmod	7:advmod	_
 7	best	good	ADJ	JJS	Degree=Sup	10	amod	10:amod	_
@@ -31371,7 +31371,7 @@
 1	Chuck	Chuck	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	Gretchen	Gretchen	PROPN	NNP	Number=Sing	1	conj	1:conj:and|6:nsubj	_
-4	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+4	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 5	very	very	ADV	RB	_	6	advmod	6:advmod	_
 6	positive	positive	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	20	punct	20:punct	_
@@ -31388,15 +31388,15 @@
 17	bike	bike	NOUN	NN	Number=Sing	14	obl	14:obl:on	SpaceAfter=No
 18	,	,	PUNCT	,	_	20	punct	20:punct	_
 19	Chuck	Chuck	PROPN	NNP	Number=Sing	20	nsubj	20:nsubj|24:nsubj|28:nsubj	_
-20	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
+20	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
 21	right	right	ADV	RB	_	22	advmod	22:advmod	_
 22	out	out	ADV	RB	_	20	advmod	20:advmod	_
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
-24	saw	see	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	conj	20:conj:and	_
+24	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	conj	20:conj:and	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	problem	problem	NOUN	NN	Number=Sing	24	obj	24:obj	_
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
-28	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	conj	20:conj:and	_
+28	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	conj	20:conj:and	_
 29	what	what	PRON	WP	PronType=Int	28	obj	28:obj	_
 30-31	Alan's	_	_	_	_	_	_	_	_
 30	Alan	Alan	PROPN	NNP	Number=Sing	32	nmod:poss	32:nmod:poss	_
@@ -31411,7 +31411,7 @@
 # sent_id = reviews-063754-0002
 # text = He worked on it right on the back of my car.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	on	on	ADP	IN	_	4	case	4:case	_
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	obl	2:obl:on	_
 5	right	right	ADV	RB	_	8	advmod	8:advmod	_
@@ -31441,7 +31441,7 @@
 # sent_id = reviews-236648-0002
 # newpar id = reviews-236648-p0002
 # text = Walked in and was outta there in 10 mins with a really good deal i thought i was going to be paying alot because i had a DUI but with my DUI and Sr-22 they were able to get me the best deal out there.
-1	Walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	in	in	ADV	RB	_	1	advmod	1:advmod	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
@@ -31458,18 +31458,18 @@
 14	good	good	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	deal	deal	NOUN	NN	Number=Sing	4	obl	4:obl:with	_
 16	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-17	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+17	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 18	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj|23:nsubj:xsubj	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
 20	going	go	VERB	VBG	VerbForm=Ger	17	ccomp	17:ccomp	_
 21	to	to	PART	TO	_	23	mark	23:mark	_
 22	be	be	AUX	VB	VerbForm=Inf	23	aux	23:aux	_
 23	paying	pay	VERB	VBG	VerbForm=Ger	20	xcomp	20:xcomp	_
-24	a	a	DET	DT	Definite=Ind|PronType=Art	25	det	25:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+24	a	a	DET	DT	Definite=Ind|PronType=Art	25	det	25:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 25	lot	lot	NOUN	NN	Number=Sing	23	obj	23:obj	_
 26	because	because	SCONJ	IN	_	28	mark	28:mark	_
 27	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	28	nsubj	28:nsubj	_
-28	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	advcl	17:advcl:because	_
+28	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	17	advcl	17:advcl:because	_
 29	a	a	DET	DT	Definite=Ind|PronType=Art	30	det	30:det	_
 30	DUI	dui	NOUN	NN	Number=Sing	28	obj	28:obj	_
 31	but	but	CCONJ	CC	_	41	cc	41:cc	_
@@ -31481,7 +31481,7 @@
 37	-	-	PUNCT	HYPH	_	36	punct	36:punct	SpaceAfter=No
 38	22	22	NUM	CD	NumType=Card	36	nummod	36:nummod	_
 39	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	41	nsubj	41:nsubj|43:nsubj:xsubj	_
-40	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	41	cop	41:cop	_
+40	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	41	cop	41:cop	_
 41	able	able	ADJ	JJ	Degree=Pos	1	conj	1:conj:but	_
 42	to	to	PART	TO	_	43	mark	43:mark	_
 43	get	get	VERB	VB	VerbForm=Inf	41	xcomp	41:xcomp	_
@@ -31520,7 +31520,7 @@
 12	ins	in	NOUN	NNS	Number=Plur	10	obj	10:obj	_
 13	but	but	CCONJ	CC	_	16	cc	16:cc	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-15	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+15	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 16	have	have	VERB	VB	VerbForm=Inf	5	conj	5:conj:and	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	blue	blue	NOUN	NN	Number=Sing	19	compound	19:compound	_
@@ -31533,10 +31533,10 @@
 # text = Glad I called before I arrived with my box to ship.
 1	Glad	glad	ADJ	JJ	Degree=Pos	0	root	0:root	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
+3	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
 4	before	before	SCONJ	IN	_	6	mark	6:mark	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	arrived	arrive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:before	_
+6	arrived	arrive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:before	_
 7	with	with	ADP	IN	_	9	case	9:case	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	box	box	NOUN	NN	Number=Sing	6	obl	6:obl:with	_
@@ -31546,7 +31546,7 @@
 
 # sent_id = reviews-372665-0004
 # text = Thought adding a comment would save someone the hassle with a useless trip there.
-1	Thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	adding	add	VERB	VBG	VerbForm=Ger	6	csubj	6:csubj	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	comment	comment	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -31578,12 +31578,12 @@
 # text = the waitress took my name and then called me that all night.
 1	the	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	waitress	waitress	NOUN	NN	Number=Sing	3	nsubj	3:nsubj|8:nsubj	_
-3	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	name	name	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	then	then	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
-8	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+8	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 9	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obj	8:obj|10:nsubj:xsubj	_
 10	that	that	PRON	DT	Number=Sing|PronType=Dem	8	xcomp	8:xcomp	_
 11	all	all	DET	DT	_	12	det	12:det	_
@@ -31596,7 +31596,7 @@
 2	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
 3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	about	about	ADP	IN	_	8	case	8:case	_
 7	that	that	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	one	one	NUM	CD	NumType=Card	5	obl	5:obl:about	SpaceAfter=No
@@ -31625,7 +31625,7 @@
 # text = if you want good pizza, go to famoso.
 1	if	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	pizza	pizza	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -31652,7 +31652,7 @@
 7	suspicious	suspicious	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 8	that	that	SCONJ	IN	_	10	mark	10:mark	_
 9	there	there	PRON	EX	_	10	expl	10:expl	_
-10	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+10	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 11	not	not	PART	RB	_	10	advmod	10:advmod	_
 12	only	only	ADV	RB	_	10	cc:preconj	10:cc:preconj	_
 13	20	20	NUM	CD	NumType=Card	14	nummod	14:nummod	_
@@ -31677,7 +31677,7 @@
 32	that	that	SCONJ	IN	_	35	mark	35:mark	_
 33	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	35	nsubj	35:nsubj	_
 34	all	all	DET	DT	_	33	det	33:det	_
-35	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	conj	3:ccomp|10:conj:but	_
+35	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	conj	3:ccomp|10:conj:but	_
 36	the	the	DET	DT	Definite=Def|PronType=Art	40	det	40:det	_
 37	same	same	ADJ	JJ	Degree=Pos	40	amod	40:amod	_
 38	unique	unique	ADJ	JJ	Degree=Pos	40	amod	40:amod	_
@@ -31689,7 +31689,7 @@
 # text = And they seem to be posted at fairly regular intervals?
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj|6:nsubj:xsubj	_
-3	seem	seem	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	seem	seem	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux:pass	6:aux:pass	_
 6	posted	post	VERB	VBN	Tense=Past|VerbForm=Part	3	xcomp	3:xcomp	_
@@ -31711,7 +31711,7 @@
 # newpar id = reviews-059386-p0002
 # text = We go to Japaneiro's all the time and we have NEVER been disappointed!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	go	go	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	4	case	4:case	_
 4-5	Japaneiro's	_	_	_	_	_	_	_	_
 4	Japaneiro	Japaneiro	PROPN	NNP	Number=Sing	2	obl	2:obl:to	_
@@ -31721,7 +31721,7 @@
 8	time	time	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	_
 9	and	and	CCONJ	CC	_	14	cc	14:cc	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj:pass	14:nsubj:pass	_
-11	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+11	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 12	NEVER	never	ADV	RB	_	14	advmod	14:advmod	_
 13	been	be	AUX	VBN	Tense=Past|VerbForm=Part	14	aux:pass	14:aux:pass	_
 14	disappointed	disappoint	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:and	SpaceAfter=No
@@ -31793,7 +31793,7 @@
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	knowledgeable	knowledgeable	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+6	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	time	time	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -31816,7 +31816,7 @@
 8	quickly	quickly	ADV	RB	_	7	advmod	7:advmod	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	felt	feel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
+11	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 14	trust	trust	VERB	VB	VerbForm=Inf	11	ccomp	11:ccomp	_
@@ -31827,7 +31827,7 @@
 # sent_id = reviews-359014-0005
 # text = I have nothing but fantastic things to say.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	nothing	nothing	PRON	NN	Number=Sing	2	obj	2:obj	_
 4	but	but	ADP	CC	_	6	cc	6:cc	_
 5	fantastic	fantastic	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -31840,7 +31840,7 @@
 # text = I highly recommend his shop.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	shop	shop	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -31864,7 +31864,7 @@
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	been	be	AUX	VBN	Tense=Past|VerbForm=Part	11	cop	11:cop	_
 11	to	to	ADP	IN	_	7	acl:relcl	7:acl:relcl	SpaceAfter=No
 12	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -31872,7 +31872,7 @@
 # sent_id = reviews-228944-0003
 # text = I have a Saab...which everything is expensive on and they have been extrememly fair and price alot lower than any other shop I called.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	Saab	Saab	PROPN	NNP	Number=Sing	2	obj	2:obj|9:obl	SpaceAfter=No
 5	...	...	PUNCT	,	_	4	punct	4:punct	SpaceAfter=No
@@ -31883,13 +31883,13 @@
 10	on	on	ADP	IN	_	6	case	6:case	_
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-13	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 14	been	be	AUX	VBN	Tense=Past|VerbForm=Part	16	cop	16:cop	_
 15	extrememly	extremely	ADV	RB	Typo=Yes	16	advmod	16:advmod	CorrectForm=extremely
 16	fair	fair	ADJ	JJ	Degree=Pos	2	conj	2:conj:and	_
 17	and	and	CCONJ	CC	_	21	cc	21:cc	_
 18	price	price	NOUN	NN	Number=Sing	21	nsubj	21:nsubj	_
-19	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+19	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 20	lot	lot	NOUN	NN	Number=Sing	21	obl:npmod	21:obl:npmod	_
 21	lower	low	ADJ	JJR	Degree=Cmp	2	conj	2:conj:and	_
 22	than	than	ADP	IN	_	25	case	25:case	_
@@ -31897,13 +31897,13 @@
 24	other	other	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	shop	shop	NOUN	NN	Number=Sing	21	obl	21:obl:than	_
 26	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
-27	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	SpaceAfter=No
+27	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	SpaceAfter=No
 28	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-228944-0004
 # text = They are the only place I would take my car peiod.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	only	only	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	place	place	NOUN	NN	Number=Sing	0	root	0:root	_
@@ -31919,7 +31919,7 @@
 # sent_id = reviews-248616-0001
 # newpar id = reviews-248616-p0001
 # text = Took a laptop in for a video cable to be replaced.
-1	Took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	3	det	3:det	_
 3	laptop	laptop	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	in	in	ADV	RB	_	1	advmod	1:advmod	_
@@ -31938,11 +31938,11 @@
 2	except	except	ADP	IN	_	4	case	4:case	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	display	display	NOUN	NN	Number=Sing	1	nmod	1:nmod:except	_
-5	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	fine	fine	ADV	RB	_	5	advmod	5:advmod	_
 7	before	before	SCONJ	IN	_	9	mark	9:mark	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:before	_
+9	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:before	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj	_
 11	in	in	ADV	RB	_	9	advmod	9:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -31967,7 +31967,7 @@
 1	Phone	phone	NOUN	NN	Number=Sing	2	compound	2:compound	_
 2	calls	call	NOUN	NNS	Number=Plur	5	nsubj:pass	5:nsubj:pass	_
 3-4	weren't	_	_	_	_	_	_	_	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 6	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
@@ -31976,7 +31976,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	botched	botch	VERB	VBN	Tense=Past|VerbForm=Part	11	amod	11:amod	_
 11	repair	repair	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
-12	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+12	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 14	week	week	NOUN	NN	Number=Sing	15	obl:npmod	15:obl:npmod	_
 15	longer	long	ADV	RBR	Degree=Cmp	12	advmod	12:advmod	_
@@ -31989,7 +31989,7 @@
 # newpar id = reviews-210019-p0001
 # text = We have stayed at Tanglewood for many years now.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	at	at	ADP	IN	_	5	case	5:case	_
 5	Tanglewood	Tanglewood	PROPN	NNP	Number=Sing	3	obl	3:obl:at	_
@@ -32002,7 +32002,7 @@
 # sent_id = reviews-210019-0002
 # text = We go over about 5 times a year.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	go	go	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	over	over	ADV	RB	_	2	advmod	2:advmod	_
 4	about	about	ADV	RB	_	5	advmod	5:advmod	_
 5	5	5	NUM	CD	NumType=Card	6	nummod	6:nummod	_
@@ -32014,7 +32014,7 @@
 # sent_id = reviews-210019-0003
 # text = We have never had a problem with the cabins.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	never	never	ADV	RB	_	4	advmod	4:advmod	_
 4	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -32027,7 +32027,7 @@
 # sent_id = reviews-210019-0004
 # text = They are always so helpful.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	always	always	ADV	RB	_	5	advmod	5:advmod	_
 4	so	so	ADV	RB	_	5	advmod	5:advmod	_
 5	helpful	helpful	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -32037,7 +32037,7 @@
 # text = The cabins have always been clean.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	cabins	cabin	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 4	always	always	ADV	RB	_	6	advmod	6:advmod	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
 6	clean	clean	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -32059,7 +32059,7 @@
 # sent_id = reviews-210019-0007
 # text = We recommend these cabins!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	recommend	recommend	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	these	this	DET	DT	Number=Plur|PronType=Dem	4	det	4:det	_
 4	cabins	cabin	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -32078,7 +32078,7 @@
 # newpar id = reviews-280170-p0002
 # text = I used to tan down the street before I was referred to this place by one of my friends.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	tan	tan	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	down	down	ADP	IN	_	7	case	7:case	_
@@ -32107,7 +32107,7 @@
 # text = I didn't know what I was missing.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	didn't	_	_	_	_	_	_	_	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	what	what	PRON	WP	PronType=Int	8	obj	8:obj	_
@@ -32141,7 +32141,7 @@
 3	clean	clean	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	and	and	CCONJ	CC	_	7	cc	7:cc	_
 5	girls	girl	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	nice	nice	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -32175,7 +32175,7 @@
 5	...	...	PUNCT	,	_	9	punct	9:punct	_
 6-7	I'm	_	_	_	_	_	_	_	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-7	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+7	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 8	pleasantly	pleasantly	ADV	RB	_	9	advmod	9:advmod	_
 9	surprised	surprised	ADJ	JJ	Degree=Pos	0	root	0:root	_
 10	that	that	SCONJ	IN	_	14	mark	14:mark	_
@@ -32192,7 +32192,7 @@
 21	there	there	ADV	RB	PronType=Dem	14	advmod	14:advmod	_
 22	where	where	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 23	company	company	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	_
-24	care	care	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:where	_
+24	care	care	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:where	_
 25	more	more	ADV	RBR	_	24	advmod	24:advmod	_
 26	about	about	ADP	IN	_	28	case	28:case	_
 27	good	good	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
@@ -32234,14 +32234,14 @@
 1	If	if	SCONJ	IN	_	2	mark	2:mark	_
 2	possible	possible	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	try	try	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	try	try	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	services	service	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 7	on	on	ADP	IN	_	8	case	8:case	_
 8	myself	myself	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	4	obl	4:obl:on	_
 9	before	before	SCONJ	IN	_	11	mark	11:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	bring	bring	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:before	_
+11	bring	bring	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:before	_
 12	in	in	ADV	RP	_	11	compound:prt	11:compound:prt	_
 13	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 14	son	son	NOUN	NN	Number=Sing	11	obj	11:obj	SpaceAfter=No
@@ -32251,7 +32251,7 @@
 # text = Drs. Ali work wonders.
 1	Drs.	Drs.	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	Ali	Ali	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-3	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	work	work	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	wonders	wonder	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 5	.	.	PUNCT	.	_	3	punct	3:punct	SpaceAfter=No
 
@@ -32263,7 +32263,7 @@
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	son	son	NOUN	NN	Number=Sing	2	conj	2:conj:nor|8:nsubj	_
 6-7	haven't	_	_	_	_	_	_	_	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	_	8	advmod	8:advmod	_
 8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
@@ -32271,7 +32271,7 @@
 11	cavity	cavity	NOUN	NN	Number=Sing	8	obj	8:obj	_
 12	since	since	SCONJ	IN	_	14	mark	14:mark	_
 13	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:since	_
+14	started	start	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:since	_
 15	dental	dental	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 16	care	care	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	there	there	ADV	RB	PronType=Dem	14	advmod	14:advmod	SpaceAfter=No
@@ -32314,7 +32314,7 @@
 # sent_id = reviews-287454-0002
 # text = They offer a large variety of quality hotdogs and hamburgers They also offer veggie dogs.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	offer	offer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	offer	offer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	large	large	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	variety	variety	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -32325,7 +32325,7 @@
 10	hamburgers	hamburger	NOUN	NNS	Number=Plur	8	conj	5:nmod:of|8:conj:and	_
 11	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 12	also	also	ADV	RB	_	13	advmod	13:advmod	_
-13	offer	offer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+13	offer	offer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 14	veggie	veggie	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	dogs	dog	NOUN	NNS	Number=Plur	13	obj	13:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -32334,7 +32334,7 @@
 # text = The fries are of good quality, the staff is friendly.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	fries	fry	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	quality	quality	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
@@ -32379,7 +32379,7 @@
 # newpar id = reviews-162253-p0002
 # text = I used my card to purchase a meal on the menu and the total on my receipt was $8.95 but when I went on line to check my transaction it show $10.74.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	card	card	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj:xsubj	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -32401,7 +32401,7 @@
 21	but	but	CCONJ	CC	_	32	cc	32:cc	_
 22	when	when	SCONJ	WRB	PronType=Int	24	mark	24:mark	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
-24	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	32	advcl	32:advcl:when	_
+24	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	32	advcl	32:advcl:when	_
 25	on	on	ADP	IN	_	26	case	26:case	_
 26	line	line	NOUN	NN	Number=Sing	24	obl	24:obl:on	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
@@ -32409,7 +32409,7 @@
 29	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	30	nmod:poss	30:nmod:poss	_
 30	transaction	transaction	NOUN	NN	Number=Sing	28	obj	28:obj	_
 31	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	32	nsubj	32:nsubj	_
-32	show	show	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+32	show	show	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 33	$	$	SYM	$	_	32	obj	32:obj	SpaceAfter=No
 34	10.74	10.74	NUM	CD	NumType=Card	33	nummod	33:nummod	SpaceAfter=No
 35	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -32424,7 +32424,7 @@
 6	maybe	maybe	ADV	RB	_	9	advmod	9:advmod	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	individual	individual	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
-9	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:or	_
+9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:or	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	mistake	mistake	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	but	but	CCONJ	CC	_	18	cc	18:cc	_
@@ -32444,7 +32444,7 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3-4	your	_	_	_	_	_	_	_	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-4	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	SpaceAfter=No
 7	!	!	PUNCT	.	_	6	punct	6:punct	_
@@ -32460,12 +32460,12 @@
 6	that	that	SCONJ	IN	_	11	mark	11:mark	_
 7	Elmira	Elmira	PROPN	NNP	Number=Sing	11	vocative	11:vocative	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	best	good	ADJ	JJS	Degree=Sup	5	ccomp	5:ccomp	_
 12-13	Ive	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-13	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+13	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 14	experienced	experience	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	,	,	PUNCT	,	_	5	punct	5:punct	_
 16	never	never	ADV	RB	_	17	advmod	17:advmod	_
@@ -32479,14 +32479,14 @@
 24	job	job	NOUN	NN	Number=Sing	21	obj	21:obj	_
 25	until	until	SCONJ	IN	_	27	mark	27:mark	_
 26	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
-27	met	meet	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	21	advcl	21:advcl:until	_
+27	met	meet	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	21	advcl	21:advcl:until	_
 28	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	obj	27:obj	SpaceAfter=No
 29	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = reviews-202709-0003
 # text = I recommend you to everyone in Calgary, as she is a professional and the cost for her was low.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obj	2:obj	_
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	everyone	everyone	PRON	NN	Number=Sing	2	obl	2:obl:to	_
@@ -32520,28 +32520,28 @@
 # newpar id = reviews-140302-p0002
 # text = I took my Mustang here and it looked amazing after they were done, they did a great job, I'm very satisfied with the results.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	Mustang	Mustang	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 5	here	here	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	8:nsubj|9:nsubj:xsubj	_
-8	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+8	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 9	amazing	amazing	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
 10	after	after	SCONJ	IN	_	13	mark	13:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-12	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
+12	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
 13	done	done	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:after	SpaceAfter=No
 14	,	,	PUNCT	,	_	2	punct	2:punct	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
+16	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	great	great	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	job	job	NOUN	NN	Number=Sing	16	obj	16:obj	SpaceAfter=No
 20	,	,	PUNCT	,	_	2	punct	2:punct	_
 21-22	I'm	_	_	_	_	_	_	_	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
-22	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
+22	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 23	very	very	ADV	RB	_	24	advmod	24:advmod	_
 24	satisfied	satisfied	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 25	with	with	ADP	IN	_	27	case	27:case	_
@@ -32555,13 +32555,13 @@
 2	paint	paint	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	wheels	wheel	NOUN	NNS	Number=Plur	2	conj	2:conj:and|5:nsubj	_
-5	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	like	like	ADP	IN	_	7	case	7:case	_
 7	glass	glass	NOUN	NN	Number=Sing	5	obl	5:obl:like	_
 8	and	and	CCONJ	CC	_	11	cc	11:cc	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	interior	interior	NOUN	NN	Number=Sing	11	nsubj	11:nsubj|12:nsubj:xsubj	_
-11	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+11	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 12	new	new	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 13	!	!	PUNCT	.	_	5	punct	5:punct	_
 
@@ -32570,7 +32570,7 @@
 1	Also	also	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	great	great	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	customer	customer	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	service	service	NOUN	NN	Number=Sing	4	obj	4:obj	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -5,7 +5,7 @@
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	Morphed	morph	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
+4	Morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
 5	Into	into	ADP	IN	_	6	case	6:case	_
 6	GoogleOS	GoogleOS	PROPN	NNP	Number=Sing	4	obl	4:obl:into	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -15,7 +15,7 @@
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	expanded	expand	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
+4	expanded	expand	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
 5	on	on	ADP	IN	_	15	case	15:case	_
 6	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 7	search	search	NOUN	NN	Number=Sing	9	compound	9:compound	SpaceAfter=No
@@ -97,7 +97,7 @@
 14	which	which	PRON	WDT	PronType=Rel	18	obj	12:ref	_
 15-16	we've	_	_	_	_	_	_	_	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-16	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+16	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 17	all	all	ADV	RB	_	18	advmod	18:advmod	_
 18	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
 19	before	before	ADV	RB	_	18	advmod	18:advmod	SpaceAfter=No
@@ -139,7 +139,7 @@
 # sent_id = weblog-blogspot.com_marketview_20050511222700_ENG_20050511_222700-0005
 # text = They own blogger, of course.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	own	own	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	own	own	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	blogger	blogger	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	2	punct	2:punct	_
 5	of	of	ADP	IN	_	2	advmod	2:advmod	_
@@ -160,7 +160,7 @@
 # text = I'm staying away from the stock.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	staying	stay	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	away	away	ADV	RB	_	3	advmod	3:advmod	_
 5	from	from	ADP	IN	_	7	case	7:case	_
@@ -173,13 +173,13 @@
 # newpar id = weblog-blogspot.com_floppingaces_20041126180010_ENG_20041126_180010-p0001
 # text = I doubt the very few who actually read my blog have not come across this yet, but I figured I would put it out there anyways.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	doubt	doubt	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	doubt	doubt	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	few	few	ADJ	JJ	Degree=Pos	13	nsubj	8:nsubj|13:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	actually	actually	ADV	RB	_	8	advmod	8:advmod	_
-8	read	read	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+8	read	read	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 9	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	blog	blog	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
@@ -191,7 +191,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	but	but	CCONJ	CC	_	20	cc	20:cc	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	figured	figure	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:but	_
+20	figured	figure	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:but	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj	_
 22	would	would	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
 23	put	put	VERB	VB	VerbForm=Inf	20	ccomp	20:ccomp	_
@@ -275,7 +275,7 @@
 4	two	two	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	pictures	picture	NOUN	NNS	Number=Plur	7	obl	7:obl:on	_
 6	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	screenshots	screenshot	NOUN	NNS	Number=Plur	7	obj	7:obj	_
 9	of	of	ADP	IN	_	12	case	12:case	_
 10	two	two	NUM	CD	NumType=Card	12	nummod	12:nummod	_
@@ -298,14 +298,14 @@
 # newpar id = weblog-blogspot.com_floppingaces_20041126180010_ENG_20041126_180010-p0003
 # text = You have to see these slides....they are amazing.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	see	see	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	these	this	DET	DT	Number=Plur|PronType=Dem	6	det	6:det	_
 6	slides	slide	NOUN	NNS	Number=Plur	4	obj	4:obj	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	SpaceAfter=No
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	amazing	amazing	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -388,7 +388,7 @@
 # text = I'm not fond of the Google-hates-privacy argument
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	fond	fond	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	of	of	ADP	IN	_	12	case	12:case	_
@@ -405,7 +405,7 @@
 1	(	(	PUNCT	-LRB-	_	5	punct	5:punct	SpaceAfter=No
 2	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj	_
 3-4	don't	_	_	_	_	_	_	_	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -425,7 +425,7 @@
 20	,	,	PUNCT	,	_	24	punct	24:punct	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj|26:nsubj:xsubj	_
 22-23	don't	_	_	_	_	_	_	_	_
-22	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
+22	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	n't	not	PART	RB	_	24	advmod	24:advmod	_
 24	need	need	VERB	VB	VerbForm=Inf	5	conj	5:conj:and	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
@@ -447,7 +447,7 @@
 41	--	--	PUNCT	,	_	44	punct	44:punct	_
 42-43	you're	_	_	_	_	_	_	_	_
 42	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	44	nsubj	44:nsubj	_
-43	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	44	cop	44:cop	_
+43	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	44	cop	44:cop	_
 44	worried	worried	ADJ	JJ	Degree=Pos	70	advcl	70:advcl:if	_
 45	that	that	SCONJ	IN	_	48	mark	48:mark	_
 46	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	48	nsubj	48:nsubj	_
@@ -474,7 +474,7 @@
 67	account	account	NOUN	NN	Number=Sing	62	obl	62:obl:on	SpaceAfter=No
 68	...	...	PUNCT	,	_	70	punct	70:punct	_
 69	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	70	nsubj	70:nsubj	_
-70	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+70	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 71	far	far	ADV	RB	Degree=Pos	75	advmod	75:advmod	SpaceAfter=No
 72	,	,	PUNCT	,	_	75	punct	75:punct	_
 73	far	far	ADV	RB	Degree=Pos	75	advmod	75:advmod	_
@@ -565,7 +565,7 @@
 # sent_id = weblog-blogspot.com_grandpasgripes_20060413051000_ENG_20060413_051000-0005
 # text = I read an Article in Time magazine accusing the Iranian Government of being willing to start a nuclear war and I sympathise with the Article.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	read	read	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	read	read	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	an	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	Article	article	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	in	in	ADP	IN	_	7	case	7:case	_
@@ -585,7 +585,7 @@
 19	war	war	NOUN	NN	Number=Sing	16	obj	16:obj	_
 20	and	and	CCONJ	CC	_	22	cc	22:cc	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-22	sympathise	sympathise	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+22	sympathise	sympathise	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 23	with	with	ADP	IN	_	25	case	25:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	Article	article	NOUN	NN	Number=Sing	22	obl	22:obl:with	SpaceAfter=No
@@ -594,7 +594,7 @@
 # sent_id = weblog-blogspot.com_grandpasgripes_20060413051000_ENG_20060413_051000-0006
 # text = They are certainly being nasty to the United Nations Security Council in connection with the anti-proliferation treaty.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	certainly	certainly	ADV	RB	_	5	advmod	5:advmod	_
 4	being	be	AUX	VBG	VerbForm=Ger	5	cop	5:cop	_
 5	nasty	nasty	ADJ	JJ	Degree=Pos	0	root	0:root	_
@@ -663,7 +663,7 @@
 # text = Many people want to use diplomacy with Iran rather than military pressure.
 1	Many	many	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	people	people	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	use	use	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	diplomacy	diplomacy	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -699,12 +699,12 @@
 # text = One reader pointed out that the President watched the Americans in the embassy when they took them hostage.
 1	One	one	NUM	CD	NumType=Card	2	nummod	2:nummod	_
 2	reader	reader	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	pointed	point	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	pointed	point	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	that	that	SCONJ	IN	_	8	mark	8:mark	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	President	President	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
-8	watched	watch	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+8	watched	watch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	Americans	American	PROPN	NNPS	Number=Plur	8	obj	8:obj	_
 11	in	in	ADP	IN	_	13	case	13:case	_
@@ -712,7 +712,7 @@
 13	embassy	embassy	NOUN	NN	Number=Sing	10	nmod	10:nmod:in	_
 14	when	when	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
+16	took	take	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 17	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	obj	16:obj|18:nsubj:xsubj	_
 18	hostage	hostage	NOUN	NN	Number=Sing	16	xcomp	16:xcomp	SpaceAfter=No
 19	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -729,7 +729,7 @@
 # text = We don't have to believe him.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -756,11 +756,11 @@
 4	that	that	SCONJ	IN	_	7	mark	7:mark	_
 5	Iranians	Iranian	PROPN	NNPS	Number=Plur	7	nsubj	7:nsubj|11:nsubj	_
 6	frequently	frequently	ADV	RB	_	7	advmod	7:advmod	_
-7	make	make	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+7	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 8	statements	statement	NOUN	NNS	Number=Plur	7	obj	7:obj	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	then	then	ADV	RB	PronType=Dem	11	advmod	11:advmod	_
-11	hide	hide	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	3:ccomp|7:conj:and	_
+11	hide	hide	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	conj	3:ccomp|7:conj:and	_
 12	behind	behind	ADP	IN	_	13	case	13:case	_
 13	lack	lack	NOUN	NN	Number=Sing	11	obl	11:obl:behind	_
 14	of	of	ADP	IN	_	15	case	15:case	_
@@ -773,7 +773,7 @@
 # text = Angry crowds chanted anti-American slogans in the western city of Falluja (pop. 256,000) as the security police killed in a friendly fire incident by US troops were buried on Saturday.
 1	Angry	angry	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	crowds	crowd	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	chanted	chant	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	chanted	chant	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	anti-American	anti-American	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	slogans	slogan	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	in	in	ADP	IN	_	9	case	9:case	_
@@ -799,7 +799,7 @@
 26	by	by	ADP	IN	_	28	case	28:case	_
 27	US	US	PROPN	NNP	Number=Sing	28	compound	28:compound	_
 28	troops	troops	NOUN	NNS	Number=Plur	20	obl	20:obl:by	_
-29	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	30	aux	30:aux	_
+29	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	30	aux	30:aux	_
 30	buried	bury	VERB	VBN	Tense=Past|VerbForm=Part	3	advcl	3:advcl:as	_
 31	on	on	ADP	IN	_	32	case	32:case	_
 32	Saturday	Saturday	PROPN	NNP	Number=Sing	30	obl	30:obl:on	SpaceAfter=No
@@ -808,7 +808,7 @@
 # sent_id = weblog-juancole.com_juancole_20030914114200_ENG_20030914_114200-0002
 # text = Reuters reported that "Sunni clerics in the town issued a 'Declaration by the people of Fallujah' condemning the deaths of the security guards and police, announcing three days of mourning, and calling for a general strike today."
 1	Reuters	Reuters	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	reported	report	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	reported	report	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	10	mark	10:mark	_
 4	"	"	PUNCT	``	_	10	punct	10:punct	SpaceAfter=No
 5	Sunni	Sunni	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -816,7 +816,7 @@
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	town	town	NOUN	NN	Number=Sing	6	nmod	6:nmod:in	_
-10	issued	issue	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+10	issued	issue	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	'	'	PUNCT	``	_	13	punct	13:punct	SpaceAfter=No
 13	Declaration	declaration	NOUN	NN	Number=Sing	10	obj	10:obj	_
@@ -855,14 +855,14 @@
 # sent_id = weblog-juancole.com_juancole_20030914114200_ENG_20030914_114200-0003
 # text = It read, "The people of Fallujah condemn the massacre which was committed on Friday against people dedicated to the protection of Fallujah.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	read	read	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	read	read	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
 4	"	"	PUNCT	``	_	2	punct	2:punct	SpaceAfter=No
 5	The	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	people	people	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	Fallujah	Fallujah	PROPN	NNP	Number=Sing	6	nmod	6:nmod:of	_
-9	condemn	condemn	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+9	condemn	condemn	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	massacre	massacre	NOUN	NN	Number=Sing	9	obj	9:obj|14:nsubj:pass	_
 12	which	which	PRON	WDT	PronType=Rel	14	nsubj:pass	11:ref	_
@@ -893,7 +893,7 @@
 9	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 10	that	that	SCONJ	IN	_	13	mark	13:mark	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj|24:nsubj|27:nsubj:xsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 13	capable	capable	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	_
 14	of	of	SCONJ	IN	_	15	mark	15:mark	_
 15	protecting	protect	VERB	VBG	VerbForm=Ger	13	advcl	13:advcl:of	_
@@ -906,7 +906,7 @@
 21	safety	safety	NOUN	NN	Number=Sing	19	conj	15:obj|19:conj:and	SpaceAfter=No
 22	,	,	PUNCT	,	_	24	punct	24:punct	_
 23	and	and	CCONJ	CC	_	24	cc	24:cc	_
-24	ask	ask	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	conj	9:ccomp|13:conj:and	_
+24	ask	ask	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	13	conj	9:ccomp|13:conj:and	_
 25	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	24	iobj	24:iobj	_
 26	to	to	PART	TO	_	27	mark	27:mark	_
 27	lift	lift	VERB	VB	VerbForm=Inf	24	xcomp	24:xcomp	_
@@ -922,7 +922,7 @@
 # text = The clerics demanded talks with local US commanders.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	clerics	cleric	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	demanded	demand	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	demanded	demand	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	talks	talk	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	with	with	ADP	IN	_	8	case	8:case	_
 6	local	local	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -950,13 +950,13 @@
 16	local	local	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	Sunnis	Sunni	PROPN	NNPS	Number=Plur	19	nsubj	19:nsubj|20:nsubj:xsubj|26:nsubj:xsubj|28:nsubj:xsubj|31:nsubj:xsubj	_
 18	either	either	CCONJ	CC	_	20	cc:preconj	20:cc:preconj	_
-19	remain	remain	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:since	_
+19	remain	remain	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:since	_
 20	committed	committed	ADJ	JJ	Degree=Pos	19	xcomp	19:xcomp	_
 21	to	to	ADP	IN	_	23	case	23:case	_
 22	Arab	Arab	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	nationalism	nationalism	NOUN	NN	Number=Sing	20	obl	20:obl:to	_
 24	or	or	CCONJ	CC	_	26	cc	26:cc	_
-25	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
+25	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
 26	become	become	VERB	VBN	Tense=Past|VerbForm=Part	20	conj	19:xcomp|20:conj:or	_
 27	Sunni	Sunni	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
 28	fundamentalists	fundamentalist	NOUN	NNS	Number=Plur	26	xcomp	26:xcomp	_
@@ -971,13 +971,13 @@
 2	such	such	ADJ	JJ	Degree=Pos	4	case	4:case	_
 3	as	as	ADP	IN	_	2	fixed	2:fixed	_
 4	Falluja	Falluja	PROPN	NNP	Number=Sing	1	nmod	1:nmod:such_as	_
-5	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	received	receive	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	special	special	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	treatment	treatment	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	from	from	ADP	IN	_	9	case	9:case	_
 9	Saddam	Saddam	PROPN	NNP	Number=Sing	5	obl	5:obl:from	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
-11	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+11	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 13	disproportionate	disproportionate	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	share	share	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -994,7 +994,7 @@
 # sent_id = weblog-juancole.com_juancole_20030914114200_ENG_20030914_114200-0008
 # text = They know that the American advent implies for them a demotion, and an elevation of the Shiites and Kurds, and they refuse to go quietly.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	7	mark	7:mark	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	American	American	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -1016,7 +1016,7 @@
 21	,	,	PUNCT	,	_	24	punct	24:punct	_
 22	and	and	CCONJ	CC	_	24	cc	24:cc	_
 23	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	24	nsubj	24:nsubj|26:nsubj:xsubj	_
-24	refuse	refuse	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+24	refuse	refuse	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	go	go	VERB	VB	VerbForm=Inf	24	xcomp	24:xcomp	_
 27	quietly	quietly	ADV	RB	_	26	advmod	26:advmod	SpaceAfter=No
@@ -1034,7 +1034,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	Supreme	Supreme	ADJ	NNP	Degree=Pos	3	amod	3:amod	_
 3	Court	Court	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	announced	announce	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	announced	announce	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 6	ruling	ruling	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	today	today	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	_
@@ -1099,7 +1099,7 @@
 6	John	John	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 7	Paul	Paul	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 8	STEVENS	STEVENS	PROPN	NNP	Number=Sing	6	flat	6:flat	_
-9	delivered	deliver	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+9	delivered	deliver	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	opinion	opinion	NOUN	NN	Number=Sing	9	obj	9:obj|50:obl	_
 12	of	of	ADP	IN	_	14	case	14:case	_
@@ -1140,7 +1140,7 @@
 47	,	,	PUNCT	,	_	49	punct	49:punct	_
 48	and	and	CCONJ	CC	_	49	cc	49:cc	_
 49	BREYER	BREYER	PROPN	NNP	Number=Sing	42	conj	42:conj:and|50:nsubj	_
-50	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+50	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 51	,	,	PUNCT	,	_	54	punct	54:punct	_
 52	and	and	CCONJ	CC	_	54	cc	54:cc	_
 53	an	a	DET	DT	Definite=Ind|PronType=Art	54	det	54:det	_
@@ -1165,13 +1165,13 @@
 72	,	,	PUNCT	,	_	74	punct	74:punct	_
 73	and	and	CCONJ	CC	_	74	cc	74:cc	_
 74	BREYER	BREYER	PROPN	NNP	Number=Sing	69	conj	69:conj:and|75:nsubj	_
-75	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	SpaceAfter=No
+75	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	SpaceAfter=No
 76	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0004
 # text = BREYER filed a concurring opinion, in which KENNEDY, SOUTER, and GINSBURG joined.
 1	BREYER	breyer	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
-2	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	filed	file	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	concurring	concur	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	opinion	opinion	NOUN	NN	Number=Sing	2	obj	2:obj|15:obl	SpaceAfter=No
@@ -1184,13 +1184,13 @@
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	GINSBURG	GINSBURG	PROPN	NNP	Number=Sing	9	conj	9:conj:and|15:nsubj	_
-15	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+15	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0005
 # text = KENNEDY filed an opinion concurring in part, in which SOUTER, GINSBURG, and BREYER joined as to Parts I and II.
 1	KENNEDY	KENNEDY	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	filed	file	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	an	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	opinion	opinion	NOUN	NN	Number=Sing	2	obj	2:obj|17:obl	_
 5	concurring	concur	VERB	VBG	VerbForm=Ger	4	acl	4:acl	_
@@ -1205,7 +1205,7 @@
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	BREYER	BREYER	PROPN	NNP	Number=Sing	11	conj	11:conj:and|17:nsubj	_
-17	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 18	as	as	ADP	IN	_	20	case	20:case	_
 19	to	to	ADP	IN	_	18	fixed	18:fixed	_
 20	Parts	part	NOUN	NNS	Number=Plur	17	obl	17:obl:as_to	_
@@ -1217,7 +1217,7 @@
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0006
 # text = SCALIA filed a dissenting opinion, in which THOMAS and ALITO joined.
 1	SCALIA	SCALIA	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	filed	file	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	dissenting	dissent	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	opinion	opinion	NOUN	NN	Number=Sing	2	obj	2:obj|12:obl	SpaceAfter=No
@@ -1227,13 +1227,13 @@
 9	THOMAS	THOMAS	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	ALITO	ALITO	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0007
 # text = THOMAS filed a dissenting opinion, in which SCALIA joined, and in which ALITO joined as to all but Parts I, II-C-1, and III-B-2.
 1	THOMAS	THOMAS	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	filed	file	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	dissenting	dissent	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	opinion	opinion	NOUN	NN	Number=Sing	2	obj	2:obj|10:obl	SpaceAfter=No
@@ -1241,13 +1241,13 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	which	which	PRON	WDT	PronType=Rel	10	obl	5:ref	_
 9	SCALIA	SCALIA	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
-10	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+10	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 11	,	,	PUNCT	,	_	16	punct	16:punct	_
 12	and	and	CCONJ	CC	_	16	cc	16:cc	_
 13	in	in	ADP	IN	_	14	case	14:case	_
 14	which	which	PRON	WDT	PronType=Int	16	obl	16:obl:in	_
 15	ALITO	ALITO	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj	_
-16	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	conj	5:acl:relcl|10:conj:and	_
+16	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	conj	5:acl:relcl|10:conj:and	_
 17	as	as	ADP	IN	_	19	case	19:case	_
 18	to	to	ADP	IN	_	17	fixed	17:fixed	_
 19	all	all	DET	DT	_	16	obl	16:obl:as_to	_
@@ -1272,7 +1272,7 @@
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0008
 # text = ALITO filed a dissenting opinion, in which SCALIA and THOMAS joined as to Parts I through III.
 1	ALITO	ALITO	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	filed	file	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	filed	file	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	dissenting	dissent	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	opinion	opinion	NOUN	NN	Number=Sing	2	obj	2:obj|12:obl	SpaceAfter=No
@@ -1282,7 +1282,7 @@
 9	SCALIA	SCALIA	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	THOMAS	THOMAS	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 13	as	as	ADP	IN	_	15	case	15:case	_
 14	to	to	ADP	IN	_	13	fixed	13:fixed	_
 15	Parts	part	NOUN	NNS	Number=Plur	12	obl	12:obl:as_to	_
@@ -1309,7 +1309,7 @@
 14	but	but	CCONJ	CC	_	17	cc	17:cc	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	rarely	rarely	ADV	RB	_	17	advmod	17:advmod	_
-17	agree	agree	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:but	_
+17	agree	agree	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:but	_
 18	with	with	ADP	IN	_	23	case	23:case	_
 19	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 20	John	John	PROPN	NNP	Number=Sing	23	compound	23:compound	_
@@ -1333,7 +1333,7 @@
 10	when	when	SCONJ	WRB	PronType=Int	13	mark	13:mark	_
 11-12	I'm	_	_	_	_	_	_	_	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-12	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
+12	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 13	finished	finished	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:when	SpaceAfter=No
 14	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -1422,7 +1422,7 @@
 # sent_id = weblog-blogspot.com_tacitusproject_20040715092419_ENG_20040715_092419-0002
 # text = I had to go to the BBC for this report .
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	go	go	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	to	to	ADP	IN	_	7	case	7:case	_
@@ -1441,7 +1441,7 @@
 3	symptomatic	symptomatic	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	6	punct	6:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	suppose	suppose	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	SpaceAfter=No
+6	suppose	suppose	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	SpaceAfter=No
 7	,	,	PUNCT	,	_	6	punct	6:punct	_
 8	of	of	ADP	IN	_	19	case	19:case	_
 9	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -1539,7 +1539,7 @@
 7	General	General	ADJ	NNP	Degree=Pos	6	amod	6:amod	_
 8	Kofi	Kofi	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 9	Annan	Annan	PROPN	NNP	Number=Sing	8	flat	8:flat	_
-10	demanded	demand	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+10	demanded	demand	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	steps	step	NOUN	NNS	Number=Plur	13	nsubj:pass	13:nsubj:pass	_
 12	be	be	AUX	VB	VerbForm=Inf	13	aux:pass	13:aux:pass	_
 13	taken	take	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	ccomp	10:ccomp	_
@@ -1605,7 +1605,7 @@
 1	And	and	CCONJ	CC	_	5	cc	5:cc	_
 2	international	international	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	donors	donor	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	given	give	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	only	only	ADV	RB	_	7	advmod	7:advmod	_
 7	half	half	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -1630,7 +1630,7 @@
 1	So	so	ADV	RB	_	4	advmod	4:advmod	_
 2	hear	hear	ADV	RB	_	4	advmod	4:advmod	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+4	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	two	two	NUM	CD	NumType=Card	7	nummod	7:nummod	_
 7	weeks	week	NOUN	NNS	Number=Plur	8	obl:npmod	8:obl:npmod	_
@@ -1764,7 +1764,7 @@
 17	that	that	SCONJ	IN	_	25	mark	25:mark	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	Gateses	Gates	PROPN	NNPS	Number=Plur	25	nsubj	25:nsubj	_
-20	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	cop	25:cop	_
+20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	cop	25:cop	_
 21	very	very	ADV	RB	_	22	advmod	22:advmod	_
 22	good	good	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 23	money	money	NOUN	NN	Number=Sing	25	compound	25:compound	SpaceAfter=No
@@ -1799,7 +1799,7 @@
 9	Bill	Bill	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj|15:nsubj:xsubj	_
 10	or	or	CCONJ	CC	_	11	cc	11:cc	_
 11	Melinda	Melinda	PROPN	NNP	Number=Sing	9	conj	9:conj:or|13:nsubj|15:nsubj:xsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 13	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	7	ccomp	7:ccomp	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	die	die	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
@@ -1809,7 +1809,7 @@
 # sent_id = weblog-blogspot.com_marketview_20060625150800_ENG_20060625_150800-0005
 # text = I assume his actual reason is that he's worried that Berkshire Hathaway just can't grow quickly enough to justify his usual charity policy.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	assume	assume	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	assume	assume	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	actual	actual	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	reason	reason	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
@@ -1841,7 +1841,7 @@
 # text = I'm not sure how the market will react.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	how	how	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
@@ -1883,7 +1883,7 @@
 26	once	once	SCONJ	IN	_	29	mark	29:mark	_
 27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
 28	shares	share	NOUN	NNS	Number=Plur	29	nsubj	29:nsubj|31:nsubj:xsubj	_
-29	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:once	_
+29	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:once	_
 30	more	more	ADV	RBR	_	29	advmod	29:advmod	_
 31	liquid	liquid	ADJ	JJ	Degree=Pos	29	xcomp	29:xcomp	SpaceAfter=No
 32	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -2002,7 +2002,7 @@
 16	each	each	DET	DT	_	17	det	17:det	_
 17	year	year	NOUN	NN	Number=Sing	11	obl:tmod	11:obl:tmod	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
-19	decrease	decrease	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+19	decrease	decrease	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 20	in	in	ADP	IN	_	21	case	21:case	_
 21	number	number	NOUN	NN	Number=Sing	19	obl	19:obl:in	_
 22	at	at	ADP	IN	_	24	case	24:case	_
@@ -2051,7 +2051,7 @@
 10	Bill	Bill	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
 12	Melinda	Melinda	PROPN	NNP	Number=Sing	10	conj	10:conj:and|13:nsubj	_
-13	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
+13	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
 14	at	at	ADP	IN	_	17	case	17:case	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 16	prime	prime	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -2115,7 +2115,7 @@
 23	in	in	ADP	IN	_	24	case	24:case	_
 24	Europe	Europe	PROPN	NNP	Number=Sing	22	nmod	22:nmod:in	SpaceAfter=No
 25	,	,	PUNCT	,	_	28	punct	28:punct	_
-26	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
+26	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
 27	basically	basically	ADV	RB	_	28	advmod	28:advmod	_
 28	accepting	accept	VERB	VBG	VerbForm=Ger	10	acl	10:acl:on	_
 29	terrorist	terrorist	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
@@ -2136,7 +2136,7 @@
 3	same	same	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	day	day	NOUN	NN	Number=Sing	19	obl	19:obl:on	_
 5	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	6	nsubj	6:nsubj	_
-6	protest	protest	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	protest	protest	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	support	support	NOUN	NN	Number=Sing	6	obl	6:obl:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
@@ -2244,7 +2244,7 @@
 26	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 27	placards	placard	NOUN	NNS	Number=Plur	24	nmod	24:nmod:on	_
 28	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-29	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	30	aux	30:aux	_
+29	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	aux	30:aux	_
 30	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	27	acl:relcl	27:acl:relcl	SpaceAfter=No
 31	"	"	PUNCT	''	_	24	punct	24:punct	SpaceAfter=No
 32	.	.	PUNCT	.	_	8	punct	8:punct	_
@@ -2319,7 +2319,7 @@
 40	of	of	ADP	IN	_	42	case	42:case	_
 41	innocent	innocent	ADJ	JJ	Degree=Pos	42	amod	42:amod	_
 42	civilians	civilian	NOUN	NNS	Number=Plur	39	nmod	39:nmod:of	_
-43	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	45	cop	45:cop	_
+43	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	cop	45:cop	_
 44	terrorist	terrorist	ADJ	JJ	Degree=Pos	45	amod	45:amod	_
 45	acts	act	NOUN	NNS	Number=Plur	35	acl	35:acl:whether	SpaceAfter=No
 46	.	.	PUNCT	.	_	25	punct	25:punct	_
@@ -2391,7 +2391,7 @@
 29	Hamas	Hamas	PROPN	NNP	Number=Sing	27	nmod	27:nmod:of	_
 30	and	and	CCONJ	CC	_	31	cc	31:cc	_
 31	Hezbollah	Hezbollah	PROPN	NNP	Number=Sing	29	conj	27:nmod:of|29:conj:and	_
-32	exploit	exploit	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:as	_
+32	exploit	exploit	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:as	_
 33	the	the	DET	DT	Definite=Def|PronType=Art	35	det	35:det	_
 34	inherent	inherent	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	weakness	weakness	NOUN	NN	Number=Sing	32	obj	32:obj	_
@@ -2407,7 +2407,7 @@
 # text = I've been fuming over this fact for a few weeks now, ever since some organizations and governments suggested we need to accept the fact that Hezbollah will get involved in running Lebanon.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	fuming	fume	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	over	over	ADP	IN	_	7	case	7:case	_
@@ -2425,9 +2425,9 @@
 17	organizations	organization	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	_
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	governments	government	NOUN	NNS	Number=Plur	17	conj	17:conj:and|20:nsubj	_
-20	suggested	suggest	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
+20	suggested	suggest	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 21	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	22	nsubj	22:nsubj|24:nsubj:xsubj	_
-22	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	ccomp	20:ccomp	_
+22	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	ccomp	20:ccomp	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	accept	accept	VERB	VB	VerbForm=Inf	22	xcomp	22:xcomp	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
@@ -2468,14 +2468,14 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	organization	organization	NOUN	NN	Number=Sing	0	root	0:root|6:nsubj|13:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	bombed	bomb	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	bombed	bomb	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 8	Marine	Marine	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	barracks	barracks	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	1983	1983	NUM	CD	NumType=Card	6	obl	6:obl:in	SpaceAfter=No
 12	,	,	PUNCT	,	_	13	punct	13:punct	_
-13	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	4:acl:relcl|6:conj	_
+13	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	4:acl:relcl|6:conj	_
 14	Americans	American	PROPN	NNPS	Number=Plur	13	obj	13:obj|15:nsubj:xsubj	_
 15	hostage	hostage	NOUN	NN	Number=Sing	13	xcomp	13:xcomp	_
 16	throughout	throughout	ADP	IN	_	18	case	18:case	_
@@ -2568,7 +2568,7 @@
 # text = The IIP had also been the main force urging Sunni Arabs to participate in the elections scheduled for January, and had been opposed in this stance by the Association of Muslim Scholars.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	IIP	IIP	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|24:nsubj:pass	_
-3	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
+3	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
 4	also	also	ADV	RB	_	8	advmod	8:advmod	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	8	cop	8:cop	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
@@ -2587,7 +2587,7 @@
 19	January	January	PROPN	NNP	Number=Sing	17	obl	17:obl:for	SpaceAfter=No
 20	,	,	PUNCT	,	_	24	punct	24:punct	_
 21	and	and	CCONJ	CC	_	24	cc	24:cc	_
-22	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	24	aux	24:aux	_
+22	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	24	aux	24:aux	_
 23	been	be	AUX	VBN	Tense=Past|VerbForm=Part	24	aux:pass	24:aux:pass	_
 24	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	conj	8:conj:and	_
 25	in	in	ADP	IN	_	27	case	27:case	_
@@ -2655,7 +2655,7 @@
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	Muslim	Muslim	ADJ	NNP	Degree=Pos	9	amod	9:amod	_
 9	Scholars	Scholar	PROPN	NNPS	Number=Plur	6	nmod	6:nmod:of	_
-10	forbade	forbid	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+10	forbade	forbid	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 11	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	10	obj	10:obj|13:nsubj:xsubj	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	participate	participate	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
@@ -2677,7 +2677,7 @@
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	AMS	AMS	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
-7	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	that	that	SCONJ	IN	_	39	mark	39:mark	_
 9	for	for	SCONJ	IN	_	12	mark	12:mark	_
 10	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	12	nsubj	12:nsubj	_
@@ -2723,15 +2723,15 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	Sunni	Sunni	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	AMS	AMS	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	4	obj	4:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	4	punct	4:punct	_
 7	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 8	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|23:nsubj	_
-9	sinned	sin	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
+9	sinned	sin	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	participated	participate	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:when	_
+12	participated	participate	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:when	_
 13	with	with	ADP	IN	_	15	case	15:case	_
 14	occupation	occupation	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	forces	force	NOUN	NNS	Number=Plur	12	obl	12:obl:with	_
@@ -2745,7 +2745,7 @@
 23	beware	beware	VERB	VB	Mood=Imp|VerbForm=Fin	9	conj	4:ccomp|9:conj:and	_
 24	lest	lest	SCONJ	IN	_	26	mark	26:mark	_
 25	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
-26	repeat	repeat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	advcl	23:advcl:lest	_
+26	repeat	repeat	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	23	advcl	23:advcl:lest	_
 27	this	this	DET	DT	Number=Sing|PronType=Dem	29	det	29:det	_
 28	same	same	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 29	sin	sin	NOUN	NN	Number=Sing	26	obj	26:obj	_
@@ -2772,7 +2772,7 @@
 3	Shiite	Shiite	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	Sadr	Sadr	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	movement	movement	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
-6	issued	issue	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	issued	issue	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	statement	statement	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	forbidding	forbid	VERB	VBG	VerbForm=Ger	8	acl	8:acl	_
@@ -2795,11 +2795,11 @@
 # text = The statement said, "We direct an appeal at the men in the Iraqi forces, whether national guards or others, the majority of whom are Muslim, calling upon them to refrain for commiting this enormous sin under the banner of forces that do not respect our religion or any principles of basic humanity, and we ask them to view this war as illegal."
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	statement	statement	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	"	"	PUNCT	``	_	3	punct	3:punct	SpaceAfter=No
 6	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	direct	direct	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+7	direct	direct	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 8	an	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	appeal	appeal	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	at	at	ADP	IN	_	12	case	12:case	_
@@ -2820,7 +2820,7 @@
 25	majority	majority	NOUN	NN	Number=Sing	29	nsubj	29:nsubj	_
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	whom	whom	PRON	WP	PronType=Int	25	nmod	12:ref	_
-28	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
+28	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
 29	Muslim	Muslim	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	SpaceAfter=No
 30	,	,	PUNCT	,	_	12	punct	12:punct	_
 31	calling	call	VERB	VBG	VerbForm=Ger	9	acl	9:acl	_
@@ -2839,7 +2839,7 @@
 44	of	of	ADP	IN	_	45	case	45:case	_
 45	forces	force	NOUN	NNS	Number=Plur	43	nmod	43:nmod:of|49:nsubj	_
 46	that	that	PRON	WDT	PronType=Rel	49	nsubj	45:ref	_
-47	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	49	aux	49:aux	_
+47	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	49	aux	49:aux	_
 48	not	not	PART	RB	_	49	advmod	49:advmod	_
 49	respect	respect	VERB	VB	VerbForm=Inf	45	acl:relcl	45:acl:relcl	_
 50	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	51	nmod:poss	51:nmod:poss	_
@@ -2853,7 +2853,7 @@
 58	,	,	PUNCT	,	_	61	punct	61:punct	_
 59	and	and	CCONJ	CC	_	61	cc	61:cc	_
 60	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	61	nsubj	61:nsubj	_
-61	ask	ask	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	3:ccomp|7:conj:and	_
+61	ask	ask	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	conj	3:ccomp|7:conj:and	_
 62	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	61	obj	61:obj|64:nsubj:xsubj	_
 63	to	to	PART	TO	_	64	mark	64:mark	_
 64	view	view	VERB	VB	VerbForm=Inf	61	xcomp	61:xcomp	_
@@ -2867,7 +2867,7 @@
 # sent_id = weblog-juancole.com_juancole_20041109060653_ENG_20041109_060653-0011
 # text = It called a "ploy" the assertaion that the attack was merely on foreign fighters at Fallujah.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	"	"	PUNCT	``	_	5	punct	5:punct	SpaceAfter=No
 5	ploy	ploy	NOUN	NN	Number=Sing	2	xcomp	2:xcomp	SpaceAfter=No
@@ -2943,7 +2943,7 @@
 3	,	,	PUNCT	,	_	8	punct	8:punct	_
 4	however	however	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	still	still	ADV	RB	_	8	advmod	8:advmod	_
 8	reluctant	reluctant	ADJ	JJ	Degree=Pos	0	root	0:root	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -2975,7 +2975,7 @@
 # text = President Bush pinched a few nerves yesterday with his choice of words:
 1	President	President	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	Bush	Bush	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-3	pinched	pinch	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	pinched	pinch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	few	few	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	nerves	nerve	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -3000,7 +3000,7 @@
 1	U.S.	U.S.	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 2	Muslim	Muslim	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	groups	group	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	criticized	criticize	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	criticized	criticize	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	President	President	PROPN	NNP	Number=Sing	4	obj	4:obj	_
 6	Bush	Bush	PROPN	NNP	Number=Sing	5	flat	5:flat	_
 7	on	on	ADP	IN	_	8	case	8:case	_
@@ -3037,7 +3037,7 @@
 # text = U.S. officials have said the plot, thwarted by Britain, to blow up several aircraft over the Atlantic bore many of the hallmarks of al Qaeda.
 1	U.S.	U.S.	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	officials	official	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	said	say	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	plot	plot	NOUN	NN	Number=Sing	20	nsubj	20:nsubj	SpaceAfter=No
@@ -3054,7 +3054,7 @@
 17	over	over	ADP	IN	_	19	case	19:case	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	Atlantic	Atlantic	PROPN	NNP	Number=Sing	13	obl	13:obl:over	_
-20	bore	bear	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
+20	bore	bear	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	_
 21	many	many	ADJ	JJ	Degree=Pos	20	obj	20:obj	_
 22	of	of	ADP	IN	_	24	case	24:case	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
@@ -3068,7 +3068,7 @@
 # text = "We believe this is an ill-advised term and we believe that it is counterproductive to associate Islam or Muslims with fascism," said Nihad Awad, executive director of the Council on American-Islamic Relations advocacy group.
 1	"	"	PUNCT	``	_	27	punct	27:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	27	ccomp	27:ccomp	_
+3	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	27	ccomp	27:ccomp	_
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	10	nsubj	10:nsubj	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 6	an	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
@@ -3078,7 +3078,7 @@
 10	term	term	NOUN	NN	Number=Sing	3	ccomp	3:ccomp	_
 11	and	and	CCONJ	CC	_	13	cc	13:cc	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|27:ccomp	_
+13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|27:ccomp	_
 14	that	that	SCONJ	IN	_	17	mark	17:mark	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	expl	17:expl	_
 16	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
@@ -3092,7 +3092,7 @@
 24	fascism	fascism	NOUN	NN	Number=Sing	19	obl	19:obl:with	SpaceAfter=No
 25	,	,	PUNCT	,	_	27	punct	27:punct	SpaceAfter=No
 26	"	"	PUNCT	''	_	27	punct	27:punct	_
-27	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+27	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 28	Nihad	Nihad	PROPN	NNP	Number=Sing	27	nsubj	27:nsubj	_
 29	Awad	Awad	PROPN	NNP	Number=Sing	28	flat	28:flat	SpaceAfter=No
 30	,	,	PUNCT	,	_	28	punct	28:punct	_
@@ -3117,12 +3117,12 @@
 3	why	why	ADV	WRB	PronType=Int	0	root	0:root	_
 4	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 5-6	didn't	_	_	_	_	_	_	_	_
-5	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
+5	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	_	7	advmod	7:advmod	_
 7	say	say	VERB	VB	VerbForm=Inf	3	acl:relcl	3:acl:relcl	_
 8-9	we're	_	_	_	_	_	_	_	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-9	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+9	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	at	at	ADP	IN	_	11	case	11:case	_
 11	war	war	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	_
 12	with	with	ADP	IN	_	14	case	14:case	_
@@ -3134,7 +3134,7 @@
 # text = We're at war with Islamic fascists.
 1-2	We're	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	at	at	ADP	IN	_	4	case	4:case	_
 4	war	war	NOUN	NN	Number=Sing	0	root	0:root	_
 5	with	with	ADP	IN	_	7	case	7:case	_
@@ -3174,7 +3174,7 @@
 2	if	if	SCONJ	IN	_	6	mark	6:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	haven't	_	_	_	_	_	_	_	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	_
 7	by	by	ADP	IN	_	8	case	8:case	_
@@ -3583,7 +3583,7 @@
 # text = We've got a Steven, the one word that didn't crash my spell-check, despite it being followed by a Vikash Chand Abdul Shakur.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	got	get	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	Steven	Steven	PROPN	NNP	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -3593,7 +3593,7 @@
 9	word	word	NOUN	NN	Number=Sing	5	appos	5:appos|13:nsubj	_
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj	9:ref	_
 11-12	didn't	_	_	_	_	_	_	_	_
-11	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
+11	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	_	13	advmod	13:advmod	_
 13	crash	crash	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
 14	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
@@ -3640,7 +3640,7 @@
 2	because	because	SCONJ	IN	_	6	mark	6:mark	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj|8:nsubj:xsubj|9:nsubj:xsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	want	want	VERB	VB	VerbForm=Inf	12	advcl	12:advcl:because	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
@@ -3695,11 +3695,11 @@
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	group	group	NOUN	NN	Number=Sing	23	nsubj	23:nsubj	_
 22	allegedly	allegedly	ADV	RB	_	23	advmod	23:advmod	_
-23	declared	declare	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+23	declared	declare	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 24	,	,	PUNCT	,	_	23	punct	23:punct	_
 25	"	"	PUNCT	``	_	23	punct	23:punct	SpaceAfter=No
 26	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
-27	announce	announce	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	ccomp	23:ccomp	_
+27	announce	announce	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	23	ccomp	23:ccomp	_
 28	that	that	SCONJ	IN	_	41	mark	41:mark	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 30	Tawhid	Tawhid	PROPN	NNP	Number=Sing	33	compound	33:compound	_
@@ -3712,7 +3712,7 @@
 37	and	and	CCONJ	CC	_	38	cc	38:cc	_
 38	soldiers	soldier	NOUN	NNS	Number=Plur	36	conj	33:appos|36:conj:and	SpaceAfter=No
 39	,	,	PUNCT	,	_	41	punct	41:punct	_
-40	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	41	aux	41:aux	_
+40	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	41	aux	41:aux	_
 41	pledged	pledge	VERB	VBN	Tense=Past|VerbForm=Part	27	ccomp	27:ccomp	_
 42	allegiance	allegiance	NOUN	NN	Number=Sing	41	obj	41:obj	_
 43	to	to	ADP	IN	_	45	case	45:case	_
@@ -3747,7 +3747,7 @@
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	group	group	NOUN	NN	Number=Sing	1	conj	1:conj:and|10:nsubj:pass|15:nsubj:xsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
 10	said	say	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 11	to	to	PART	TO	_	15	mark	15:mark	_
 12	have	have	AUX	VB	VerbForm=Inf	15	aux	15:aux	_
@@ -3775,10 +3775,10 @@
 6	trial	trial	NOUN	NN	Number=Sing	5	flat	5:flat	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Germany	Germany	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
-9	alleged	allege	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+9	alleged	allege	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 10	that	that	SCONJ	IN	_	14	mark	14:mark	_
 11	Zarqawi	Zarqawi	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
-12	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
+12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
 13	not	not	PART	RB	_	14	advmod	14:advmod	_
 14	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part	9	ccomp	9:ccomp	_
 15	Monotheism	Monotheism	PROPN	NNP	Number=Sing	14	obj	14:obj|20:nsubj:xsubj	_
@@ -3823,7 +3823,7 @@
 17	radical	radical	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 18	guerrilla	guerrilla	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	groups	group	NOUN	NNS	Number=Plur	23	nsubj:pass	23:nsubj:pass	_
-20	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
+20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 21	being	be	AUX	VBG	VerbForm=Ger	23	aux:pass	23:aux:pass	_
 22	"	"	PUNCT	``	_	23	punct	23:punct	SpaceAfter=No
 23	picked	pick	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl	11:acl:that	_
@@ -3894,7 +3894,7 @@
 16	Arabs	Arab	PROPN	NNPS	Number=Plur	8	nmod	8:nmod:of|19:nsubj	SpaceAfter=No
 17	"	"	PUNCT	''	_	16	punct	16:punct	_
 18	who	who	PRON	WP	PronType=Rel	19	nsubj	16:ref	_
-19	pledged	pledge	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
+19	pledged	pledge	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
 20	personal	personal	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	loyalty	loyalty	NOUN	NN	Number=Sing	19	obj	19:obj	_
 22	to	to	ADP	IN	_	23	case	23:case	_
@@ -3946,7 +3946,7 @@
 8	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 9	that	that	SCONJ	IN	_	13	mark	13:mark	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj:pass	13:nsubj:pass	_
-11	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux:pass	13:aux:pass	_
+11	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux:pass	13:aux:pass	_
 12	especially	especially	ADV	RB	_	13	advmod	13:advmod	_
 13	influenced	influence	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	ccomp	8:ccomp	_
 14	by	by	ADP	IN	_	17	case	17:case	_
@@ -3976,7 +3976,7 @@
 1	In	in	ADP	IN	_	2	case	2:case	_
 2	1998	1998	NUM	CD	NumType=Card	5	obl	5:obl:in	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
-4	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
+4	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 5	joined	join	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 6	by	by	ADP	IN	_	7	case	7:case	_
 7	Egyptians	Egyptian	PROPN	NNPS	Number=Plur	5	obl	5:obl:by	_
@@ -4060,7 +4060,7 @@
 13	in	in	ADP	IN	_	14	case	14:case	_
 14	Afghanistan	Afghanistan	PROPN	NNP	Number=Sing	12	nmod	12:nmod:in	_
 15	probably	probably	ADV	RB	_	16	advmod	16:advmod	_
-16	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+16	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	distinctive	distinctive	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	coloration	coloration	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -4077,7 +4077,7 @@
 # text = They also had a special connection to some extremists in Jordan and Germany.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	special	special	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	connection	connection	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -4093,7 +4093,7 @@
 # sent_id = weblog-juancole.com_juancole_20041018060600_ENG_20041018_060600-0015
 # text = They are probably especially oriented toward the Salafi school of modern Islamic thought, which has a Protestant-like emphasis on going back to the original practice of the early companions of the Prophet Muhammad.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux:pass	5:aux:pass	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 3	probably	probably	ADV	RB	_	5	advmod	5:advmod	_
 4	especially	especially	ADV	RB	_	5	advmod	5:advmod	_
 5	oriented	orient	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
@@ -4135,7 +4135,7 @@
 1	(	(	PUNCT	-LRB-	_	6	punct	6:punct	SpaceAfter=No
 2	Most	most	ADJ	JJS	Degree=Sup	3	amod	3:amod	_
 3	Salafis	Salafi	PROPN	NNPS	Number=Plur	6	nsubj	6:nsubj|8:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
 6	militant	militant	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	or	or	CCONJ	CC	_	8	cc	8:cc	_
@@ -4143,7 +4143,7 @@
 9	,	,	PUNCT	,	_	6	punct	6:punct	_
 10	though	though	SCONJ	IN	_	12	mark	12:mark	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj|18:nsubj:xsubj	_
-12	tend	tend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:though	_
+12	tend	tend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:though	_
 13	to	to	PART	TO	_	18	mark	18:mark	_
 14	be	be	AUX	VB	VerbForm=Inf	18	cop	18:cop	_
 15	rather	rather	ADV	RB	_	18	advmod	18:advmod	_
@@ -4194,7 +4194,7 @@
 27	among	among	ADP	IN	_	29	case	29:case	_
 28	early	early	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 29	Protestants	Protestant	PROPN	NNPS	Number=Plur	18	nmod	18:nmod:among	_
-30	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	SpaceAfter=No
+30	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	SpaceAfter=No
 31	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041018060600_ENG_20041018_060600-0018
@@ -4215,7 +4215,7 @@
 14	presence	presence	NOUN	NN	Number=Sing	10	obl	10:obl:to	_
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	Iraq	Iraq	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
-17	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
+17	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 18	begun	begin	VERB	VBN	Tense=Past|VerbForm=Part	4	ccomp	4:ccomp	_
 19	joining	join	VERB	VBG	VerbForm=Ger	18	xcomp	18:xcomp	_
 20	Monotheism	Monotheism	PROPN	NNP	Number=Sing	19	obj	19:obj	_
@@ -4236,7 +4236,7 @@
 # sent_id = weblog-juancole.com_juancole_20041018060600_ENG_20041018_060600-0019
 # text = These have been sighted among Iraqi crowds on Haifa Street in Baghdad and in Samarra.
 1	These	this	PRON	DT	Number=Plur|PronType=Dem	4	nsubj:pass	4:nsubj:pass	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux:pass	4:aux:pass	_
 4	sighted	sight	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 5	among	among	ADP	IN	_	7	case	7:case	_
@@ -4257,7 +4257,7 @@
 1	So	so	ADV	RB	_	4	advmod	4:advmod	_
 2	now	now	ADV	RB	_	4	advmod	4:advmod	_
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	hundreds	hundred	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 6	of	of	ADP	IN	_	10	case	10:case	_
 7	al	al	PROPN	NNP	Number=Sing	9	compound	9:compound	SpaceAfter=No
@@ -4268,7 +4268,7 @@
 12	Iraq	Iraq	PROPN	NNP	Number=Sing	10	nmod	10:nmod:in	_
 13	where	where	SCONJ	WRB	PronType=Rel	16	mark	16:mark	_
 14	there	there	PRON	EX	_	16	expl	16:expl	_
-15	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
+15	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
 17	none	none	NOUN	NN	Number=Sing	16	nsubj	16:nsubj	_
 18	before	before	ADV	RB	_	16	advmod	16:advmod	SpaceAfter=No
@@ -4302,7 +4302,7 @@
 24	in	in	ADP	IN	_	25	case	25:case	_
 25	Tangiers	tangier	NOUN	NNS	Number=Plur	16	obl	16:obl:in|27:nsubj	_
 26	that	that	PRON	WDT	PronType=Rel	27	nsubj	25:ref	_
-27	morphed	morph	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
+27	morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
 28	into	into	SCONJ	IN	_	35	mark	35:mark	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 30	Moroccan	Moroccan	PROPN	NNP	Number=Sing	33	compound	33:compound	_
@@ -4310,10 +4310,10 @@
 32	Combatant	Combatant	PROPN	NNP	Number=Sing	33	compound	33:compound	_
 33	Group	Group	PROPN	NNP	Number=Sing	35	nsubj	35:nsubj	_
 34	,	,	PUNCT	,	_	35	punct	35:punct	_
-35	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	27	advcl	27:advcl:into	_
+35	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	27	advcl	27:advcl:into	_
 36	members	member	NOUN	NNS	Number=Plur	35	obj	35:obj|38:nsubj|51:nsubj	_
 37	who	who	PRON	WP	PronType=Rel	38	nsubj	36:ref	_
-38	met	meet	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
+38	met	meet	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
 39	with	with	ADP	IN	_	42	case	42:case	_
 40	September	September	PROPN	NNP	Number=Sing	42	compound	42:compound	_
 41	11	11	NUM	CD	NumType=Card	40	nummod	40:nummod	_
@@ -4360,7 +4360,7 @@
 6	which	which	PRON	WDT	PronType=Rel	9	obl	4:ref	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	US	US	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
-9	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 10	key	key	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	mistakes	mistake	NOUN	NNS	Number=Plur	9	obj	9:obj|15:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj	11:ref	_
@@ -4392,15 +4392,15 @@
 # newpar id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-p0002
 # text = Bush came out today and said that if he had known what was coming, he would have expended every effort to stop it, and that so would have Clinton.
 1	Bush	Bush	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj|6:nsubj	_
-2	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	out	out	ADV	RB	_	2	advmod	2:advmod	_
 4	today	today	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+6	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 7	that	that	SCONJ	IN	_	19	mark	19:mark	_
 8	if	if	SCONJ	IN	_	11	mark	11:mark	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-10	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
+10	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
 11	known	know	VERB	VBN	Tense=Past|VerbForm=Part	19	advcl	19:advcl:if	_
 12	what	what	PRON	WP	PronType=Int	14	nsubj	14:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
@@ -4457,7 +4457,7 @@
 9	9/11	9/11	NUM	CD	NumType=Card	8	obj	8:obj	_
 10	if	if	SCONJ	IN	_	13	mark	13:mark	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-12	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
+12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 13	known	know	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:if	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 15	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
@@ -4498,13 +4498,13 @@
 # text = We now know that Bush and his administration came into office obsessed with Iraq.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	now	now	ADV	RB	_	3	advmod	3:advmod	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	that	that	SCONJ	IN	_	9	mark	9:mark	_
 5	Bush	Bush	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	administration	administration	NOUN	NN	Number=Sing	5	conj	5:conj:and|9:nsubj	_
-9	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 10	into	into	ADP	IN	_	11	case	11:case	_
 11	office	office	NOUN	NN	Number=Sing	9	obl	9:obl:into	_
 12	obsessed	obsessed	ADJ	JJ	Degree=Pos	9	advcl	9:advcl	_
@@ -4544,7 +4544,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0011
 # text = Wolfowitz contradicted counter-terrorism czar Richard Clarke when the latter spoke of the al-Qaeda threat, insisting that the preeminent threat of terrorism against the US came from Iraq, and indicating he accepted Laurie Mylroie's crackpot conspiracy theory that Saddam was behind the 1993 World Trade Towers bombing.
 1	Wolfowitz	Wolfowitz	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	contradicted	contradict	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	contradicted	contradict	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	counter-terrorism	counter-terrorism	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	czar	czar	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	Richard	Richard	PROPN	NNP	Number=Sing	2	obj	2:obj	_
@@ -4570,14 +4570,14 @@
 25	against	against	ADP	IN	_	27	case	27:case	_
 26	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 27	US	US	PROPN	NNP	Number=Sing	24	nmod	24:nmod:against	_
-28	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	ccomp	18:ccomp	_
+28	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	ccomp	18:ccomp	_
 29	from	from	ADP	IN	_	30	case	30:case	_
 30	Iraq	Iraq	PROPN	NNP	Number=Sing	28	obl	28:obl:from	SpaceAfter=No
 31	,	,	PUNCT	,	_	33	punct	33:punct	_
 32	and	and	CCONJ	CC	_	33	cc	33:cc	_
 33	indicating	indicate	VERB	VBG	VerbForm=Ger	18	conj	2:advcl|18:conj:and	_
 34	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	35	nsubj	35:nsubj	_
-35	accepted	accept	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	33	ccomp	33:ccomp	_
+35	accepted	accept	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	33	ccomp	33:ccomp	_
 36	Laurie	Laurie	PROPN	NNP	Number=Sing	41	nmod:poss	41:nmod:poss	_
 37-38	Mylroie's	_	_	_	_	_	_	_	_
 37	Mylroie	Mylroie	PROPN	NNP	Number=Sing	36	flat	36:flat	_
@@ -4601,7 +4601,7 @@
 # text = If you believe crackpot theories instead of focusing on the reality--that was an al-Qaeda operation mainly carried out by al-Gamaa al-Islamiyyah, an Egyptian terrorist component allied with Bin Laden-- then you will concentrate on the wrong threat.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	believe	believe	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	43	advcl	43:advcl:if	_
+3	believe	believe	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	43	advcl	43:advcl:if	_
 4	crackpot	crackpot	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	theories	theory	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	instead	instead	ADV	RB	_	8	mark	8:mark	_
@@ -4668,11 +4668,11 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0014
 # text = Wolfowitz lied to him and said that there was a 10 to 50% chance that Iraq was behind them.
 1	Wolfowitz	Wolfowitz	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj|6:nsubj	_
-2	lied	lie	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	lied	lie	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	4	case	4:case	_
 4	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	obl	2:obl:to	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+6	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 7	that	that	SCONJ	IN	_	9	mark	9:mark	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
 9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
@@ -4701,7 +4701,7 @@
 # text = The hijackers were obviously al-Qaeda, and no operational links between al-Qaeda and Iraq had ever been found).
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	hijackers	hijacker	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	cop	7:cop	_
 4	obviously	obviously	ADV	RB	_	7	advmod	7:advmod	_
 5	al	al	PROPN	NNP	Number=Sing	7	compound	7:compound	SpaceAfter=No
 6	-	-	PUNCT	HYPH	_	7	punct	7:punct	SpaceAfter=No
@@ -4717,7 +4717,7 @@
 16	Qaeda	Qaeda	PROPN	NNP	Number=Sing	12	nmod	12:nmod:between	_
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	Iraq	Iraq	PROPN	NNP	Number=Sing	16	conj	12:nmod:between|16:conj:and	_
-19	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	aux	22:aux	_
+19	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	22	aux	22:aux	_
 20	ever	ever	ADV	RB	_	22	advmod	22:advmod	_
 21	been	be	AUX	VBN	Tense=Past|VerbForm=Part	22	aux:pass	22:aux:pass	_
 22	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	conj	7:conj:and	SpaceAfter=No
@@ -4728,7 +4728,7 @@
 # text = Rumsfeld initially rejected an attack on al-Qaeda bases in Afghanistan, saying there were "no good targets" in Afghanistan.
 1	Rumsfeld	Rumsfeld	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
 2	initially	initially	ADV	RB	_	3	advmod	3:advmod	_
-3	rejected	reject	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	rejected	reject	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	attack	attack	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	on	on	ADP	IN	_	10	case	10:case	_
@@ -4741,7 +4741,7 @@
 13	,	,	PUNCT	,	_	3	punct	3:punct	_
 14	saying	say	VERB	VBG	VerbForm=Ger	3	advcl	3:advcl	_
 15	there	there	PRON	EX	_	16	expl	16:expl	_
-16	were	be	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	_
+16	were	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	_
 17	"	"	PUNCT	``	_	20	punct	20:punct	SpaceAfter=No
 18	no	no	DET	DT	_	20	det	20:det	_
 19	good	good	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
@@ -4762,7 +4762,7 @@
 7	Qaeda	Qaeda	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	bases	basis	NOUN	NNS	Number=Plur	2	nmod	2:nmod:about|11:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	11	nsubj	8:ref	_
-10	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
+10	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
 11	trained	train	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	9/11	9/11	NUM	CD	NumType=Card	14	nummod	14:nummod	_
@@ -4782,7 +4782,7 @@
 # text = The Pentagon did not even have a plan for dealing with Afghanistan or al-Qaeda that it could pull off the shelf, according to Bob Woodward.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	Pentagon	Pentagon	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-3	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
+3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
 4	not	not	PART	RB	_	6	advmod	6:advmod	_
 5	even	even	ADV	RB	_	6	advmod	6:advmod	_
 6	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -4813,7 +4813,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0020
 # text = Bush did not have his eye on the ball.
 1	Bush	Bush	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -4826,7 +4826,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0021
 # text = Neither did Cheney, Rumsfeld, or Wolfowitz.
 1	Neither	neither	CCONJ	CC	_	2	cc	2:cc	_
-2	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Cheney	Cheney	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
 5	Rumsfeld	Rumsfeld	PROPN	NNP	Number=Sing	3	conj	2:nsubj|3:conj:or	SpaceAfter=No
@@ -4838,7 +4838,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0022
 # text = They were playing Captain Ahab to Saddam's great white whale.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 3	playing	play	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	Captain	Captain	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Ahab	Ahab	PROPN	NNP	Number=Sing	3	obj	3:obj	_
@@ -4873,7 +4873,7 @@
 18	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 19	US	US	PROPN	NNP	Number=Sing	20	compound	20:compound	_
 20	government	government	NOUN	NN	Number=Sing	15	nmod	15:nmod:in	_
-21	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl	5:acl:that	_
+21	knew	know	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	acl	5:acl:that	_
 22	all	all	ADV	RB	_	24	advmod	24:advmod	_
 23	about	about	ADP	IN	_	24	case	24:case	_
 24	Bin	Bin	PROPN	NNP	Number=Sing	21	obl	21:obl:about	_
@@ -4882,13 +4882,13 @@
 27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
 28	threat	threat	NOUN	NN	Number=Sing	24	conj	21:obl:about|24:conj:and	_
 29	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	posed	pose	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	SpaceAfter=No
+30	posed	pose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	SpaceAfter=No
 31	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0024
 # text = They were from all accounts marginalized and not listened to.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj:pass	6:nsubj:pass|9:nsubj:pass	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 3	from	from	ADP	IN	_	5	case	5:case	_
 4	all	all	DET	DT	_	5	det	5:det	_
 5	accounts	account	NOUN	NNS	Number=Plur	6	obl	6:obl:from	_
@@ -4902,7 +4902,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0025
 # text = Bush demoted Dick Clarke, among the most vocal and focused of the al-Qaeda experts, from his cabinet.
 1	Bush	Bush	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	demoted	demote	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	demoted	demote	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Dick	Dick	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 4	Clarke	Clarke	PROPN	NNP	Number=Sing	3	flat	3:flat	SpaceAfter=No
 5	,	,	PUNCT	,	_	3	punct	3:punct	_
@@ -4940,7 +4940,7 @@
 12	officers	officer	NOUN	NNS	Number=Plur	8	nmod	8:nmod:from|15:nsubj	SpaceAfter=No
 13	,	,	PUNCT	,	_	12	punct	12:punct	_
 14	who	who	PRON	WP	PronType=Rel	15	nsubj	12:ref	_
-15	outranked	outrank	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+15	outranked	outrank	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 16	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obj	15:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	22	punct	22:punct	_
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
@@ -5006,7 +5006,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0028
 # text = Clinton had worked out a deal with Pakistani Prime Minister Nawaz Sharif in summer of 1999 that would have allowed the US to send a Special Ops team in after Bin Laden in Qandahar, based from Pakistan.
 1	Clinton	Clinton	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-2	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+2	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 3	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -5048,9 +5048,9 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0029
 # text = I presume you need the Pakistan base for rescue operations in case anything went wrong.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	presume	presume	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	presume	presume	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+4	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	Pakistan	Pakistan	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 7	base	base	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -5060,7 +5060,7 @@
 11	in	in	SCONJ	IN	_	14	mark	14:mark	_
 12	case	case	NOUN	NN	Number=Sing	11	fixed	11:fixed	_
 13	anything	anything	PRON	NN	Number=Sing	14	nsubj	14:nsubj|15:nsubj:xsubj	_
-14	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:in_case	_
+14	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:in_case	_
 15	wrong	wrong	ADJ	JJ	Degree=Pos	14	xcomp	14:xcomp	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -5068,7 +5068,7 @@
 # text = You also need Pakistani air space.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	Pakistani	Pakistani	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	air	air	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	space	space	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -5098,7 +5098,7 @@
 7	Gen.	Gen.	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
 8	Pervez	Pervez	PROPN	NNP	Number=Sing	7	flat	7:flat	_
 9	Musharraf	Musharraf	PROPN	NNP	Number=Sing	7	flat	7:flat	_
-10	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+10	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	coup	coup	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	against	against	ADP	IN	_	14	case	14:case	_
@@ -5125,7 +5125,7 @@
 15	new	new	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 16	military	military	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	government	government	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
-18	reneged	renege	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+18	reneged	renege	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 19	on	on	ADP	IN	_	21	case	21:case	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	deal	deal	NOUN	NN	Number=Sing	18	obl	18:obl:on	SpaceAfter=No
@@ -5134,7 +5134,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0034
 # text = Musharraf told Clinton he couldn't use Pakistani soil or air space to send the team in against Bin Laden.
 1	Musharraf	Musharraf	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Clinton	Clinton	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 4	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 5-6	couldn't	_	_	_	_	_	_	_	_
@@ -5164,7 +5164,7 @@
 4	map	map	NOUN	NN	Number=Sing	1	obl	1:obl:at	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
-7	try	try	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
+7	try	try	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	figure	figure	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
@@ -5237,10 +5237,10 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0039
 # text = Clinton tried, and tried hard.
 1	Clinton	Clinton	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj|5:nsubj	_
-2	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	,	,	PUNCT	,	_	5	punct	5:punct	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
-5	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+5	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 6	hard	hard	ADV	RB	Degree=Pos	5	advmod	5:advmod	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -5249,7 +5249,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	gods	god	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
 3-4	weren't	_	_	_	_	_	_	_	_
-3	were	be	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	n't	not	PART	RB	_	3	advmod	3:advmod	_
 5	with	with	ADP	IN	_	6	case	6:case	_
 6	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	3	obl	3:obl:with	_
@@ -5266,7 +5266,7 @@
 2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	obj	5:obj|8:nsubj:xsubj	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	refer	refer	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
@@ -5283,7 +5283,7 @@
 # text = i don't think so.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	so	so	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
@@ -5294,7 +5294,7 @@
 # text = i'm the king
 1-2	i'm	_	_	_	_	_	_	_	_
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	king	king	NOUN	NN	Number=Sing	0	root	0:root	_
 
@@ -5322,7 +5322,7 @@
 7	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obl	3:obl:with	_
 8	before	before	SCONJ	IN	_	10	mark	10:mark	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:before	_
+10	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:before	_
 11	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 12	'	'	PUNCT	``	_	14	punct	14:punct	SpaceAfter=No
 13	matt	matt	PROPN	NNP	Number=Sing	14	compound	14:compound	_
@@ -5345,7 +5345,7 @@
 # newpar id = email-enronsent23_01-p0001
 # text = you know, whatever.
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
 4	whatever	whatever	PRON	WP	PronType=Int	2	parataxis	2:parataxis	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -5363,7 +5363,7 @@
 # sent_id = email-enronsent23_01-0003
 # text = what are you doing tonight.
 1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	tonight	tonight	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	SpaceAfter=No
@@ -5393,14 +5393,14 @@
 # text = your retarded.
 1-2	your	_	_	_	_	_	_	_	_
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-2	r	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	retarded	retarded	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_05-0002
 # text = i used to have one.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	have	have	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	one	one	NUM	CD	NumType=Card	4	obj	4:obj	SpaceAfter=No
@@ -5409,7 +5409,7 @@
 # sent_id = email-enronsent23_05-0003
 # text = they are great dogs.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	great	great	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	dogs	dog	NOUN	NNS	Number=Plur	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -5417,16 +5417,16 @@
 # sent_id = email-enronsent23_05-0004
 # newpar id = email-enronsent23_05-p0002
 # text = cockerspaniels are retarded.
-1	cocker	cocker	NOUN	NN	Number=Sing	2	compound	2:compound	SpaceAfter=No|CorrectSpaceAfter=Yes
+1	cocker	cocker	NOUN	NN	Number=Sing	2	compound	2:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
 2	spaniels	spaniel	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	retarded	retarded	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent23_05-0005
 # text = why do you think i should get one of those?
 1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
@@ -5446,7 +5446,7 @@
 2	n't	not	PART	RB	_	3	advmod	3:advmod	_
 3	believe	believe	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+5	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 6	last	last	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	night	night	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -5467,7 +5467,7 @@
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 6-7	don't	_	_	_	_	_	_	_	_
-6	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	_	8	advmod	8:advmod	_
 8	want	want	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -5477,7 +5477,7 @@
 13	,	,	PUNCT	,	_	3	punct	3:punct	_
 14	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
 15	just	just	ADV	RB	_	16	advmod	16:advmod	_
-16	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+16	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	make	make	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
 19	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
@@ -5551,7 +5551,7 @@
 # sent_id = email-enronsent23_02-0005
 # text = what do you think?
 1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -5599,7 +5599,7 @@
 10	other	other	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	girl	girl	NOUN	NN	Number=Sing	6	obl	6:obl:with	_
 12	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	bet	bet	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	with	with	ADP	IN	_	13	obl	13:obl	SpaceAfter=No
@@ -5615,13 +5615,13 @@
 1	really	really	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	no	no	DET	DT	_	6	det	6:det	_
 6	idea	idea	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	what	what	PRON	WP	PronType=Int	10	obl	10:obl:about	_
 8-9	you're	_	_	_	_	_	_	_	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-9	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+9	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 10	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl	6:acl	_
 11	about	about	ADP	IN	_	7	case	7:case	SpaceAfter=No
 12	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -5641,7 +5641,7 @@
 # text = i don't even like a&m, i wouldn't bet on them.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	n't	not	PART	RB	_	5	advmod	5:advmod	_
 4	even	even	ADV	RB	_	5	advmod	5:advmod	_
 5	like	like	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -5660,7 +5660,7 @@
 # newpar id = email-enronsent23_06-p0002
 # text = colorado beat texas a&m.
 1	colorado	colorado	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	beat	beat	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	beat	beat	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	texas	texas	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	a&m	a&m	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -5668,9 +5668,9 @@
 # sent_id = email-enronsent23_06-0009
 # text = i know you remember the bet.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	remember	remember	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+4	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	bet	bet	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -5685,7 +5685,7 @@
 # sent_id = email-enronsent23_07-0002
 # text = i got her number though.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	number	number	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	though	though	ADV	RB	_	2	discourse	2:discourse	SpaceAfter=No
@@ -5694,7 +5694,7 @@
 # sent_id = email-enronsent23_07-0003
 # text = i want to hook up with that girl paige in the brown leather jacket.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	hook	hook	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	up	up	ADP	RP	_	4	compound:prt	4:compound:prt	_
@@ -5712,7 +5712,7 @@
 # sent_id = email-enronsent23_07-0004
 # text = what happened to you?
 1	what	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	happened	happen	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	happened	happen	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	4	case	4:case	_
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obl	2:obl:to	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -5720,7 +5720,7 @@
 # sent_id = email-enronsent23_07-0005
 # text = i had a blast that night.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	blast	blast	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	that	that	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
@@ -5730,7 +5730,7 @@
 # sent_id = email-enronsent23_07-0006
 # newpar id = email-enronsent23_07-p0002
 # text = did you hook up with that blonde chick saturday night?
-1	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+1	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	hook	hook	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	_
@@ -5755,7 +5755,7 @@
 # sent_id = email-enronsent23_07-0008
 # text = i flew here last night.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	flew	fly	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	flew	fly	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	here	here	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
 4	last	last	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	night	night	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	SpaceAfter=No
@@ -5763,7 +5763,7 @@
 
 # sent_id = email-enronsent23_07-0009
 # text = are you lying?
-1	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	lying	lie	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -5795,7 +5795,7 @@
 5	dinner	dinner	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	when	when	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
+8	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 9	back	back	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -5807,7 +5807,7 @@
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-5	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	SpaceAfter=No
+5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_03-0002
@@ -5866,7 +5866,7 @@
 # sent_id = email-enronsent23_03-0006
 # text = I heard that more may be going up for sale in the next month or do.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	heard	hear	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	heard	hear	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	7	mark	7:mark	_
 4	more	more	ADJ	JJR	Degree=Cmp	7	nsubj	7:nsubj	_
 5	may	may	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -5886,7 +5886,7 @@
 # sent_id = email-enronsent23_03-0007
 # text = Someone told me that Chase is planning a shitload of layoffs.
 1	Someone	someone	PRON	NN	Number=Sing	2	nsubj	2:nsubj	_
-2	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	iobj	2:iobj	_
 4	that	that	SCONJ	IN	_	7	mark	7:mark	_
 5	Chase	Chase	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
@@ -5957,13 +5957,13 @@
 # text = I just got your email and I certainly concur with Jeff making the call.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	email	email	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	9	cc	9:cc	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	certainly	certainly	ADV	RB	_	9	advmod	9:advmod	_
-9	concur	concur	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+9	concur	concur	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 10	with	with	SCONJ	IN	_	12	mark	12:mark	_
 11	Jeff	Jeff	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 12	making	make	VERB	VBG	VerbForm=Ger	9	advcl	9:advcl:with	_
@@ -5991,10 +5991,10 @@
 4	risk	risk	NOUN	NN	Number=Sing	0	root	0:root|7:obj	_
 5	that	that	PRON	WDT	PronType=Rel	7	obj	4:ref	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
+10	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
 11	have	have	VERB	VB	VerbForm=Inf	4	conj	4:conj:but|7:obj	_
 12	assurances	assurance	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 13	from	from	ADP	IN	_	14	case	14:case	_
@@ -6007,7 +6007,7 @@
 # text = I don't know how much it will help however.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
@@ -6037,7 +6037,7 @@
 15	sure	sure	ADJ	JJ	Degree=Pos	8	conj	8:conj:but	_
 16-17	you've	_	_	_	_	_	_	_	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
-17	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	already	already	ADV	RB	_	19	advmod	19:advmod	_
 19	gone	go	VERB	VBN	Tense=Past|VerbForm=Part	15	ccomp	15:ccomp	_
 20	through	through	ADP	IN	_	21	case	21:case	_
@@ -6054,7 +6054,7 @@
 4	how	how	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	details	detail	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj|8:nsubj:xsubj	_
-7	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+7	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 8	fuzzy	fuzzy	ADJ	JJ	Degree=Pos	7	xcomp	7:xcomp	_
 9	on	on	ADP	IN	_	12	case	12:case	_
 10	an	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -6066,7 +6066,7 @@
 # text = When you discussed it, i was trying to think back to our remedies and discussions but the 3 years have made it difficult.
 1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
+3	discussed	discuss	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
@@ -6084,7 +6084,7 @@
 18	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 19	3	3	NUM	CD	NumType=Card	20	nummod	20:nummod	_
 20	years	year	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	_
-21	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
+21	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
 22	made	make	VERB	VBN	Tense=Past|VerbForm=Part	8	conj	8:conj:but	_
 23	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	22	obj	22:obj|24:nsubj:xsubj	_
 24	difficult	difficult	ADJ	JJ	Degree=Pos	22	xcomp	22:xcomp	SpaceAfter=No
@@ -6094,7 +6094,7 @@
 # text = I don't know if there is anything I can do but I'm always willing to help.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
@@ -6107,7 +6107,7 @@
 12	but	but	CCONJ	CC	_	16	cc	16:cc	_
 13-14	I'm	_	_	_	_	_	_	_	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
-14	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
+14	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 15	always	always	ADV	RB	_	16	advmod	16:advmod	_
 16	willing	willing	ADJ	JJ	Degree=Pos	4	conj	4:conj:but	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
@@ -6131,7 +6131,7 @@
 # text = These guys tried the Ken Lay route.
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	tried	try	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 5	Ken	Ken	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 6	Lay	Lay	PROPN	NNP	Number=Sing	5	flat	5:flat	_
@@ -6142,7 +6142,7 @@
 # text = Now they are part of your working group.
 1	Now	now	ADV	RB	_	4	advmod	4:advmod	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	part	part	NOUN	NN	Number=Sing	0	root	0:root	_
 5	of	of	ADP	IN	_	8	case	8:case	_
 6	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
@@ -6215,7 +6215,7 @@
 29	Capital	Capital	PROPN	NNP	Number=Sing	30	compound	30:compound	_
 30	Markets	Market	PROPN	NNPS	Number=Plur	25	nmod	25:nmod:of	_
 31	and	and	CCONJ	CC	_	32	cc	32:cc	_
-32	J.	J.	PROPN	NNP	Number=Sing	30	conj	25:nmod:of|30:conj:and	SpaceAfter=No|CorrectSpaceAfter=Yes
+32	J.	J.	PROPN	NNP	Number=Sing	30	conj	25:nmod:of|30:conj:and	CorrectSpaceAfter=Yes|SpaceAfter=No
 33	Aron	Aron	PROPN	NNP	Number=Sing	32	flat	32:flat	SpaceAfter=No
 34	.	.	PUNCT	.	_	16	punct	16:punct	_
 
@@ -6258,7 +6258,7 @@
 # newpar id = email-enronsent21_01-p0005
 # text = I know you must be going nuts with all the events, so I have not called.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|7:nsubj:xsubj	_
 4	must	must	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux	6:aux	_
@@ -6271,7 +6271,7 @@
 12	,	,	PUNCT	,	_	17	punct	17:punct	_
 13	so	so	ADV	RB	_	17	advmod	17:advmod	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-15	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
+15	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	not	not	PART	RB	_	17	advmod	17:advmod	_
 17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -6279,7 +6279,7 @@
 # sent_id = email-enronsent21_01-0010
 # newpar id = email-enronsent21_01-p0006
 # text = Hope you will be sorted.
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
 3	will	will	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	be	be	AUX	VB	VerbForm=Inf	5	aux:pass	5:aux:pass	_
@@ -6292,7 +6292,7 @@
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
 6	time	time	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -6317,7 +6317,7 @@
 # sent_id = email-enronsent21_01-0015
 # text = There are only two counterparties at this time who have overdue margin:
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root|10:nsubj	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root|10:nsubj	_
 3	only	only	ADV	RB	_	5	advmod	5:advmod	_
 4	two	two	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	counterparties	counterparty	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
@@ -6325,7 +6325,7 @@
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	time	time	NOUN	NN	Number=Sing	2	obl	2:obl:at	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	2:ref	_
-10	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+10	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 11	overdue	overdue	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	margin	margin	NOUN	NN	Number=Sing	10	obj	10:obj	SpaceAfter=No
 13	:	:	PUNCT	:	_	2	punct	2:punct	_
@@ -6377,7 +6377,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
 8	any	any	DET	DT	_	10	det	10:det	_
 9	additional	additional	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	information	information	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
@@ -6396,7 +6396,7 @@
 3	,	,	PUNCT	,	_	6	punct	6:punct	_
 4	but	but	CCONJ	CC	_	6	cc	6:cc	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	assume	assume	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
+6	assume	assume	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
 7	that	that	SCONJ	IN	_	12	mark	12:mark	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	bluegrass	bluegrass	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -6446,7 +6446,7 @@
 # sent_id = email-enronsent04_02-0006
 # text = We have this report?
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	report	report	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -6460,7 +6460,7 @@
 
 # sent_id = email-enronsent04_02-0008
 # text = Thought that you might be interested.
-1	Thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	that	that	SCONJ	IN	_	6	mark	6:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4	might	might	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
@@ -6484,13 +6484,13 @@
 1	Well	well	INTJ	UH	_	4	discourse	4:discourse	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	launched	launch	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	today	today	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	SpaceAfter=No
 6	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent04_02-0012
 # text = Have you seen the materials from the press conference that he launched today?
-1	Have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
@@ -6501,14 +6501,14 @@
 9	conference	conference	NOUN	NN	Number=Sing	5	nmod	5:nmod:from|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	launched	launch	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+12	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 13	today	today	NOUN	NN	Number=Sing	12	obl:tmod	12:obl:tmod	SpaceAfter=No
 14	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent04_02-0013
 # text = I think this is actually a good thing--makes our proposal look like a much more preferable alternative by comparison, makes our support in the process more important, and sets Harvey up as the Ralph Nader equivalent in the election to fix California's broken system---a potential spoiler.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	this	this	PRON	DT	Number=Sing|PronType=Dem	8	nsubj	8:nsubj	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 5	actually	actually	ADV	RB	_	8	advmod	8:advmod	_
@@ -6584,14 +6584,14 @@
 # text = I'm not driving tonite, but I bet that we could hitch a ride back with Anil.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	driving	drive	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	tonite	tonite	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
 7	but	but	CCONJ	CC	_	9	cc	9:cc	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	bet	bet	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+9	bet	bet	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 10	that	that	SCONJ	IN	_	13	mark	13:mark	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 12	could	could	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
@@ -6607,13 +6607,13 @@
 # text = I'm not sure, but I think that he's got class tonite, too.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	not	not	PART	RB	_	4	advmod	4:advmod	_
 4	sure	sure	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	but	but	CCONJ	CC	_	8	cc	8:cc	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+8	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 9	that	that	SCONJ	IN	_	12	mark	12:mark	_
 10-11	he's	_	_	_	_	_	_	_	_
 10	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
@@ -6662,14 +6662,14 @@
 # sent_id = email-enronsent23_04-0002
 # text = we are finished.
 1	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	finished	finished	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_04-0003
 # text = i need to now get a job at house of pies b/c that is the only way to pay the bills.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|5:nsubj:xsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	5	mark	5:mark	_
 4	now	now	ADV	RB	_	5	advmod	5:advmod	_
 5	get	get	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
@@ -6740,13 +6740,13 @@
 2	n't	not	PART	RB	_	3	advmod	3:advmod	_
 3	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	to	to	ADP	IN	_	8	case	8:case	_
-5	any	any	DET	DT	_	8	det	8:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+5	any	any	DET	DT	_	8	det	8:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 6	more	more	ADJ	JJR	Degree=Cmp	8	amod	8:amod	_
 7	lsu	lsu	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	games	game	NOUN	NNS	Number=Plur	3	obl	3:obl:to	_
 9	unless	unless	SCONJ	IN	_	11	mark	11:mark	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:unless	_
+11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:unless	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 13	free	free	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	ticket	ticket	NOUN	NN	Number=Sing	11	obj	11:obj	SpaceAfter=No
@@ -6814,7 +6814,7 @@
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	lesson	lesson	NOUN	NN	Number=Sing	0	root	0:root	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-17	learned	learn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	following	follow	VERB	VBG	VerbForm=Ger	21	case	21:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	Ark	Ark	PROPN	NNP	Number=Sing	21	compound	21:compound	_
@@ -6848,12 +6848,12 @@
 # newpar id = email-enronsent23_04-p0003
 # text = i have stronger will than you think.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	stronger	strong	ADJ	JJR	Degree=Cmp	4	amod	4:amod	_
 4	will	will	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	than	than	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:than	SpaceAfter=No
+7	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:than	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_04-0015
@@ -6863,7 +6863,7 @@
 3	pies	Pie	PROPN	NNPS	Number=Plur	1	nmod	1:nmod:of	_
 4	here	here	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+6	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent23_04-0016
@@ -6897,7 +6897,7 @@
 # text = i didn't want you to go.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	didn't	_	_	_	_	_	_	_	_
-2	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
+2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	4	obj	4:obj|7:nsubj:xsubj	_
@@ -6947,7 +6947,7 @@
 # sent_id = email-enronsent18_01-0002
 # text = We are still trying to work the PSE swap transaction, now that the forex desk has been able to find a fix for CPI in the market.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
 4	trying	try	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -6987,7 +6987,7 @@
 7	colleagues	colleague	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	_
 8	in	in	ADP	IN	_	9	case	9:case	_
 9	credit	credit	NOUN	NN	Number=Sing	7	nmod	7:nmod:in	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	calculating	calculate	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	reserve	reserve	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -7000,7 +7000,7 @@
 # sent_id = email-enronsent18_01-0004
 # text = They are currently using 9.5% fixed based on the 1 year implied volatility.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	currently	currently	ADV	RB	_	4	advmod	4:advmod	_
 4	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 5	9.5	9.5	NUM	CD	NumType=Card	6	nummod	6:nummod	SpaceAfter=No
@@ -7099,7 +7099,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 2	credit	credit	NOUN	NN	Number=Sing	3	compound	3:compound	_
 3	guys	guy	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|17:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	currently	currently	ADV	RB	_	6	advmod	6:advmod	_
 6	assuming	assume	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 7	that	that	SCONJ	IN	_	9	mark	9:mark	_
@@ -7148,7 +7148,7 @@
 # newpar id = email-enronsent18_01-p0002
 # text = I met you at the Risk conference last week in Houston.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	met	meet	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	met	meet	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obj	2:obj	_
 4	at	at	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -7163,7 +7163,7 @@
 # sent_id = email-enronsent18_01-0014
 # text = I enjoyed your presentations very much.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	presentations	presentation	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	very	very	ADV	RB	_	6	advmod	6:advmod	_
@@ -7196,7 +7196,7 @@
 
 # sent_id = email-enronsent18_01-0016
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -7258,7 +7258,7 @@
 # sent_id = email-enronsent32_02-0003
 # text = I have settled the Ecogas/Enron/Randy Maffett lawsuit.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	settled	settle	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 5	Ecogas	Ecogas	PROPN	NNP	Number=Sing	11	compound	11:compound	SpaceAfter=No
@@ -7289,7 +7289,7 @@
 1	Seriously	seriously	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	talked	talk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	talked	talk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
 6	morning	morning	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	_
 7	with	with	ADP	IN	_	8	case	8:case	_
@@ -7297,7 +7297,7 @@
 9	Hall	Hall	PROPN	NNP	Number=Sing	8	flat	8:flat	_
 10	and	and	CCONJ	CC	_	12	cc	12:cc	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	agreed	agree	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+12	agreed	agree	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 13	that	that	SCONJ	IN	_	16	mark	16:mark	_
 14	Ecogas	Ecogas	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj	_
 15	would	would	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
@@ -7368,7 +7368,7 @@
 # sent_id = email-enronsent32_02-0009
 # text = I have asked Doug Daniels to prepare the settlement papers reflecting such an agreement.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Doug	Doug	PROPN	NNP	Number=Sing	3	obj	3:obj|7:nsubj:xsubj	_
 5	Daniels	Daniels	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -7433,7 +7433,7 @@
 
 # sent_id = email-enronsent32_02-0015
 # text = Thank you for your help in tracking these invoices.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
@@ -7557,7 +7557,7 @@
 # sent_id = email-enronsent32_02-0024
 # text = We are renewing our L/C's on a month to month basis for the PX per Sanders.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	renewing	renew	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	L/C's	l/c's	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -7600,7 +7600,7 @@
 # sent_id = email-enronsent32_02-0026
 # text = I agree with Steve's position stated in his separate e'mail.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	agree	agree	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	agree	agree	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	with	with	ADP	IN	_	6	case	6:case	_
 4-5	Steve's	_	_	_	_	_	_	_	_
 4	Steve	Steve	PROPN	NNP	Number=Sing	6	nmod:poss	6:nmod:poss	_
@@ -7635,7 +7635,7 @@
 # text = Tracy, Do we have concerns here.
 1	Tracy	Tracy	PROPN	NNP	Number=Sing	5	vocative	5:vocative	SpaceAfter=No
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
-3	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	Do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	concerns	concern	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -7645,7 +7645,7 @@
 # sent_id = email-enronsent32_02-0030
 # text = We pointed out to the PX that there was excess credit.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	pointed	point	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	pointed	point	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	out	out	ADP	RP	_	2	compound:prt	2:compound:prt	_
 4	to	to	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -7666,7 +7666,7 @@
 5	pay	pay	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 6	these	this	DET	DT	Number=Plur|PronType=Dem	7	det	7:det	_
 7	bills	bill	NOUN	NNS	Number=Plur	5	obj	5:obj	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	not	not	PART	RB	_	11	advmod	11:advmod	_
 11	keeping	keep	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
@@ -7768,7 +7768,7 @@
 # sent_id = email-enronsent36_01-0010
 # text = I spoke with Mike Collins [203-719-8385 (phone) and 203-719-7031 (fax)] who conrfirmed to me that the cap included the remaining 2.5+million remaining shares.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	spoke	speak	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	spoke	speak	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	with	with	ADP	IN	_	4	case	4:case	_
 4	Mike	Mike	PROPN	NNP	Number=Sing	2	obl	2:obl:with|18:nsubj	_
 5	Collins	Collins	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -7784,13 +7784,13 @@
 15	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 16	]	]	PUNCT	-RRB-	_	7	punct	7:punct	_
 17	who	who	PRON	WP	PronType=Rel	18	nsubj	4:ref	_
-18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	18	obl	18:obl:to	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	cap	cap	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	_
-24	included	include	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	ccomp	18:ccomp	_
+24	included	include	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	ccomp	18:ccomp	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 26	remaining	remain	VERB	VBG	VerbForm=Ger	31	amod	31:amod	_
 27	2.5	2.5	NUM	CD	NumType=Card	29	compound	29:compound	SpaceAfter=No
@@ -7903,7 +7903,7 @@
 # text = Currently we have a blank "sample" for our Paragraph 13s which are attached to our sample ISDAs for (a) US Corporate, (b) Hedge Funds, (c) Municipal.
 1	Currently	currently	ADV	RB	_	3	advmod	3:advmod	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 5	blank	blank	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
@@ -7914,7 +7914,7 @@
 11	Paragraph	paragraph	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	13s	13	NOUN	NNS	Number=Plur	7	nmod	7:nmod:for|15:nsubj:pass	_
 13	which	which	PRON	WDT	PronType=Rel	15	nsubj:pass	12:ref	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux:pass	15:aux:pass	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux:pass	15:aux:pass	_
 15	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
 16	to	to	ADP	IN	_	19	case	19:case	_
 17	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -8033,7 +8033,7 @@
 7	even	even	ADV	RB	_	10	advmod	10:advmod	_
 8	though	though	SCONJ	IN	_	10	mark	10:mark	_
 9	there	there	PRON	EX	_	10	expl	10:expl	_
-10	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:though	_
+10	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:though	_
 11	blanks	blank	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -8067,7 +8067,7 @@
 # text = I just wanted to follow up on whether you will have a chance to send a draft Credit Support Annex (similar in form to the one previously executed with ENA).
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	follow	follow	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	up	up	ADP	RP	_	5	compound:prt	5:compound:prt	_
@@ -8102,7 +8102,7 @@
 # sent_id = email-enronsent36_01-0033
 # text = I understand you may not have credit approval yet so perhaps we can leave the appropriate sections blank in the meantime.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	understand	understand	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	understand	understand	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4	may	may	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
@@ -8219,12 +8219,12 @@
 # sent_id = email-enronsent09_02-0005
 # text = Pat had told me before he left that it would help me better grasp the process as a whole.
 1	Pat	Pat	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-2	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+2	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 3	told	tell	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obj	3:obj	_
 5	before	before	SCONJ	IN	_	7	mark	7:mark	_
 6	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:before	_
+7	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:before	_
 8	that	that	SCONJ	IN	_	11	mark	11:mark	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	would	would	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
@@ -8242,7 +8242,7 @@
 # sent_id = email-enronsent09_02-0006
 # text = I understand the imminent cold weather is making things crazy, so now may not be the best time to be in your way.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	understand	understand	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	understand	understand	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	imminent	imminent	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	cold	cold	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -8302,7 +8302,7 @@
 # sent_id = email-enronsent09_02-0008
 # text = I think it will help me very much in my role.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	will	will	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 5	help	help	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -8355,7 +8355,7 @@
 # text = We just did a deal for the rest of the month for 10,000/d at meter # 1552 QE-1 @ $4.355 .... can you let me and Robert Lloyd know what the sitara # is?
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	deal	deal	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	for	for	ADP	IN	_	8	case	8:case	_
@@ -8407,11 +8407,11 @@
 # sent_id = email-enronsent09_02-0017
 # text = I show that we also had 20.000 at LS HPL for the 13th.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	show	show	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	show	show	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	6	mark	6:mark	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	also	also	ADV	RB	_	6	advmod	6:advmod	_
-6	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+6	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 7	20.000	20.000	NUM	CD	NumType=Card	6	obj	6:obj	_
 8	at	at	ADP	IN	_	10	case	10:case	_
 9	LS	ls	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -8514,7 +8514,7 @@
 # text = I'm working hard for you!
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	working	work	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	hard	hard	ADV	RB	Degree=Pos	3	advmod	3:advmod	_
 5	for	for	ADP	IN	_	6	case	6:case	_
@@ -8531,7 +8531,7 @@
 # sent_id = email-enronsent09_02-0029
 # text = I need a new lawnmower, so I'll try to bump it up a little more.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	lawnmower	lawnmower	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -8552,10 +8552,10 @@
 
 # sent_id = email-enronsent09_02-0030
 # text = Hope you're doing good.
-1	Hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2-3	you're	_	_	_	_	_	_	_	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-3	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	1	ccomp	1:ccomp	_
 5	good	good	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -8588,7 +8588,7 @@
 1	WE	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2	AT	at	ADP	IN	_	3	case	3:case	_
 3	HOME	home	NOUN	NN	Number=Sing	1	nmod	1:nmod:at	_
-4	LOVE	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	LOVE	love	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	IT	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
 6	AT	at	ADP	IN	_	7	case	7:case	_
 7	$	$	SYM	$	_	4	obl	4:obl:at	SpaceAfter=No
@@ -8607,7 +8607,7 @@
 # newpar id = email-enronsent09_02-p0017
 # text = These have been sold.
 1	These	this	PRON	DT	Number=Plur|PronType=Dem	4	nsubj:pass	4:nsubj:pass	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux:pass	4:aux:pass	_
 4	sold	sell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -8633,7 +8633,7 @@
 2	like	like	SCONJ	IN	_	5	mark	5:mark	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	kids	kid	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:like	_
+5	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:like	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	great	great	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	time	time	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
@@ -8643,17 +8643,17 @@
 # newpar id = email-enronsent09_02-p0020
 # text = I hope you don't mind, but I've taken liberty to turn them into a web photo album at http://24.27.98.30/pictures/08-05_Garrett_Gayle_Bday.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	mind	mind	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	SpaceAfter=No
 7	,	,	PUNCT	,	_	11	punct	11:punct	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
 9-10	I've	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	taken	take	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:but	_
 12	liberty	liberty	NOUN	NN	Number=Sing	11	obj	11:obj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -8672,7 +8672,7 @@
 # text = If you want to pass this web site address along to other folks, feel free.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:if	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	pass	pass	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
@@ -8692,7 +8692,7 @@
 # text = If you want a CD copy of this web site, give me a yell.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	CD	cd	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	copy	copy	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -8789,7 +8789,7 @@
 # sent_id = email-enronsent29_02-0004
 # newpar id = email-enronsent29_02-p0004
 # text = Are you free for lunch some day this week?
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	for	for	ADP	IN	_	5	case	5:case	_
@@ -8805,7 +8805,7 @@
 1	Also	also	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	an	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	extra	extra	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	ticket	ticket	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -8816,9 +8816,9 @@
 12	on	on	ADP	IN	_	13	case	13:case	_
 13	Sat.	Sat.	PROPN	NNP	Number=Sing	11	nmod	11:nmod:on	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
+15	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj|19:nsubj:xsubj	_
-17	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
+17	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	go	go	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	SpaceAfter=No
 20	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -8876,7 +8876,7 @@
 5	Master	master	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	draft	draft	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+8	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent29_02-0011
@@ -8913,7 +8913,7 @@
 12	standard	standard	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	template	template	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	use	use	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+15	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 16	for	for	ADP	IN	_	20	case	20:case	_
 17	Enfolio	Enfolio	PROPN	NNP	Number=Sing	20	compound	20:compound	_
 18	gas	gas	NOUN	NN	Number=Sing	19	compound	19:compound	_
@@ -8926,7 +8926,7 @@
 1	As	as	SCONJ	IN	_	4	mark	4:mark	_
 2-3	we're	_	_	_	_	_	_	_	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:as	_
 5	more	more	ADJ	JJR	Degree=Cmp	4	obj	4:obj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
@@ -9004,7 +9004,7 @@
 # text = I'm free any day but Tuesday.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	any	any	DET	DT	_	5	det	5:det	_
 5	day	day	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	_
@@ -9027,7 +9027,7 @@
 # text = My weekends seem to be taken up with condo matters, house hunting.
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	weekends	weekend	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|6:nsubj:xsubj	_
-3	seem	seem	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	seem	seem	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux:pass	6:aux:pass	_
 6	taken	take	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	xcomp	3:xcomp	_
@@ -9042,14 +9042,14 @@
 
 # sent_id = email-enronsent29_02-0022
 # text = Thank you though.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	though	though	ADV	RB	_	1	advmod	1:advmod	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent29_02-0023
 # text = Are you free for lunch today.
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	for	for	ADP	IN	_	5	case	5:case	_
@@ -9060,7 +9060,7 @@
 # sent_id = email-enronsent29_02-0024
 # text = I want to go to the cafeteria for vegetables.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	go	go	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	to	to	ADP	IN	_	7	case	7:case	_
@@ -9077,7 +9077,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	interested	interested	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -9110,7 +9110,7 @@
 
 # sent_id = email-enronsent29_02-0027
 # text = Are you free for lunch some day this week?
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	for	for	ADP	IN	_	5	case	5:case	_
@@ -9126,7 +9126,7 @@
 1	Also	also	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	an	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	extra	extra	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	ticket	ticket	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -9137,9 +9137,9 @@
 12	on	on	ADP	IN	_	13	case	13:case	_
 13	Sat.	Sat.	PROPN	NNP	Number=Sing	11	nmod	11:nmod:on	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
+15	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj|19:nsubj:xsubj	_
-17	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
+17	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	15	ccomp	15:ccomp	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	go	go	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	SpaceAfter=No
 20	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -9249,7 +9249,7 @@
 # text = I'm free any day but Tuesday.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	any	any	DET	DT	_	5	det	5:det	_
 5	day	day	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	_
@@ -9272,7 +9272,7 @@
 # text = My weekends seem to be taken up with condo matters, house hunting.
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	weekends	weekend	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|6:nsubj:xsubj	_
-3	seem	seem	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	seem	seem	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux:pass	6:aux:pass	_
 6	taken	take	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	xcomp	3:xcomp	_
@@ -9287,14 +9287,14 @@
 
 # sent_id = email-enronsent29_02-0041
 # text = Thank you though.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	though	though	ADV	RB	_	1	advmod	1:advmod	SpaceAfter=No
 4	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent29_02-0042
 # text = Are you free for lunch today.
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	for	for	ADP	IN	_	5	case	5:case	_
@@ -9305,7 +9305,7 @@
 # sent_id = email-enronsent29_02-0043
 # text = I want to go to the cafeteria for vegetables.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	go	go	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	to	to	ADP	IN	_	7	case	7:case	_
@@ -9322,7 +9322,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	interested	interested	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -9401,7 +9401,7 @@
 
 # sent_id = email-enronsent28_01-0006
 # text = Thank you for you patience.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	ADP	IN	_	5	case	5:case	_|CheckAttachment=4
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nmod:poss	5:nmod:poss	_|CheckAttachment=1|CheckReln=obl
@@ -9413,7 +9413,7 @@
 # text = The Dow topped out in February of 1966 at 995.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	Dow	Dow	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	topped	top	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	topped	top	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	February	February	PROPN	NNP	Number=Sing	3	obl	3:obl:in	_
@@ -9432,7 +9432,7 @@
 5	year	year	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	Dow	Dow	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
-8	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
+8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
 9	tumbled	tumble	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 10	to	to	ADP	IN	_	11	case	11:case	_
 11	744	744	NUM	CD	NumType=Card	9	obl	9:obl:to	SpaceAfter=No
@@ -9443,7 +9443,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	Dow	Dow	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	then	then	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
-4	rallied	rally	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	rallied	rally	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	to	to	ADP	IN	_	7	case	7:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	high	high	NOUN	NN	Number=Sing	4	obl	4:obl:to	_
@@ -9463,7 +9463,7 @@
 4	'68	'68	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
-7	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
+7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
 8	fallen	fall	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 9	to	to	ADP	IN	_	10	case	10:case	_
 10	825	825	NUM	CD	NumType=Card	8	obl	8:obl:to	SpaceAfter=No
@@ -9489,7 +9489,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	Dow	Dow	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	then	then	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
-4	sank	sink	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+4	sank	sink	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 5	to	to	ADP	IN	_	6	case	6:case	_
 6	631	631	NUM	CD	NumType=Card	4	obl	4:obl:to	_
 7	in	in	ADP	IN	_	8	case	8:case	_
@@ -9506,7 +9506,7 @@
 4	'71	'71	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
-7	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
+7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
 8	climbed	climb	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 9	back	back	ADV	RB	_	8	advmod	8:advmod	_
 10	to	to	ADP	IN	_	11	case	11:case	_
@@ -9529,7 +9529,7 @@
 2	big	big	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	rally	rally	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	then	then	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
-5	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	Dow	Dow	PROPN	NNP	Number=Sing	5	obj	5:obj	_
 8	(	(	PUNCT	-LRB-	_	9	punct	9:punct	SpaceAfter=No
@@ -9560,7 +9560,7 @@
 5	'73	'73	NUM	CD	NumType=Card	3	nmod	3:nmod:of	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	Dow	Dow	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
-8	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
+8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
 9	collapsed	collapse	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 10	to	to	ADP	IN	_	11	case	11:case	_
 11	788	788	NUM	CD	NumType=Card	9	obl	9:obl:to	SpaceAfter=No
@@ -9568,7 +9568,7 @@
 
 # sent_id = email-enronsent28_01-0015
 # text = Think that was bad - by December of '74 the Dow had sunk to a bear market low of 577.
-1	Think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	4	nsubj	4:nsubj	_
 3	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 4	bad	bad	ADJ	JJ	Degree=Pos	1	ccomp	1:ccomp	_
@@ -9579,7 +9579,7 @@
 9	'74	'74	NUM	CD	NumType=Card	7	nmod	7:nmod:of	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	Dow	Dow	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
-12	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
+12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 13	sunk	sink	VERB	VBN	Tense=Past|VerbForm=Part	1	parataxis	1:parataxis	_
 14	to	to	ADP	IN	_	18	case	18:case	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
@@ -9603,7 +9603,7 @@
 9	of	of	ADP	IN	_	11	case	11:case	_
 10	Wall	Wall	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	Street	Street	PROPN	NNP	Number=Sing	6	nmod	6:nmod:of	_
-12	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
+12	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 13	predicting	predict	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 15	250	250	NUM	CD	NumType=Card	16	nummod	16:nummod	_
@@ -9646,7 +9646,7 @@
 10	since	since	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	Depression	Depression	PROPN	NNP	Number=Sing	9	nmod	9:nmod:since	_
-13	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+13	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 14	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	way	way	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	down	down	ADV	RB	_	13	advmod	13:advmod	SpaceAfter=No
@@ -9658,21 +9658,21 @@
 2	late	late	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	1974	1974	NUM	CD	NumType=Card	6	obl	6:obl:by	_
 4	investors	investor	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-5	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+5	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 6	dizzy	dizzy	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	10	punct	10:punct	_|CheckAttachment=6
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-9	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
+9	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
 10	desperate	desperate	ADJ	JJ	Degree=Pos	6	conj	6:conj	CheckReln=parataxis|SpaceAfter=No
 11	,	,	PUNCT	,	_	14	punct	14:punct	_|CheckAttachment=10
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj:pass	14:nsubj:pass	_
-13	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	aux:pass	14:aux:pass	_
+13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	aux:pass	14:aux:pass	_
 14	wrung	wring	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	conj	6:conj	CheckReln=parataxis|SpaceAfter=No
 15	-	-	PUNCT	HYPH	_	14	punct	14:punct	SpaceAfter=No
 16	out	out	ADP	RP	_	14	compound:prt	14:compound:prt	SpaceAfter=No
 17	,	,	PUNCT	,	_	20	punct	20:punct	_|CheckAttachment=6
 18	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
-19	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
+19	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
 20	left	leave	VERB	VBN	Tense=Past|VerbForm=Part	6	conj	6:conj	_|CheckReln=parataxis
 21	Wall	Wall	PROPN	NNP	Number=Sing	22	compound	22:compound	_
 22	Street	Street	PROPN	NNP	Number=Sing	20	obj	20:obj	SpaceAfter=No
@@ -9688,7 +9688,7 @@
 1	great	great	INTJ	UH	_	4	discourse	4:discourse	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	forward	forward	ADV	RB	_	4	advmod	4:advmod	_
 6	to	to	SCONJ	IN	_	7	mark	7:mark	_
 7	seeing	see	VERB	VBG	VerbForm=Ger	4	advcl	4:advcl:to	_
@@ -9803,7 +9803,7 @@
 9	conducted	conduct	VERB	VBN	Tense=Past|VerbForm=Part	8	acl	8:acl	_
 10	on	on	ADP	IN	_	11	case	11:case	_
 11	Nville	Nville	PROPN	NNP	Number=Sing	9	obl	9:obl:on	_
-12	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	been	be	AUX	VBN	Tense=Past|VerbForm=Part	14	aux:pass	14:aux:pass	_
 14	discussed	discuss	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 15	with	with	ADP	IN	_	16	case	16:case	_
@@ -9821,7 +9821,7 @@
 # text = As we have discussed....effective Sep 13th, Anita will make the adjustments to Enron's inventory and pad gas to reflect the February 26th results.
 1	As	as	SCONJ	IN	_	4	mark	4:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	discussed	discuss	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl	12:advcl:as	SpaceAfter=No
 5	....	....	PUNCT	,	_	12	punct	12:punct	SpaceAfter=No
 6	effective	effective	ADJ	JJ	Degree=Pos	12	advmod	12:advmod	_|CheckAttachment=8|CheckReln=amod
@@ -9852,19 +9852,19 @@
 # sent_id = email-enronsent28_01-0034
 # text = I talked with Gary Wilson, and he confirmed that the revised values are correct.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	talked	talk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	talked	talk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	with	with	ADP	IN	_	4	case	4:case	_
 4	Gary	Gary	PROPN	NNP	Number=Sing	2	obl	2:obl:with	_
 5	Wilson	Wilson	PROPN	NNP	Number=Sing	4	flat	4:flat	SpaceAfter=No
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	confirmed	confirm	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+9	confirmed	confirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 10	that	that	SCONJ	IN	_	15	mark	15:mark	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	revised	revise	VERB	VBN	Tense=Past|VerbForm=Part	13	amod	13:amod	_
 13	values	value	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 15	correct	correct	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -9938,7 +9938,7 @@
 22	)	)	PUNCT	-RRB-	_	21	punct	21:punct	_
 23	that	that	PRON	WDT	PronType=Rel	25	obj	18:ref	_
 24	Anita	Anita	PROPN	NNP	Number=Sing	25	nsubj	25:nsubj	_
-25	showed	show	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+25	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 26	on	on	ADP	IN	_	31	case	31:case	_
 27	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 28	February	February	PROPN	NNP	Number=Sing	31	compound	31:compound	_
@@ -9956,7 +9956,7 @@
 40	that	that	PRON	WDT	PronType=Rel	43	obj	39:ref	_
 41	Gary	Gary	PROPN	NNP	Number=Sing	43	nsubj	43:nsubj	_
 42	Wilson	Wilson	PROPN	NNP	Number=Sing	41	flat	41:flat	_
-43	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	_
+43	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	_
 44	from	from	ADP	IN	_	45	case	45:case	_
 45	MIPS	mips	NOUN	NN	Number=Sing	43	obl	43:obl:from	SpaceAfter=No
 46	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -10005,7 +10005,7 @@
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
 6	any	any	DET	DT	_	7	det	7:det	_
 7	questions	question	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -10021,7 +10021,7 @@
 # text = yeah i got yelled at also.
 1	yeah	yeah	INTJ	UH	_	4	discourse	4:discourse	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
-3	got	get	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	got	get	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	yelled	yell	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	at	at	ADP	IN	_	4	obl	4:obl	_
 6	also	also	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
@@ -10030,7 +10030,7 @@
 # sent_id = email-enronsent04_01-0002
 # text = i tried to say i wasn't that drunk but z wasn't having any of that conversation.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	say	say	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
@@ -10054,7 +10054,7 @@
 # sent_id = email-enronsent04_01-0003
 # text = she told me that after friday and saturday she felt i was slowly regressing.
 1	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	iobj	2:iobj	_
 4	that	that	SCONJ	IN	_	10	mark	10:mark	_
 5	after	after	ADP	IN	_	6	case	6:case	_
@@ -10062,7 +10062,7 @@
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	saturday	Saturday	PROPN	NNP	Number=Sing	6	conj	6:conj:and|10:obl:after	_
 9	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	felt	feel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+10	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
 13	slowly	slowly	ADV	RB	_	14	advmod	14:advmod	_
@@ -10073,10 +10073,10 @@
 # text = then i told her i felt i should be able to screw missy just once.
 1	then	then	ADV	RB	PronType=Dem	3	advmod	3:advmod	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	iobj	3:iobj	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	felt	feel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 7	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
 8	should	should	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 9	be	be	AUX	VB	VerbForm=Inf	10	cop	10:cop	_
@@ -10091,7 +10091,7 @@
 # sent_id = email-enronsent04_01-0005
 # text = she said that was ok.
 1	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	PRON	DT	Number=Sing|PronType=Dem	5	nsubj	5:nsubj	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 5	ok	ok	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	SpaceAfter=No
@@ -10100,7 +10100,7 @@
 # sent_id = email-enronsent04_01-0006
 # newpar id = email-enronsent04_01-p0002
 # text = Did you get in as much trouble as I did this weekend - Lori seems to think I need to get help - I told her it's normal to drink all day at a bar, then go to dinner where you don't know half the people there and proceed to get extremely fucked up
-1	Did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+1	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	get	get	VERB	VB	VerbForm=Inf	15	parataxis	15:parataxis	_
 4	in	in	ADP	IN	_	7	case	7:case	_
@@ -10109,7 +10109,7 @@
 7	trouble	trouble	NOUN	NN	Number=Sing	3	obl	3:obl:in	_
 8	as	as	SCONJ	IN	_	10	mark	10:mark	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	_
+10	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:as	_
 11	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_
 12	weekend	weekend	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	_
 13	-	-	PUNCT	,	_	15	punct	15:punct	_
@@ -10118,13 +10118,13 @@
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	think	think	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj|21:nsubj:xsubj	_
-19	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	ccomp	17:ccomp	_
+19	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	ccomp	17:ccomp	_
 20	to	to	PART	TO	_	21	mark	21:mark	_
 21	get	get	VERB	VB	VerbForm=Inf	19	xcomp	19:xcomp	_
 22	help	help	NOUN	NN	Number=Sing	21	obj	21:obj	_
 23	-	-	PUNCT	,	_	15	punct	15:punct	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj	25:nsubj	_
-25	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	15	parataxis	15:parataxis	_
+25	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	parataxis	15:parataxis	_
 26	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	iobj	25:iobj	_
 27-28	it's	_	_	_	_	_	_	_	_
 27	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	expl	29:expl	_
@@ -10145,7 +10145,7 @@
 42	where	where	SCONJ	WRB	PronType=Rel	46	mark	46:mark	_
 43	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	46	nsubj	46:nsubj	_
 44-45	don't	_	_	_	_	_	_	_	_
-44	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	46	aux	46:aux	_
+44	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	46	aux	46:aux	_
 45	n't	not	PART	RB	_	46	advmod	46:advmod	_
 46	know	know	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	_
 47	half	half	DET	PDT	_	49	det:predet	49:det:predet	_
@@ -10188,7 +10188,7 @@
 # text = If you are not the addressee indicated in this message (or responsible for delivery of the message to such person), you may not copy or deliver this message to anyone.
 1	If	if	SCONJ	IN	_	6	mark	6:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|13:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	not	not	PART	RB	_	6	advmod	6:advmod	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	addressee	addressee	NOUN	NN	Number=Sing	27	advcl	27:advcl:if	_
@@ -10252,7 +10252,7 @@
 6	or	or	CCONJ	CC	_	8	cc	8:cc	_
 7	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	employer	employer	NOUN	NN	Number=Sing	5	conj	5:conj:or|11:nsubj	_
-9	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	not	not	PART	RB	_	11	advmod	11:advmod	_
 11	consent	consent	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:if	_
 12	to	to	ADP	IN	_	14	case	14:case	_
@@ -10277,7 +10277,7 @@
 8	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
 9	message	message	NOUN	NN	Number=Sing	1	nmod	1:nmod:in	_
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj	1:ref	_
-11	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
+11	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 12	not	not	PART	RB	_	13	advmod	13:advmod	_
 13	relate	relate	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 14	to	to	ADP	IN	_	17	case	17:case	_
@@ -10368,7 +10368,7 @@
 # sent_id = email-enronsent04_01-0019
 # text = They offer an exceptional compensation package including a healthy salary, comprehensive benefits program, and ample room for associates to grow within the firm.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	offer	offer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	offer	offer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	an	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	exceptional	exceptional	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	compensation	compensation	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -10473,7 +10473,7 @@
 # text = I've thought about you a few times in the last few months, didn't want to intrude upon an already bad situation with my bullshit questions.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|17:nsubj|19:nsubj:xsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	thought	think	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	about	about	ADP	IN	_	5	case	5:case	_
 5	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	3	obl	3:obl:about	_
@@ -10487,7 +10487,7 @@
 13	months	month	NOUN	NNS	Number=Plur	3	obl	3:obl:in	SpaceAfter=No
 14	,	,	PUNCT	,	_	17	punct	17:punct	_
 15-16	didn't	_	_	_	_	_	_	_	_
-15	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
+15	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
 16	n't	not	PART	RB	_	17	advmod	17:advmod	_
 17	want	want	VERB	VB	VerbForm=Inf	3	conj	3:conj	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
@@ -10507,7 +10507,7 @@
 # text = I'm hearing some pretty depressing stuff from the people I know at ENE.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	hearing	hear	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	some	some	DET	DT	_	7	det	7:det	_
 5	pretty	pretty	ADV	RB	_	6	advmod	6:advmod	_
@@ -10517,7 +10517,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	people	people	NOUN	NNS	Number=Plur	3	obl	3:obl:from	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+12	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 13	at	at	ADP	IN	_	14	case	14:case	_
 14	ENE	ENE	PROPN	NNP	Number=Sing	12	obl	12:obl:at	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -10525,9 +10525,9 @@
 # sent_id = email-enronsent04_01-0028
 # text = I wish I had the capital to open my own shop?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+4	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	capital	capital	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
@@ -10566,7 +10566,7 @@
 # text = I've got some friends at Duke and Dynegy from B-school, the Gianoucous (spelling??) brothers (John and Dimitri?from elementary school) started their own outfit a while back, and my old man is at Schlumberger and has good contacts in general (if you aren't married to a trading environment).
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	got	get	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	some	some	DET	DT	_	5	det	5:det	_
 5	friends	friend	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -10595,7 +10595,7 @@
 28	elementary	elementary	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 29	school	school	NOUN	NN	Number=Sing	23	nmod	23:nmod:from	SpaceAfter=No
 30	)	)	PUNCT	-RRB-	_	23	punct	23:punct	_
-31	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+31	started	start	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 32	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	34	nmod:poss	34:nmod:poss	_
 33	own	own	ADJ	JJ	Degree=Pos	34	amod	34:amod	_
 34	outfit	outfit	NOUN	NN	Number=Sing	31	obj	31:obj	_
@@ -10620,7 +10620,7 @@
 53	if	if	SCONJ	IN	_	57	mark	57:mark	_
 54	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	57	nsubj	57:nsubj	_
 55-56	aren't	_	_	_	_	_	_	_	_
-55	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	57	cop	57:cop	_
+55	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	57	cop	57:cop	_
 56	n't	not	PART	RB	_	57	advmod	57:advmod	_
 57	married	married	ADJ	JJ	Degree=Pos	47	advcl	47:advcl:if	_
 58	to	to	ADP	IN	_	61	case	61:case	_
@@ -10655,7 +10655,7 @@
 # text = you guys have any job opening for ex natural gas traders that made their now almost defunctc ompany over 40 million in the last two years?
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	vocative	2:vocative	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	any	any	DET	DT	_	6	det	6:det	_
 5	job	job	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	opening	opening	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -10665,7 +10665,7 @@
 10	gas	gas	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	traders	trader	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|13:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 15	now	now	ADV	RB	_	17	advmod	17:advmod	_
 16	almost	almost	ADV	RB	_	17	advmod	17:advmod	_
@@ -10697,7 +10697,7 @@
 12	and	and	CCONJ	CC	_	15	cc	15:cc	_
 13-14	i'm	_	_	_	_	_	_	_	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
-14	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+14	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 15	checking	check	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:and	_
 16	out	out	ADP	RP	_	15	compound:prt	15:compound:prt	_
 17	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
@@ -10714,7 +10714,7 @@
 # text = As we discussed, here is a first effort at a revised TVA offer letter.
 1	As	as	SCONJ	IN	_	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	SpaceAfter=No
+3	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
 5	here	here	ADV	RB	PronType=Dem	0	root	0:root	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
@@ -10732,7 +10732,7 @@
 # sent_id = email-enronsent32_01-0003
 # text = I drafted the Into TVA Option as a series of calls tied to the MOPA delivery term and quantity - not sure if this anything close to what you all had in mind.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	drafted	draft	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	drafted	draft	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	Into	into	ADP	IN	_	5	case	5:case	_
 5	TVA	tva	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -10761,7 +10761,7 @@
 28	what	what	PRON	WP	PronType=Int	26	obl	26:obl:to	_
 29	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	31	nsubj	31:nsubj	_
 30	all	all	DET	DT	_	29	det	29:det	_
-31	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
+31	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
 32	in	in	ADP	IN	_	33	case	33:case	_
 33	mind	mind	NOUN	NN	Number=Sing	31	obl	31:obl:in	SpaceAfter=No
 34	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -10776,7 +10776,7 @@
 6	shape	shape	NOUN	NN	Number=Sing	9	obj	9:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	all	all	DET	DT	_	7	det	7:det	_
-9	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+9	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	offer	offer	NOUN	NN	Number=Sing	12	nsubj	12:nsubj|14:nsubj:xsubj	_
 12	ought	ought	AUX	MD	VerbForm=Fin	9	ccomp	9:ccomp	_
@@ -10808,7 +10808,7 @@
 5	4:00	4:00	NUM	CD	NumType=Card	1	obl	1:obl:at	_
 6	unless	unless	SCONJ	IN	_	8	mark	8:mark	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	call	call	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:unless	_
+8	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:unless	_
 9	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	8	obj	8:obj	_
 
 # sent_id = email-enronsent32_01-0008
@@ -10901,7 +10901,7 @@
 
 # sent_id = email-enronsent32_01-0018
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -10958,7 +10958,7 @@
 10	and	and	CCONJ	CC	_	13	cc	13:cc	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	traders	trader	NOUN	NNS	Number=Plur	13	nsubj	13:nsubj	_
-13	scheduled	schedule	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+13	scheduled	schedule	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 15	430	430	NUM	CD	NumType=Card	16	nummod	16:nummod	_
 16	call	call	NOUN	NN	Number=Sing	13	obj	13:obj	_
@@ -10970,12 +10970,12 @@
 # sent_id = email-enronsent32_01-0025
 # text = don't they know we have better things to do
 1-2	don't	_	_	_	_	_	_	_	_
-1	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+1	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	n't	not	PART	RB	_	4	advmod	4:advmod	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 7	better	good	ADJ	JJR	Degree=Cmp	8	amod	8:amod	_
 8	things	thing	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -11019,7 +11019,7 @@
 # sent_id = email-enronsent32_01-0031
 # text = Attached are clean and blacklined drafts of the Enron guaranties to be made in support of EPMI's obligations under the Indian Mesa II Renewable Energy Purchase Agreement ("PPA") and Green Premium Sharing Agreement ("GSPA").?
 1	Attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	aux:pass	1:aux:pass	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	aux:pass	1:aux:pass	_
 3	clean	clean	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	blacklined	blackline	VERB	VBN	Tense=Past|VerbForm=Part	3	conj	3:conj:and|6:amod	_
@@ -11120,7 +11120,7 @@
 # text = As we discussed last week, since the Enron guaranties will need to be in a form that will acceptable to our project lenders and equity participants, we thought that we should start with a form that was used in our last financing and that was negotiated by Enron and the banks.
 1	As	as	SCONJ	IN	_	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	30	advcl	30:advcl:as	_
+3	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	30	advcl	30:advcl:as	_
 4	last	last	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	week	week	NOUN	NN	Number=Sing	3	obl:tmod	3:obl:tmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	30	punct	30:punct	_
@@ -11147,7 +11147,7 @@
 27	participants	participant	NOUN	NNS	Number=Plur	24	conj	20:obl:to|24:conj:and	SpaceAfter=No
 28	,	,	PUNCT	,	_	30	punct	30:punct	_
 29	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	30	nsubj	30:nsubj	_
-30	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+30	thought	think	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 31	that	that	SCONJ	IN	_	34	mark	34:mark	_
 32	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	34	nsubj	34:nsubj	_
 33	should	should	AUX	MD	VerbForm=Fin	34	aux	34:aux	_
@@ -11176,7 +11176,7 @@
 # sent_id = email-enronsent32_01-0034
 # text = We plan to use the same basic form for the Enron guaranty that will be made in favor of EPMI with respect to the seller's obligations under the PPA.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	plan	plan	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	plan	plan	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	use	use	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
@@ -11236,7 +11236,7 @@
 8	call	call	NOUN	NN	Number=Sing	5	obj	5:obj	_
 9	if	if	SCONJ	IN	_	11	mark	11:mark	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:if	_
+11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:if	_
 12	any	any	DET	DT	_	13	det	13:det	_
 13	questions	question	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 14	concerning	concern	VERB	VBG	VerbForm=Ger	17	case	17:case	_
@@ -11247,7 +11247,7 @@
 
 # sent_id = email-enronsent32_01-0037
 # text = Thank you.
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -11349,12 +11349,12 @@
 # sent_id = email-enronsent32_01-0049
 # text = I enjoyed working with you and wish you the best of everything.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj|7:nsubj	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	working	work	VERB	VBG	VerbForm=Ger	2	xcomp	2:xcomp	_
 4	with	with	ADP	IN	_	5	case	5:case	_
 5	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	3	obl	3:obl:with	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+7	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 8	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	7	iobj	7:iobj	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	best	good	ADJ	JJS	Degree=Sup	7	obj	7:obj	_
@@ -11378,7 +11378,7 @@
 12	ISO	ISO	PROPN	NNP	Number=Sing	15	compound	15:compound	_
 13	New	New	ADJ	NNP	Degree=Pos	14	amod	14:amod	_
 14	England	England	PROPN	NNP	Number=Sing	15	compound	15:compound	_
-15	Inc.	Inc.	PROPN	NNP	Number=Sing	8	list	8:list	SpaceAfter=No|CorrectSpaceAfter=Yes
+15	Inc.	Inc.	PROPN	NNP	Number=Sing	8	list	8:list	CorrectSpaceAfter=Yes|SpaceAfter=No
 16	One	One	NUM	NNP	NumType=Card	17	nummod	17:nummod	_
 17	Sullivan	Sullivan	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	Road	Road	PROPN	NNP	Number=Sing	8	list	8:list	_
@@ -11414,7 +11414,7 @@
 # sent_id = email-enronsent32_01-0053
 # text = Events change everyday.
 1	Events	event	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
-2	change	change	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	change	change	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	everyday	everyday	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	SpaceAfter=No
 4	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -11472,7 +11472,7 @@
 # text = As we discussed, here is a copy of the draft memo.
 1	As	as	SCONJ	IN	_	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	SpaceAfter=No
+3	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	advcl	5:advcl:as	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
 5	here	here	ADV	RB	PronType=Dem	0	root	0:root	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
@@ -11539,7 +11539,7 @@
 # sent_id = email-enronsent32_01-0062
 # text = I faxed comments to you on dash.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	faxed	fax	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	faxed	fax	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	comments	comment	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obl	2:obl:to	_
@@ -11549,7 +11549,7 @@
 
 # sent_id = email-enronsent32_01-0063
 # text = Do you have any current info on deal status?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	any	any	DET	DT	_	6	det	6:det	_
@@ -11579,7 +11579,7 @@
 
 # sent_id = email-enronsent18_02-0002
 # text = Are you going to be able to make the power VAR meeting on Thursday?
-1	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|6:nsubj:xsubj|8:nsubj:xsubj	_
 3	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
@@ -11610,7 +11610,7 @@
 # newpar id = email-enronsent18_02-p0004
 # text = I have just checked with RAC (David Gorte) and we have a green light to go ahead with the project.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
 4	checked	check	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	with	with	ADP	IN	_	6	case	6:case	_
@@ -11621,7 +11621,7 @@
 10	)	)	PUNCT	-RRB-	_	8	punct	8:punct	_
 11	and	and	CCONJ	CC	_	13	cc	13:cc	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 15	green	green	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 16	light	light	NOUN	NN	Number=Sing	13	obj	13:obj	_
@@ -11673,7 +11673,7 @@
 # text = I just wanted to check with you regarding the consulting arrangement we discussed a couple of weeks ago.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	check	check	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	with	with	ADP	IN	_	7	case	7:case	_
@@ -11683,7 +11683,7 @@
 10	consulting	consulting	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	arrangement	arrangement	NOUN	NN	Number=Sing	5	obl	5:obl:regarding	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	couple	couple	NOUN	NN	Number=Sing	18	obl:npmod	18:obl:npmod	_
 16	of	of	ADP	IN	_	17	case	17:case	_
@@ -11708,7 +11708,7 @@
 13	contract	contract	NOUN	NN	Number=Sing	5	obl	5:obl:with	_
 14	where	where	SCONJ	WRB	PronType=Rel	16	mark	16:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|28:nsubj	_
-16	give	give	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	some	some	DET	DT	_	18	det	18:det	_
 18	thoughts	thought	NOUN	NNS	Number=Plur	16	obj	16:obj	_
 19	to	to	ADP	IN	_	21	case	21:case	_
@@ -11718,9 +11718,9 @@
 23	issues	issue	NOUN	NNS	Number=Plur	21	nmod	21:nmod:of	_
 24	that	that	PRON	WDT	PronType=Rel	26	obj	21:ref	_
 25	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
+26	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
-28	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	conj	13:acl:relcl|16:conj:and	_
+28	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	16	conj	13:acl:relcl|16:conj:and	_
 29	to	to	ADP	IN	_	30	case	30:case	_
 30	Houston	Houston	PROPN	NNP	Number=Sing	28	obl	28:obl:to	_
 31	to	to	PART	TO	_	32	mark	32:mark	_
@@ -11782,7 +11782,7 @@
 # sent_id = email-enronsent18_02-0016
 # newpar id = email-enronsent18_02-p0009
 # text = Did you have a chance to take a look at the resume I sent you?
-1	Did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+1	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
@@ -11795,14 +11795,14 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	resume	resume	NOUN	NN	Number=Sing	9	nmod	9:nmod:at	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent18_02-0017
 # text = He looked like a great guy for your group.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	looked	look	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	like	like	ADP	IN	_	6	case	6:case	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	great	great	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -11832,7 +11832,7 @@
 # sent_id = email-enronsent18_02-0021
 # text = We discussed a few days ago a consulting arrangement with Prof. Sheridan Titman from UT.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	discussed	discuss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	few	few	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	days	day	NOUN	NNS	Number=Plur	6	obl:npmod	6:obl:npmod	_
@@ -11913,7 +11913,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	presentation	presentation	NOUN	NN	Number=Sing	5	nsubj:pass	5:nsubj:pass	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	at	at	ADP	IN	_	16	case	16:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 13	Canadian	Canadian	ADJ	NNP	Degree=Pos	16	amod	16:amod	_
@@ -12005,7 +12005,7 @@
 4	:	:	PUNCT	:	_	3	punct	3:punct	_
 5	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 6-7	haven't	_	_	_	_	_	_	_	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	_	8	advmod	8:advmod	_
 8	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	3	appos	3:appos	_
 9	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -12028,7 +12028,7 @@
 4	sure	sure	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 5	that	that	SCONJ	IN	_	8	mark	8:mark	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj:pass	8:nsubj:pass	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux:pass	8:aux:pass	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	aux:pass	8:aux:pass	_
 8	billed	bill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	ccomp	4:ccomp	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -12095,11 +12095,11 @@
 1	In	in	ADP	IN	_	5	mark	5:mark	_
 2	case	case	NOUN	NN	Number=Sing	1	fixed	1:fixed	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	interested	interested	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:in_case	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	attach	attach	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	attach	attach	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 9	this	this	DET	DT	Number=Sing|PronType=Dem	10	det	10:det	_
 10	paper	paper	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	on	on	ADP	IN	_	15	case	15:case	_
@@ -12165,7 +12165,7 @@
 # newpar id = email-enronsent18_02-p0025
 # text = I have spoken with Mark Lay and he is interested.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	spoken	speak	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	with	with	ADP	IN	_	5	case	5:case	_
 5	Mark	Mark	PROPN	NNP	Number=Sing	3	obl	3:obl:with	_
@@ -12264,7 +12264,7 @@
 # newpar id = email-enronsent18_02-p0029
 # text = I have called Mark Lay and left a message on his voice mail.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|7:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	called	call	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Mark	Mark	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 5	Lay	Lay	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -12322,7 +12322,7 @@
 # sent_id = email-enronsent18_02-0067
 # text = I hope that this would mean that you would remain involved at some level.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	6	mark	6:mark	_
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	6	nsubj	6:nsubj	_
 5	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
@@ -12391,7 +12391,7 @@
 4	matters	matter	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	as	as	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj|8:nsubj:xsubj	_
-7	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:as	_
+7	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:as	_
 8	best	good	ADJ	JJS	Degree=Sup	7	xcomp	7:xcomp	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	advise	advise	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	_
@@ -12467,7 +12467,7 @@
 # newpar id = email-enronsent18_02-p0036
 # text = I thought that since Chonawee has an optimization background, he would be good to have him go to dinner with Dr. Lasdon on Thrusday as well.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	that	that	SCONJ	IN	_	14	mark	14:mark	_
 4	since	since	SCONJ	IN	_	6	mark	6:mark	_
 5	Chonawee	Chonawee	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
@@ -12517,7 +12517,7 @@
 # newpar id = email-enronsent21_02-p0001
 # text = We are still trying to figure out some of the cash traders.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
 4	trying	try	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -12534,7 +12534,7 @@
 # text = Once we get the word from Lavo we'll let you know.
 1	Once	once	SCONJ	IN	_	3	mark	3:mark	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:once	_
+3	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:once	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	word	word	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	from	from	ADP	IN	_	7	case	7:case	_
@@ -12565,7 +12565,7 @@
 # sent_id = email-enronsent21_02-0006
 # newpar id = email-enronsent21_02-p0004
 # text = Are there any new developments in the trader world?
-1	Are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	_	5	det	5:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -12580,24 +12580,24 @@
 # text = We still have the traders and books that you provided last week, but need to know if there are any changes to this.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj|15:nsubj|17:nsubj:xsubj	_
 2	still	still	ADV	RB	_	3	advmod	3:advmod	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	traders	trader	NOUN	NNS	Number=Plur	3	obj	3:obj|10:obj	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
 7	books	book	NOUN	NNS	Number=Plur	5	conj	3:obj|5:conj:and|10:obj	_
 8	that	that	PRON	WDT	PronType=Rel	10	obj	5:ref	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	provided	provide	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+10	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 11	last	last	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	week	week	NOUN	NN	Number=Sing	10	obl:tmod	10:obl:tmod	SpaceAfter=No
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
 14	but	but	CCONJ	CC	_	15	cc	15:cc	_
-15	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:but	_
+15	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:but	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	know	know	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	if	if	SCONJ	IN	_	20	mark	20:mark	_
 19	there	there	PRON	EX	_	20	expl	20:expl	_
-20	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+20	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
 21	any	any	DET	DT	_	22	det	22:det	_
 22	changes	change	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	_
 23	to	to	ADP	IN	_	24	case	24:case	_
@@ -12612,7 +12612,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:if	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	change	change	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	so	so	SCONJ	IN	_	15	mark	15:mark	_
@@ -12673,7 +12673,7 @@
 # sent_id = email-enronsent21_02-0014
 # text = I wish I could make it.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	could	could	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 5	make	make	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -12702,12 +12702,12 @@
 3	gone	go	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	anywhere	anywhere	ADV	RB	_	3	advmod	3:advmod	_
 5	or	or	CCONJ	CC	_	12	cc	12:cc	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	other	other	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	possibilities	possibility	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	better	good	ADJ	JJR	Degree=Cmp	3	conj	3:conj:or	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -12745,7 +12745,7 @@
 8	half	half	NOUN	NN	Number=Sing	4	obl	4:obl:by	_
 9	that	that	SCONJ	IN	_	11	mark	11:mark	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-11	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+11	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	get	get	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	an	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
@@ -12795,7 +12795,7 @@
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	nmod	2:nmod:of	_
 5	who	who	PRON	WP	PronType=Rel	7	nsubj	2:ref	_
 6	already	already	ADV	RB	_	7	advmod	7:advmod	_
-7	sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+7	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 8	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	7	iobj	7:iobj	_
 9	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	RSVP	rsvp	NOUN	NN	Number=Sing	11	compound	11:compound	_
@@ -12844,7 +12844,7 @@
 # sent_id = email-enronsent21_02-0027
 # text = There are deals in the Aruba book so I'm not sure why you aren't picking those up.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	deals	deal	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
 4	in	in	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -12853,13 +12853,13 @@
 8	so	so	ADV	RB	_	12	advmod	12:advmod	_
 9-10	I'm	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-10	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	not	not	PART	RB	_	12	advmod	12:advmod	_
 12	sure	sure	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
 13	why	why	SCONJ	WRB	PronType=Int	17	mark	17:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
 15-16	aren't	_	_	_	_	_	_	_	_
-15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
+15	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	n't	not	PART	RB	_	17	advmod	17:advmod	_
 17	picking	pick	VERB	VBG	Tense=Pres|VerbForm=Part	12	ccomp	12:ccomp	_
 18	those	that	PRON	DT	Number=Plur|PronType=Dem	17	obj	17:obj	_
@@ -12870,7 +12870,7 @@
 # text = The deals are listed below.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	deals	deal	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	listed	list	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 5	below	below	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 6	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -13040,7 +13040,7 @@
 # text = The positions needed to be divided to reflect BCF's.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	positions	position	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|6:nsubj:xsubj	_
-3	needed	need	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	needed	need	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	aux:pass	6:aux:pass	_
 6	divided	divide	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	xcomp	3:xcomp	_
@@ -13071,7 +13071,7 @@
 8	few	few	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	times	time	NOUN	NNS	Number=Plur	4	obl:npmod	4:obl:npmod	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	send	send	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -13212,7 +13212,7 @@
 # newpar id = email-enronsent21_02-p0017
 # text = Attached are all live financial deals by risk type.
 1	Attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	aux:pass	1:aux:pass	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	aux:pass	1:aux:pass	_
 3	all	all	DET	DT	_	6	det	6:det	_
 4	live	live	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	financial	financial	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -13382,7 +13382,7 @@
 # text = Here you go...
 1	Here	here	ADV	RB	PronType=Dem	3	advmod	3:advmod	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	...	...	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent21_02-0069
@@ -13485,12 +13485,12 @@
 1	Hi	hi	INTJ	UH	_	5	discourse	5:discourse	_
 2-3	I´m	_	_	_	_	_	_	_	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-3	´m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	´m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	from	from	ADP	IN	_	5	case	5:case	_
 5	Brazil	Brazil	PROPN	NNP	Number=Sing	0	root	0:root	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
-8	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	know	know	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	of	of	ADP	IN	_	12	case	12:case	_
@@ -13579,7 +13579,7 @@
 9	elephant	elephant	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
 10	named	name	VERB	VBN	Tense=Past|VerbForm=Part	9	acl	9:acl	_
 11	Olly	Olly	PROPN	NNP	Number=Sing	10	xcomp	10:xcomp	_
-12	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+12	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 13	an	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 14	extremely	extremely	ADV	RB	_	15	advmod	15:advmod	_
 15	uplifting	uplifting	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -13630,7 +13630,7 @@
 # newpar id = newsgroup-groups.google.com_JyotishRemedies_cc96334336b9368b_ENG_20050623_013400-p0002
 # text = We have started a new forum for an interactive and absorbing discussion on Astrology & Palmistry and everything in between including Gemology, Feng Shui/Vaastu Shastra.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	started	start	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	new	new	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -13662,7 +13662,7 @@
 # sent_id = newsgroup-groups.google.com_JyotishRemedies_cc96334336b9368b_ENG_20050623_013400-0003
 # text = We look forward to your active participation to make this forum an exciting meeting place for like minded individuals.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	forward	forward	ADV	RB	_	2	advmod	2:advmod	_
 4	to	to	ADP	IN	_	7	case	7:case	_
 5	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	7	nmod:poss	7:nmod:poss	_
@@ -13743,11 +13743,11 @@
 6	-	-	PUNCT	,	_	1	punct	1:punct	_
 7	all	all	DET	DT	_	8	det	8:det	_
 8	tubes	tube	NOUN	NNS	Number=Plur	11	nsubj:pass	11:nsubj:pass	_
-9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	been	be	AUX	VBN	Tense=Past|VerbForm=Part	11	aux:pass	11:aux:pass	_
 11	tested	test	VERB	VBN	Tense=Past|VerbForm=Part	1	parataxis	1:parataxis	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 14	all	all	ADV	RB	_	15	advmod	15:advmod	_
 15	good	good	ADJ	JJ	Degree=Pos	11	parataxis	11:parataxis	SpaceAfter=No
 16	-	-	PUNCT	,	_	1	punct	1:punct	_
@@ -13760,7 +13760,7 @@
 # text = Heterosexuals increasingly back gay marriage
 1	Heterosexuals	heterosexual	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
 2	increasingly	increasingly	ADV	RB	_	3	advmod	3:advmod	_
-3	back	back	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	back	back	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	gay	gay	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	marriage	marriage	NOUN	NN	Number=Sing	3	obj	3:obj	_
 
@@ -13818,7 +13818,7 @@
 34	coupled	coupled	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	friends	friend	NOUN	NNS	Number=Plur	32	nmod	32:nmod:with|37:nsubj|40:nsubj:xsubj	_
 36	who	who	PRON	WP	PronType=Rel	37	nsubj	35:ref	_
-37	happen	happen	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	_
+37	happen	happen	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	_
 38	to	to	PART	TO	_	40	mark	40:mark	_
 39	be	be	AUX	VB	VerbForm=Inf	40	cop	40:cop	_
 40	gay	gay	ADJ	JJ	Degree=Pos	37	xcomp	37:xcomp	SpaceAfter=No
@@ -13931,7 +13931,7 @@
 # text = I just finish reading a really good book (it was actually a ebook) from some new series called the The Tale of Terra.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	finish	finish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	finish	finish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	reading	read	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 6	really	really	ADV	RB	_	7	advmod	7:advmod	_
@@ -13960,7 +13960,7 @@
 # text = The story had brillant battle scenes, lovable heroes and villians, a compelling story line, and it left me dying for the next part of the series:) go to taleofterra.com to learn more aboout it
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	story	story	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	brillant	brilliant	ADJ	JJ	Degree=Pos|Typo=Yes	6	amod	6:amod	CorrectForm=brilliant
 5	battle	battle	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	scenes	scene	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
@@ -13977,7 +13977,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
-20	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+20	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 21	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	20	obj	20:obj|22:nsubj:xsubj	_
 22	dying	dying	ADJ	JJ	Degree=Pos	20	xcomp	20:xcomp	_
 23	for	for	ADP	IN	_	26	case	26:case	_
@@ -14091,7 +14091,7 @@
 # sent_id = newsgroup-groups.google.com_RagnarokOnlineII_9a68fd122989608b_ENG_20051110_012200-0002
 # text = WE HAVE A DATE FOR THE RELEASE OF RAGNAROK ONLINE 2 (beta anyway)September 16-18, this was announced by Gravity CEO Kim Jung-Ryool on either 16th or 17th of july and as i don't want to take someone's credit's i got it here^^GameSpot
 1	WE	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	HAVE	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	HAVE	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	A	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	DATE	date	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	FOR	for	ADP	IN	_	7	case	7:case	_
@@ -14131,7 +14131,7 @@
 39	as	as	SCONJ	IN	_	43	mark	43:mark	_
 40	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	43	nsubj	43:nsubj|45:nsubj:xsubj	_
 41-42	don't	_	_	_	_	_	_	_	_
-41	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	43	aux	43:aux	_
+41	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	43	aux	43:aux	_
 42	n't	not	PART	RB	_	43	advmod	43:advmod	_
 43	want	want	VERB	VB	VerbForm=Inf	50	advcl	50:advcl:as	_
 44	to	to	PART	TO	_	45	mark	45:mark	_
@@ -14141,7 +14141,7 @@
 47	's	's	PART	POS	_	46	case	46:case	_
 48	credit's	credit'	NOUN	NNS	Number=Plur	45	obj	45:obj	_
 49	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	50	nsubj	50:nsubj	_
-50	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	23	conj	23:conj:and	_
+50	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	23	conj	23:conj:and	_
 51	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	50	obj	50:obj	_
 52	here	here	ADV	RB	PronType=Dem	50	advmod	50:advmod	SpaceAfter=No
 53	^^	^^	SYM	NFP	_	52	discourse	52:discourse	SpaceAfter=No
@@ -14154,7 +14154,7 @@
 3	way	way	NOUN	NN	Number=Sing	6	obl	6:obl:by	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	now	now	ADV	RB	_	6	advmod	6:advmod	_
-6	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	"	"	PUNCT	``	_	9	punct	9:punct	SpaceAfter=No
 9	forum	forum	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
@@ -14191,7 +14191,7 @@
 # newpar id = newsgroup-groups.google.com_alt.animals.cat_0f877e44e3521d27_ENG_20040131_084700-p0002
 # text = We have updated our site to include a LOST and FOUND page and you can now join our branch and make a secure on-line donation to the charity.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	updated	update	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	site	site	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -14244,7 +14244,7 @@
 2	-	-	PUNCT	:	_	1	punct	1:punct	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	also	also	ADV	RB	_	5	advmod	5:advmod	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	appos	1:appos	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	1	appos	1:appos	_
 6	more	more	ADJ	JJR	Degree=Cmp	7	amod	7:amod	_
 7	cats	cat	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 8	coming	come	VERB	VBG	VerbForm=Ger	7	acl	7:acl	_
@@ -14292,9 +14292,9 @@
 4	Indian	Indian	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	capital	capital	NOUN	NN	Number=Sing	1	nmod	1:nmod:in	_
 6	Delhi	Delhi	PROPN	NNP	Number=Sing	5	appos	5:appos	_
-7	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+9	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 10	arrested	arrest	VERB	VBN	Tense=Past|VerbForm=Part	7	ccomp	7:ccomp	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	suspected	suspect	VERB	VBN	Tense=Past|VerbForm=Part	13	amod	13:amod	_
@@ -14319,10 +14319,10 @@
 1	Delhi	Delhi	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 2	police	police	NOUN	NN	Number=Sing	3	compound	3:compound	_
 3	chief	chief	NOUN	NN	Number=Sing	4	compound	4:compound	_
-4	K	K	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj|16:nsubj	SpaceAfter=No|CorrectSpaceAfter=Yes
+4	K	K	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj|16:nsubj	CorrectSpaceAfter=Yes|SpaceAfter=No
 5	K	K	PROPN	NNP	Number=Sing	4	flat	4:flat	_
 6	Paul	Paul	PROPN	NNP	Number=Sing	4	flat	4:flat	_
-7	named	name	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	named	name	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	man	man	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	as	as	ADP	IN	_	11	case	11:case	_
@@ -14331,9 +14331,9 @@
 13	Dar	Dar	PROPN	NNP	Number=Sing	11	flat	11:flat	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
+16	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	conj	7:conj:and	_
 17	police	police	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-18	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
+18	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
 19	hunting	hunt	VERB	VBG	Tense=Pres|VerbForm=Part	16	ccomp	16:ccomp	_
 20	for	for	ADP	IN	_	22	case	22:case	_
 21	four	four	NUM	CD	NumType=Card	22	nummod	22:nummod	_
@@ -14343,7 +14343,7 @@
 # sent_id = newsgroup-groups.google.com_IndiaNewsWindow_8945cbef01f41435_ENG_20051113_092500-0004
 # text = He said Mr Dar, 33, was arrested in Indian-administered Kashmir and belonged to the outlawed Lashkar-e-Toiba militant group.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Mr	Mr	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	Dar	Dar	PROPN	NNP	Number=Sing	9	nsubj:pass	9:nsubj:pass|16:nsubj:pass	SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
@@ -14357,7 +14357,7 @@
 13	administered	administer	VERB	VBN	Tense=Past|VerbForm=Part	14	amod	14:amod	_
 14	Kashmir	Kashmir	PROPN	NNP	Number=Sing	9	obl	9:obl:in	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
-16	belonged	belong	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	conj	2:ccomp|9:conj:and	_
+16	belonged	belong	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	conj	2:ccomp|9:conj:and	_
 17	to	to	ADP	IN	_	26	case	26:case	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 19	outlawed	outlaw	VERB	VBN	Tense=Past|VerbForm=Part	26	amod	26:amod	_
@@ -14382,7 +14382,7 @@
 # newpar id = newsgroup-groups.google.com_HistoricalLinguistics_f65a1220aacc96f3_ENG_20050517_153400-p0001
 # text = I like the way Otto Jespersen (in 'Language: Its Nature, Development and Origin') aptly summarised the nature of language changes by comparing it with one of the theories of the Manchester School of Economics:
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	way	way	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	Otto	Otto	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
@@ -14401,7 +14401,7 @@
 18	'	'	PUNCT	''	_	10	punct	10:punct	SpaceAfter=No
 19	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 20	aptly	aptly	ADV	RB	_	21	advmod	21:advmod	_
-21	summarised	summarise	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+21	summarised	summarise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	nature	nature	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	of	of	ADP	IN	_	26	case	26:case	_
@@ -14443,7 +14443,7 @@
 16	no	no	DET	DT	_	18	det	18:det	_
 17	artificial	artificial	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	hindrances	hindrance	NOUN	NNS	Number=Plur	20	nsubj:pass	20:nsubj:pass	_
-19	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux:pass	20:aux:pass	_
+19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux:pass	20:aux:pass	_
 20	put	put	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:if	_
 21	in	in	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
@@ -14528,7 +14528,7 @@
 13	and	and	CCONJ	CC	_	22	cc	22:cc	_
 14	if	if	SCONJ	IN	_	16	mark	16:mark	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+16	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 18	charity	charity	NOUN	NN	Number=Sing	20	compound	20:compound	_
 19	/	/	PUNCT	,	_	20	punct	20:punct	_
@@ -14613,7 +14613,7 @@
 # text = Inhibitory Systems Control the Pattern of Activity in the Cortex
 1	Inhibitory	inhibitory	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	Systems	system	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	Control	control	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	Control	control	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	Pattern	pattern	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	of	of	ADP	IN	_	7	case	7:case	_
@@ -14628,7 +14628,7 @@
 1	"	"	PUNCT	``	_	5	punct	5:punct	SpaceAfter=No
 2	Inhibitory	inhibitory	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	systems	system	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	essential	essential	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	for	for	SCONJ	IN	_	7	mark	7:mark	_
 7	controlling	control	VERB	VBG	VerbForm=Ger	5	advcl	5:advcl:for	_
@@ -14667,7 +14667,7 @@
 # text = The findings demonstrate the inhibitory network is central to controlling not only the amplitude, extent and duration of activation of recurrent excitatory cortical networks, but also the precise timing of action potentials, and, thus, network synchronization..."
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	findings	finding	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	demonstrate	demonstrate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	demonstrate	demonstrate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	inhibitory	inhibitory	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	network	network	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
@@ -14786,7 +14786,7 @@
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	Hurricane	Hurricane	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	Katrina	Katrina	PROPN	NNP	Number=Sing	6	nmod	6:nmod:of	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	powerful	powerful	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	evidence	evidence	NOUN	NN	Number=Sing	0	root	0:root	_
 13	that	that	SCONJ	IN	_	27	mark	27:mark	_
@@ -14802,7 +14802,7 @@
 23	and	and	CCONJ	CC	_	25	cc	25:cc	_
 24	other	other	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	countries	country	NOUN	NNS	Number=Plur	22	conj	18:obl:in|22:conj:and	_
-26	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	27	aux	27:aux	_
+26	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	aux	27:aux	_
 27	failed	fail	VERB	VBN	Tense=Past|VerbForm=Part	12	acl	12:acl:that	_
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	account	account	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	_
@@ -14842,7 +14842,7 @@
 11	at	at	ADP	IN	_	13	case	13:case	_
 12	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	mouth	mouth	NOUN	NN	Number=Sing	10	nmod	10:nmod:at	_
-14	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+14	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 15	left	leave	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	area	area	NOUN	NN	Number=Sing	15	obj	15:obj|22:nsubj:xsubj	_
@@ -14920,7 +14920,7 @@
 # sent_id = newsgroup-groups.google.com_n3td3v_e874a1e5eb995654_ENG_20060120_052200-0002
 # text = n3td3v saw this story on BBC News Online and thought you should see it.
 1	n3td3v	n3td3v	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj|10:nsubj	_
-2	saw	see	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	saw	see	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	story	story	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	on	on	ADP	IN	_	8	case	8:case	_
@@ -14928,7 +14928,7 @@
 7	News	News	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	Online	Online	PROPN	NNP	Number=Sing	2	obl	2:obl:on	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+10	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
 12	should	should	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 13	see	see	VERB	VB	VerbForm=Inf	10	ccomp	10:ccomp	_
@@ -14965,7 +14965,7 @@
 15	reveal	reveal	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 16	what	what	PRON	WP	PronType=Int	15	obj	15:obj	_
 17	users	user	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-18	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+18	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 19	searching	search	VERB	VBG	Tense=Pres|VerbForm=Part	16	acl:relcl	16:acl:relcl	_
 20	for	for	ADP	IN	_	19	obl	19:obl	SpaceAfter=No
 21	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -14993,11 +14993,11 @@
 5	sport	sport	NOUN	NN	Number=Sing	3	conj	3:conj:and|6:compound	_
 6	headlines	headline	NOUN	NNS	Number=Plur	1	obj	1:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	-	-	PUNCT	,	_	1	punct	1:punct	_
 10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:when	_
+12	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:when	_
 13	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	12	obj	12:obj	SpaceAfter=No
 14	,	,	PUNCT	,	_	1	punct	1:punct	_
 15	all	all	ADV	RB	_	19	advmod	19:advmod	_
@@ -15065,7 +15065,7 @@
 10	of	of	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	sender	sender	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	_
-13	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
+13	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
 14	been	be	AUX	VBN	Tense=Past|VerbForm=Part	15	aux:pass	15:aux:pass	_
 15	verified	verify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	ccomp	2:ccomp	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -15075,7 +15075,7 @@
 # text = If you do not wish to receive such e-mails in the future or want to know more about the BBC's Email a Friend service, please read our frequently asked questions.
 1	If	if	SCONJ	IN	_	5	mark	5:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj|14:nsubj|16:nsubj:xsubj	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	not	not	PART	RB	_	5	advmod	5:advmod	_
 5	wish	wish	VERB	VB	VerbForm=Inf	28	advcl	28:advcl:if	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -15086,7 +15086,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	future	future	NOUN	NN	Number=Sing	7	obl	7:obl:in	_
 13	or	or	CCONJ	CC	_	14	cc	14:cc	_
-14	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:or|28:advcl:if	_
+14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:or|28:advcl:if	_
 15	to	to	PART	TO	_	16	mark	16:mark	_
 16	know	know	VERB	VB	VerbForm=Inf	14	xcomp	14:xcomp	_
 17	more	more	ADJ	JJR	Degree=Cmp	16	obj	16:obj	_
@@ -15141,7 +15141,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	President	President	PROPN	NNP	Number=Sing	20	nsubj	20:nsubj	_
 19	Bush	Bush	PROPN	NNP	Number=Sing	18	flat	18:flat	_
-20	visited	visit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+20	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 21	Chinese	Chinese	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
 22	President	President	PROPN	NNP	Number=Sing	20	obj	20:obj	_
 23	Hu	Hu	PROPN	NNP	Number=Sing	22	flat	22:flat	_
@@ -15332,7 +15332,7 @@
 # newpar id = newsgroup-groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100-p0002
 # text = I started this page to help with my boredom.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	page	page	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj:xsubj	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -15345,7 +15345,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100-0004
 # text = I have Chronic Lyme disease, so I'm stuck at home.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Chronic	chronic	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	Lyme	Lyme	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	disease	disease	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -15353,7 +15353,7 @@
 7	so	so	ADV	RB	_	10	advmod	10:advmod	_
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-9	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+9	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 10	stuck	stuck	ADJ	JJ	Degree=Pos	2	advcl	2:advcl	_
 11	at	at	ADP	IN	_	12	case	12:case	_
 12	home	home	NOUN	NN	Number=Sing	10	obl	10:obl:at	SpaceAfter=No
@@ -15362,7 +15362,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100-0005
 # text = I started collecting animations & jokes just to help with my boredom and depression.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	collecting	collect	VERB	VBG	VerbForm=Ger	2	xcomp	2:xcomp	_
 4	animations	animation	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 5	&	&	CCONJ	CC	_	6	cc	6:cc	_
@@ -15381,11 +15381,11 @@
 # newpar id = newsgroup-groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100-p0003
 # text = I enjoyed the animations and wanted to share them with my friends.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|6:nsubj|8:nsubj:xsubj	_
-2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	animations	animation	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+6	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	share	share	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	8	obj	8:obj	_
@@ -15398,13 +15398,13 @@
 # text = So I started a small mailing list and added their addresses to it.
 1	So	so	ADV	RB	_	3	advmod	3:advmod	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|9:nsubj	_
-3	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 5	small	small	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	mailing	mailing	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	list	list	NOUN	NN	Number=Sing	3	obj	3:obj	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	added	add	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+9	added	add	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 10	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	addresses	address	NOUN	NNS	Number=Plur	9	obj	9:obj	_
 12	to	to	ADP	IN	_	13	case	13:case	_
@@ -15432,7 +15432,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100-0009
 # text = I started with 21 email addresses.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	with	with	ADP	IN	_	6	case	6:case	_
 4	21	21	NUM	CD	NumType=Card	6	nummod	6:nummod	_
 5	email	email	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -15443,7 +15443,7 @@
 # text = We now have over 5000 addresses.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	now	now	ADV	RB	_	3	advmod	3:advmod	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	over	over	ADV	RB	_	5	advmod	5:advmod	_
 5	5000	5000	NUM	CD	NumType=Card	6	nummod	6:nummod	_
 6	addresses	address	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
@@ -15595,18 +15595,18 @@
 11	horses	horse	NOUN	NNS	Number=Plur	1	conj	1:conj	SpaceAfter=No
 12	,	,	PUNCT	,	_	18	punct	18:punct	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	name	name	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl	_
+14	name	name	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl	_
 15	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	18	punct	18:punct	_
 17	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 19	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	18	obj	18:obj	SpaceAfter=No
 20	.	.	PUNCT	.	_	18	punct	18:punct	_
 
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0005
 # text = People love to buy these cute cuddly little animals for gifts and collectables.
 1	People	people	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	buy	buy	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	these	this	DET	DT	Number=Plur|PronType=Dem	9	det	9:det	_
@@ -15623,7 +15623,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0006
 # text = They are very well made and realistic.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj|7:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	very	very	ADV	RB	_	4	advmod	4:advmod	_
 4	well	well	ADV	RB	Degree=Pos	5	advmod	5:advmod	_
 5	made	make	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
@@ -15643,7 +15643,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0008
 # text = We are looking to expand our Wholesale Clients across the Nation.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	expand	expand	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
@@ -15659,12 +15659,12 @@
 # text = If you own a Retail Store or are a Professional Vendor who exhibits at Sport, Hunting, or Craft Shows and are interested in selling our products,please give us a call!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|11:nsubj|24:nsubj	_
-3	own	own	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	31	advcl	31:advcl:if	_
+3	own	own	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	31	advcl	31:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	Retail	retail	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	Store	store	NOUN	NN	Number=Sing	3	obj	3:obj	_
 7	or	or	CCONJ	CC	_	11	cc	11:cc	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	Professional	professional	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	Vendor	vendor	NOUN	NN	Number=Sing	3	conj	3:conj:or|13:nsubj|31:advcl:if	_
@@ -15679,7 +15679,7 @@
 20	Craft	craft	NOUN	NN	Number=Sing	15	conj	15:conj:or|21:compound	_
 21	Shows	show	NOUN	NNS	Number=Plur	13	obl	13:obl:at	_
 22	and	and	CCONJ	CC	_	24	cc	24:cc	_
-23	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
+23	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 24	interested	interested	ADJ	JJ	Degree=Pos	3	conj	3:conj:or|31:advcl:if	_
 25	in	in	SCONJ	IN	_	26	mark	26:mark	_
 26	selling	sell	VERB	VBG	VerbForm=Ger	24	advcl	24:advcl:in	_
@@ -15700,7 +15700,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0011
 # text = We have a Full Color Catalog and Wholesale Price List ready to mail to you today!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	Full	full	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	Color	color	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -15747,7 +15747,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.bears_07e0e03c803ffdbd_ENG_20040217_113500-0014
 # text = We accecpt: Visa, MasterCard, Amex, Dinners Club/Carte Blanche, & Personal Checks/Money Orders.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	accecpt	accecpt	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	accecpt	accecpt	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	:	:	PUNCT	:	_	2	punct	2:punct	_
 4	Visa	Visa	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -15814,7 +15814,7 @@
 11	China	China	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	SpaceAfter=No
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	just	just	ADV	RB	_	14	advmod	14:advmod	_
-14	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	an	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 16	exhibition	exhibition	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	in	in	ADP	IN	_	18	case	18:case	_
@@ -15871,7 +15871,7 @@
 # text = His artworks were selected and exhibited in British Museum in 2002.
 1	His	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	artworks	artwork	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass|6:nsubj:pass	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 4	selected	select	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	exhibited	exhibit	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj:and	_
@@ -15907,7 +15907,7 @@
 21	work	work	NOUN	NN	Number=Sing	14	obl	14:obl:into	SpaceAfter=No
 22	,	,	PUNCT	,	_	24	punct	24:punct	SpaceAfter=No
 23	"	"	PUNCT	''	_	24	punct	24:punct	_
-24	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+24	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 25	Gordon	Gordon	PROPN	NNP	Number=Sing	24	nsubj	24:nsubj	_
 26	S.	S.	PROPN	NNP	Number=Sing	25	flat	25:flat	_
 27	Barrass	Barrass	PROPN	NNP	Number=Sing	25	flat	25:flat	SpaceAfter=No
@@ -16068,7 +16068,7 @@
 11	encyclopedia	encyclopedia	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	project	project	NOUN	NN	Number=Sing	6	nmod	6:nmod:behind	SpaceAfter=No
 13	,	,	PUNCT	,	_	14	punct	14:punct	_
-14	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+14	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 15	Friday	Friday	PROPN	NNP	Number=Sing	14	obl:tmod	14:obl:tmod	_
 16	that	that	SCONJ	IN	_	21	mark	21:mark	_
 17	search	search	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -16122,7 +16122,7 @@
 5	0	0	NUM	CD	NumType=Card	3	nmod	3:nmod	_
 6	(	(	PUNCT	-LRB-	_	8	punct	8:punct	SpaceAfter=No
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
-8	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
+8	took	take	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 9	down	down	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	Netscape	Netscape	PROPN	NNP	Number=Sing	8	obj	8:obj	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
@@ -16201,7 +16201,7 @@
 2	While	while	SCONJ	IN	_	6	mark	6:mark	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	have	have	VERB	VB	VerbForm=Inf	20	advcl	20:advcl:while	_
 7	anything	anything	PRON	NN	Number=Sing	6	obj	6:obj	_
@@ -16215,7 +16215,7 @@
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	Wikimedia	Wikimedia	PROPN	NNP	Number=Sing	17	compound	17:compound	_
 17	Foundation	Foundation	PROPN	NNP	Number=Sing	13	conj	13:conj:and|20:nsubj	_
-18	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+18	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 19	collaboratively	collaboratively	ADV	RB	_	20	advmod	20:advmod	_
 20	evaluating	evaluate	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 21	creative	creative	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
@@ -16338,13 +16338,13 @@
 7	for	for	ADP	IN	_	8	case	8:case	_
 8	people	people	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|11:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	taking	take	VERB	VBG	VerbForm=Ger	8	acl:relcl	8:acl:relcl	_
 12	action	action	NOUN	NN	Number=Sing	11	obj	11:obj	_
 13	on	on	ADP	IN	_	14	case	14:case	_
 14	issues	issue	NOUN	NNS	Number=Plur	11	obl	11:obl:on|16:nsubj	_
 15	that	that	PRON	WDT	PronType=Rel	16	nsubj	14:ref	_
-16	concern	concern	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	concern	concern	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	obj	16:obj	SpaceAfter=No
 18	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -16352,13 +16352,13 @@
 # text = I'm getting in touch because I think it could be useful to people campaigning about hospital closures.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	getting	get	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	touch	touch	NOUN	NN	Number=Sing	3	obl	3:obl:in	_
 6	because	because	SCONJ	IN	_	8	mark	8:mark	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:because	_
+8	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:because	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 10	could	could	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 11	be	be	AUX	VB	VerbForm=Inf	12	cop	12:cop	_
@@ -16375,7 +16375,7 @@
 # text = We've got a page dedicated to issues around hospitals ( http://www.bbc.co.uk/dna/actionnetwork/C55153 ) and a group called NHS SOS have already put up a campaign about ward closures in Cumbria.
 1-2	We've	_	_	_	_	_	_	_	_
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	got	get	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	page	page	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -16393,7 +16393,7 @@
 17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	16	acl	16:acl	_
 18	NHS	NHS	PROPN	NNP	Number=Sing	19	compound	19:compound	_
 19	SOS	SOS	PROPN	NNP	Number=Sing	17	xcomp	17:xcomp	_
-20	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
+20	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
 21	already	already	ADV	RB	_	22	advmod	22:advmod	_
 22	put	put	VERB	VBN	Tense=Past|VerbForm=Part	3	conj	3:conj:and	_
 23	up	up	ADP	RP	_	22	compound:prt	22:compound:prt	_
@@ -16410,7 +16410,7 @@
 # text = I'm hoping to build this up to be a hub for all the campaigners - a place where people can exchange ideas and advice.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	hoping	hope	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	build	build	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
@@ -16448,7 +16448,7 @@
 8	from	from	ADP	IN	_	9	case	9:case	_
 9	CHANT	CHANT	PROPN	NNP	Number=Sing	7	nmod	7:nmod:from	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	7:ref	_
-11	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+11	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 12	this	this	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
 13	page	page	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
@@ -16498,7 +16498,7 @@
 20	group	group	NOUN	NN	Number=Sing	17	obj	17:obj	_
 21	if	if	SCONJ	IN	_	23	mark	23:mark	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	23	nsubj	23:nsubj|25:nsubj:xsubj	_
-23	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+23	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
 24	to	to	PART	TO	_	25	mark	25:mark	_
 25	take	take	VERB	VB	VerbForm=Inf	23	xcomp	23:xcomp	_
 26	action	action	NOUN	NN	Number=Sing	25	obj	25:obj	_
@@ -16514,7 +16514,7 @@
 3	attach	attach	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	anything	anything	PRON	NN	Number=Sing	3	obj	3:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	write	write	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	to	to	ADP	IN	_	8	case	8:case	_
 8	pages	page	NOUN	NNS	Number=Plur	3	obl	3:obl:to	_
 9	for	for	ADP	IN	_	12	case	12:case	_
@@ -16537,7 +16537,7 @@
 # text = I'm more than happy to help people with the site or answer any questions about Action Network - just drop me a message.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	more	more	ADJ	JJR	Degree=Cmp	0	root	0:root	_
 4	than	than	ADP	IN	_	5	case	5:case	_
 5	happy	happy	ADJ	JJ	Degree=Pos	3	obl	3:obl:than	_
@@ -16566,7 +16566,7 @@
 # text = Otherwise, hope to see you there!
 1	Otherwise	otherwise	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	3	punct	3:punct	_
-3	hope	hope	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	hope	hope	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	see	see	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	5	obj	5:obj	_
@@ -16629,7 +16629,7 @@
 4	stands	stand	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	up	up	ADV	RB	_	4	advmod	4:advmod	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	offers	offer	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	SpaceAfter=No|CorrectSpaceAfter=Yes
+7	offers	offer	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	CorrectSpaceAfter=Yes|SpaceAfter=No
 8	that	that	SCONJ	IN	_	37	mark	37:mark	SpaceAfter=No
 9	,	,	PUNCT	,	_	37	punct	37:punct	_
 10	"	"	PUNCT	``	_	37	punct	37:punct	SpaceAfter=No
@@ -16649,10 +16649,10 @@
 24	when	when	SCONJ	WRB	PronType=Int	27	mark	27:mark	_
 25	a	a	DET	DT	Definite=Ind|PronType=Art	26	det	26:det	_
 26	car	car	NOUN	NN	Number=Sing	27	nsubj	27:nsubj|30:nsubj	_
-27	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	20	advcl	20:advcl:when	_
+27	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	advcl	20:advcl:when	_
 28	along	along	ADV	RB	_	27	advmod	27:advmod	_
 29	and	and	CCONJ	CC	_	30	cc	30:cc	_
-30	killed	kill	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	27	conj	20:advcl:when|27:conj:and	_
+30	killed	kill	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	27	conj	20:advcl:when|27:conj:and	_
 31	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	30	obj	30:obj	SpaceAfter=No
 32	,	,	PUNCT	,	_	37	punct	37:punct	_
 33	that	that	PRON	DT	Number=Sing|PronType=Dem	37	nsubj	37:nsubj	_
@@ -16700,7 +16700,7 @@
 6	carrying	carry	VERB	VBG	VerbForm=Ger	5	acl	5:acl	_
 7	fifty	fifty	NUM	CD	NumType=Card	8	nummod	8:nummod	_
 8	children	child	NOUN	NNS	Number=Plur	6	obj	6:obj	_
-9	drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	advcl	22:advcl:if	_
+9	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	advcl	22:advcl:if	_
 10	off	off	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	cliff	cliff	NOUN	NN	Number=Sing	9	obl	9:obl:off	SpaceAfter=No
@@ -16722,7 +16722,7 @@
 1	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 2-3	I'm	_	_	_	_	_	_	_	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	afraid	afraid	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	not	not	PART	RB	_	4	ccomp	4:ccomp	SpaceAfter=No
 6	,	,	PUNCT	,	_	4	punct	4:punct	_
@@ -16755,7 +16755,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	other	other	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	children	child	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
-11	volunteer	volunteer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	SpaceAfter=No
+11	volunteer	volunteer	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	SpaceAfter=No
 12	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = newsgroup-groups.google.com_jokecity_0566f0ba3b5f748f_ENG_20051125_240500-0009
@@ -16982,7 +16982,7 @@
 28	,	,	PUNCT	,	_	31	punct	31:punct	SpaceAfter=No
 29	"	"	PUNCT	''	_	31	punct	31:punct	_
 30	Kistler	Kistler	PROPN	NNP	Number=Sing	31	nsubj	31:nsubj	_
-31	told	tell	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+31	told	tell	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 32	SPACE.com	space.com	X	ADD	_	31	obj	31:obj	SpaceAfter=No
 33	.	.	PUNCT	.	_	31	punct	31:punct	_
 
@@ -16991,7 +16991,7 @@
 1	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 2	Our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
 3	plans	plan	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	include	include	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	raising	raise	VERB	VBG	VerbForm=Ger	4	ccomp	4:ccomp	_
 6	private	private	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	capital	capital	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -17123,7 +17123,7 @@
 # sent_id = newsgroup-groups.google.com_hiddennook_88969236563fa748_ENG_20050215_173600-0011
 # text = They want to use LTS to tie into NASA's vision for Space Exploration, and seem pleased that the White House is moving in that direction.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj|17:nsubj|18:nsubj:xsubj	_
-2	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	use	use	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	LTS	LTS	PROPN	NNP	Number=Sing	4	obj	4:obj	_
@@ -17139,7 +17139,7 @@
 14	Exploration	exploration	NOUN	NN	Number=Sing	11	nmod	11:nmod:for	SpaceAfter=No
 15	,	,	PUNCT	,	_	17	punct	17:punct	_
 16	and	and	CCONJ	CC	_	17	cc	17:cc	_
-17	seem	seem	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+17	seem	seem	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 18	pleased	pleased	ADJ	JJ	Degree=Pos	17	xcomp	17:xcomp	_
 19	that	that	SCONJ	IN	_	24	mark	24:mark	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -17156,7 +17156,7 @@
 # text = "We are so excited that the White House and the recent new government space policy underscores the need to involve the private sector in assisting NASA develop its plans for the new Vision for Space Exploration," said Walter Kistler, LTS co-founder and Chairman.
 1	"	"	PUNCT	``	_	40	punct	40:punct	SpaceAfter=No
 2	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	so	so	ADV	RB	_	5	advmod	5:advmod	_
 5	excited	excited	ADJ	JJ	Degree=Pos	40	ccomp	40:ccomp	_
 6	that	that	SCONJ	IN	_	17	mark	17:mark	_
@@ -17193,7 +17193,7 @@
 37	Exploration	exploration	NOUN	NN	Number=Sing	34	nmod	34:nmod:for	SpaceAfter=No
 38	,	,	PUNCT	,	_	40	punct	40:punct	SpaceAfter=No
 39	"	"	PUNCT	''	_	40	punct	40:punct	_
-40	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+40	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 41	Walter	Walter	PROPN	NNP	Number=Sing	40	nsubj	40:nsubj	_
 42	Kistler	Kistler	PROPN	NNP	Number=Sing	41	flat	41:flat	SpaceAfter=No
 43	,	,	PUNCT	,	_	41	punct	41:punct	_
@@ -17229,7 +17229,7 @@
 22	sooner	soon	ADV	RBR	Degree=Cmp	19	advmod	19:advmod	_
 23	than	than	SCONJ	IN	_	25	mark	25:mark	_
 24	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	25	nsubj	25:nsubj	_
-25	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:than	SpaceAfter=No
+25	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:than	SpaceAfter=No
 26	.	.	PUNCT	.	_	14	punct	14:punct	_
 
 # sent_id = newsgroup-groups.google.com_hiddennook_88969236563fa748_ENG_20050215_173600-0014
@@ -17310,7 +17310,7 @@
 35	and	and	CCONJ	CC	_	37	cc	37:cc	_
 36	the	the	DET	DT	Definite=Def|PronType=Art	37	det	37:det	_
 37	Pentagon	Pentagon	PROPN	NNP	Number=Sing	34	conj	34:conj:and|39:nsubj	_
-38	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	39	aux	39:aux	_
+38	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	39	aux	39:aux	_
 39	told	tell	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 40	the	the	DET	DT	Definite=Def|PronType=Art	42	det	42:det	_
 41	White	White	ADJ	NNP	Degree=Pos	42	amod	42:amod	_
@@ -17376,7 +17376,7 @@
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	past	past	NOUN	NN	Number=Sing	20	obl	20:obl:in	_
 18	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	20	nsubj	20:nsubj|24:nsubj:xsubj	_
-19	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+19	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 20	proven	prove	VERB	VBN	Tense=Past|VerbForm=Part	7	advcl	7:advcl:as	_
 21	to	to	PART	TO	_	24	mark	24:mark	_
 22	be	be	AUX	VB	VerbForm=Inf	24	cop	24:cop	_
@@ -17395,7 +17395,7 @@
 2	these	this	DET	DT	Number=Plur|PronType=Dem	4	det	4:det	_
 3	new	new	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	rockets	rocket	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 6	probably	probably	ADV	RB	_	8	advmod	8:advmod	_
 7	more	more	ADV	RBR	_	8	advmod	8:advmod	_
 8	expensive	expensive	ADJ	JJ	Degree=Pos	13	advcl	13:advcl:although	SpaceAfter=No
@@ -17464,7 +17464,7 @@
 25	spaceflight	spaceflight	NOUN	NN	Number=Sing	22	nmod	22:nmod:for	SpaceAfter=No
 26	,	,	PUNCT	,	_	28	punct	28:punct	SpaceAfter=No
 27	"	"	PUNCT	''	_	28	punct	28:punct	_
-28	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+28	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	30	det	30:det	_
 30	letter	letter	NOUN	NN	Number=Sing	28	nsubj	28:nsubj	SpaceAfter=No
 31	,	,	PUNCT	,	_	30	punct	30:punct	_
@@ -17532,7 +17532,7 @@
 39	"	"	PUNCT	''	_	42	punct	42:punct	_
 40	the	the	DET	DT	Definite=Def|PronType=Art	41	det	41:det	_
 41	letter	letter	NOUN	NN	Number=Sing	42	nsubj	42:nsubj	_
-42	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+42	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 43	.	.	PUNCT	.	_	42	punct	42:punct	_
 
 # sent_id = newsgroup-groups.google.com_hiddennook_e21e429b3ad58235_ENG_20050830_214700-0009
@@ -17697,7 +17697,7 @@
 8	down	down	ADP	RP	_	4	compound:prt	4:compound:prt	_
 9	if	if	SCONJ	IN	_	11	mark	11:mark	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:if	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:if	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	work	work	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	its	its	PRON	PRP$	Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
@@ -17717,7 +17717,7 @@
 # newpar id = newsgroup-groups.google.com_JokeEruption_df151b356f94881c_ENG_20050819_155700-p0008
 # text = I had a rose named after me and I was very flattered.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	rose	rose	NOUN	NN	Number=Sing	2	obj	2:obj|5:nsubj:xsubj	_
 5	named	name	VERB	VBN	Tense=Past|VerbForm=Part	2	xcomp	2:xcomp	_
@@ -17819,7 +17819,7 @@
 # text = If you get a good wife, you'll become happy; if you get a bad one, you'll become a philosopher.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	_
+3	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	wife	wife	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -17832,7 +17832,7 @@
 12	;	;	PUNCT	,	_	11	punct	11:punct	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+15	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	bad	bad	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	one	one	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
@@ -17932,7 +17932,7 @@
 # newpar id = newsgroup-groups.google.com_JokeEruption_df151b356f94881c_ENG_20050819_155700-p0022
 # text = I have never hated a man enough to give his diamonds back.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	never	never	ADV	RB	_	4	advmod	4:advmod	_
 4	hated	hate	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -18041,7 +18041,7 @@
 4	thirteen	thirteen	NUM	CD	NumType=Card	7	advcl	7:advcl:until	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	name	name	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
 10	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	ccomp	7:ccomp	_
@@ -18072,7 +18072,7 @@
 6	state	state	NOUN	NN	Number=Sing	0	root	0:root	_
 7	if	if	SCONJ	IN	_	9	mark	9:mark	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:if	_
+9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:if	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	little	little	ADJ	JJ	Degree=Pos	12	obl:npmod	12:obl:npmod	_
 12	later	late	ADV	RBR	Degree=Cmp	9	advmod	9:advmod	_
@@ -18098,7 +18098,7 @@
 # text = I don't feel old.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|5:nsubj:xsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	feel	feel	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	old	old	ADJ	JJ	Degree=Pos	4	xcomp	4:xcomp	SpaceAfter=No
@@ -18108,7 +18108,7 @@
 # text = I don't feel anything until noon.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	feel	feel	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	anything	anything	PRON	NN	Number=Sing	4	obj	4:obj	_
@@ -18153,7 +18153,7 @@
 7	...	...	PUNCT	,	_	3	punct	3:punct	_
 8	as	as	SCONJ	IN	_	10	mark	10:mark	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|11:nsubj:xsubj	_
-10	grow	grow	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:as	_
+10	grow	grow	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:as	_
 11	older	old	ADJ	JJR	Degree=Cmp	10	xcomp	10:xcomp	SpaceAfter=No
 12	,	,	PUNCT	,	_	15	punct	15:punct	_
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
@@ -18256,7 +18256,7 @@
 
 # sent_id = newsgroup-groups.google.com_JokeEruption_df151b356f94881c_ENG_20050819_155700-0059
 # text = Do You Yahoo!?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	Yahoo!	yahoo!	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -18435,7 +18435,7 @@
 # newpar id = answers-20111107144434AA0lJDI_ans-p0001
 # text = What are some Major land forms in Ireland?
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	_	6	det	6:det	_
 4	Major	major	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	land	land	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -18460,7 +18460,7 @@
 # sent_id = answers-20111108044633AAdN4ph_ans-0001
 # newpar id = answers-20111108044633AAdN4ph_ans-p0001
 # text = Do you know the online streaming link for Red FM 93.5 delhi ?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -18484,7 +18484,7 @@
 # sent_id = answers-20111108044633AAdN4ph_ans-0003
 # newpar id = answers-20111108044633AAdN4ph_ans-p0002
 # text = Υes.
-1	Υes	yes	INTJ	UH	Typo=Yes	0	root	0:root	SpaceAfter=No|CorrectForm=Yes
+1	Υes	yes	INTJ	UH	Typo=Yes	0	root	0:root	CorrectForm=Yes|SpaceAfter=No
 2	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # newdoc id = answers-20111108063043AAOhkv9_ans
@@ -18528,7 +18528,7 @@
 # newpar id = answers-20090801154222AA09uXV_ans-p0001
 # text = Which do you prefer Crab or Shrimp?
 1	Which	which	PRON	WDT	PronType=Int	4	obj	4:obj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	Crab	crab	NOUN	NN	Number=Sing	1	appos	1:appos	_
@@ -18540,7 +18540,7 @@
 # newpar id = answers-20090801154222AA09uXV_ans-p0002
 # text = I like shrimp,fried,grilled,or steamed.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	shrimp	shrimp	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	SpaceAfter=No
 5	fried	fry	VERB	VBN	Tense=Past|VerbForm=Part	3	acl	3:acl	SpaceAfter=No
@@ -18659,7 +18659,7 @@
 2	in	in	ADP	IN	_	3	case	3:case	_
 3	Indiana	Indiana	PROPN	NNP	Number=Sing	1	obl	1:obl:in	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	parataxis	9:parataxis	_
+5	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	parataxis	9:parataxis	_
 6-7	it's	_	_	_	_	_	_	_	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj|12:nsubj	_
 7	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
@@ -18693,7 +18693,7 @@
 1	which	which	DET	WDT	PronType=Int	3	det	3:det	_
 2	burger	burger	NOUN	NN	Number=Sing	3	compound	3:compound	_
 3	chain	chain	NOUN	NN	Number=Sing	6	obj	6:obj	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 6	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
@@ -18737,7 +18737,7 @@
 3	shop	shop	NOUN	NN	Number=Sing	0	root	0:root|6:obl	_
 4	that	that	PRON	WDT	PronType=Rel	6	obl	3:ref	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+6	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 7	of	of	ADP	IN	_	4	case	4:case	_
 8	AND	and	CCONJ	CC	_	10	cc	10:cc	_
 9	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -18770,11 +18770,11 @@
 # sent_id = answers-20090709103651AAwwZKx_ans-0001
 # newpar id = answers-20090709103651AAwwZKx_ans-p0001
 # text = Do you think there are any koreans in Miramar?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
 6	any	any	DET	DT	_	7	det	7:det	_
 7	koreans	Korean	PROPN	NNPS	Number=Plur	5	nsubj	5:nsubj	_
 8	in	in	ADP	IN	_	9	case	9:case	_
@@ -18801,11 +18801,11 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	but	but	CCONJ	CC	_	6	cc	6:cc	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	believe	believe	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	some	some	DET	DT	_	8	det	8:det	_
 8	Koreans	Korean	PROPN	NNPS	Number=Plur	9	nsubj	9:nsubj	_
-9	reside	reside	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
+9	reside	reside	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	country	country	NOUN	NN	Number=Sing	9	obl	9:obl:in	_
@@ -18853,7 +18853,7 @@
 9	,	,	PUNCT	,	_	3	punct	3:punct	_
 10	if	if	SCONJ	IN	_	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:if	_
+12	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:if	_
 13	that	that	PRON	DT	Number=Sing|PronType=Dem	12	obj	12:obj	_
 14	then	then	ADV	RB	PronType=Dem	18	advmod	18:advmod	_
 15	yes	yes	INTJ	UH	_	18	discourse	18:discourse	_
@@ -18875,7 +18875,7 @@
 5	,	,	PUNCT	,	_	10	punct	10:punct	_
 6	what	what	PRON	WP	PronType=Int	10	obj	10:obj	_
 7	else	else	ADV	RB	_	6	amod	6:amod	_
-8	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+8	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	people	people	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	_
 10	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	_
 11	in	in	ADP	IN	_	12	case	12:case	_
@@ -18888,14 +18888,14 @@
 1	Well	well	INTJ	UH	_	4	discourse	4:discourse	SpaceAfter=No
 2	,	,	PUNCT	,	_	4	punct	4:punct	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	variety	variety	NOUN	NN	Number=Sing	4	obj	4:obj|11:obj	_
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	sports	sport	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	6:ref	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-11	play	play	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+11	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 12	like	like	ADP	IN	_	13	case	13:case	_
 13	basketball	basketball	NOUN	NN	Number=Sing	6	nmod	6:nmod:like	SpaceAfter=No
 14	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -18909,7 +18909,7 @@
 # text = Well they play the Wii like me :)
 1	Well	well	INTJ	UH	_	3	discourse	3:discourse	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	play	play	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	Wii	Wii	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 6	like	like	ADP	IN	_	7	case	7:case	_
@@ -18933,7 +18933,7 @@
 2	Hank	Hank	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 3	Green	Green	PROPN	NNP	Number=Sing	2	flat	2:flat	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+5	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	hardly	hardly	ADV	RB	_	8	advmod	8:advmod	_
 8	awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -19103,7 +19103,7 @@
 # text = I'm looking for websites like flickr.com tumblr.com and autocorrects.com but ones that aren't very common and have a variety of funny pictures!
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	looking	look	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	for	for	ADP	IN	_	5	case	5:case	_
 5	websites	website	NOUN	NNS	Number=Plur	3	obl	3:obl:for	_
@@ -19116,12 +19116,12 @@
 12	ones	one	NOUN	NNS	Number=Plur	5	conj	3:obl:for|5:conj:but|17:nsubj|19:nsubj	_
 13	that	that	PRON	WDT	PronType=Rel	17	nsubj	12:ref	_
 14-15	aren't	_	_	_	_	_	_	_	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
 15	n't	not	PART	RB	_	17	advmod	17:advmod	_
 16	very	very	ADV	RB	_	17	advmod	17:advmod	_
 17	common	common	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	_
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
-19	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	conj	12:acl:relcl|17:conj:and	_
+19	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	conj	12:acl:relcl|17:conj:and	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 21	variety	variety	NOUN	NN	Number=Sing	19	obj	19:obj	_
 22	of	of	ADP	IN	_	24	case	24:case	_
@@ -19145,7 +19145,7 @@
 
 # sent_id = answers-20111108090345AAQiffR_ans-0004
 # text = Thank you (:
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 3	(:	(:	SYM	NFP	_	1	discourse	1:discourse	_
 
@@ -19159,7 +19159,7 @@
 # newpar id = answers-20111107201117AANg07J_ans-p0001
 # text = how do you mold silicone or rubber into a mermaid tail?
 1	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	mold	mold	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	silicone	silicone	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -19214,7 +19214,7 @@
 # sent_id = answers-20111107201117AANg07J_ans-0006
 # text = They sell these kits in most hobby and craft stores.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	sell	sell	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	these	this	DET	DT	Number=Plur|PronType=Dem	4	det	4:det	_
 4	kits	kit	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	in	in	ADP	IN	_	10	case	10:case	_
@@ -19229,7 +19229,7 @@
 # sent_id = answers-20090730195539AAVSpaH_ans-0001
 # newpar id = answers-20090730195539AAVSpaH_ans-p0001
 # text = Do you prefer ham, bacon or sausages with your breakfast?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	ham	ham	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -19271,13 +19271,13 @@
 2	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nmod:poss	3:nmod:poss	_
 3	breakfast	breakfast	NOUN	NN	Number=Sing	5	obl	5:obl:with	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	bacon	bacon	NOUN	NN	Number=Sing	5	obj	5:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	sausage	sausage	NOUN	NN	Number=Sing	6	conj	5:obj|6:conj:and	_
 9	when	when	SCONJ	WRB	PronType=Int	11	mark	11:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	having	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
+11	having	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 13	big	big	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	breakfast	breakfast	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -19333,7 +19333,7 @@
 1	Yeah	yeah	INTJ	UH	_	3	discourse	3:discourse	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 3-4	gotta	_	_	_	_	_	_	_	_
-3	got	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	got	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	ta	to	PART	TO	Abbr=Yes	5	mark	5:mark	_
 5	burn	burn	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	obj	5:obj	SpaceAfter=No
@@ -19352,7 +19352,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 4	all	all	DET	DT	_	3	det	3:det	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	secret	secret	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	locator	locator	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	chips	chip	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -19418,7 +19418,7 @@
 6	blogs	blog	NOUN	NNS	Number=Plur	2	nmod	2:nmod:of	_
 7-8	Ive	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-8	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	read	read	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 11	so	so	ADV	RB	_	10	advmod	10:advmod	_
@@ -19455,7 +19455,7 @@
 # text = I'm under 21+ and looking for a nice place to take my boyfriend out for dinner where they play music and there is a dance floor.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|7:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	under	under	ADP	IN	_	4	case	4:case	_
 4	21	21	NUM	CD	NumType=Card	0	root	0:root	SpaceAfter=No
 5	+	+	SYM	SYM	_	4	advmod	4:advmod	_
@@ -19474,7 +19474,7 @@
 18	dinner	dinner	NOUN	NN	Number=Sing	13	obl	13:obl:for	_
 19	where	where	SCONJ	WRB	PronType=Rel	21	mark	21:mark	_
 20	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	play	play	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+21	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 22	music	music	NOUN	NN	Number=Sing	21	obj	21:obj	_
 23	and	and	CCONJ	CC	_	25	cc	25:cc	_
 24	there	there	PRON	EX	_	25	expl	25:expl	_
@@ -19536,7 +19536,7 @@
 5	So	so	ADV	RB	_	7	advmod	7:advmod	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	Louvre	Louvre	PROPN	NNP	Number=Sing	3	appos	3:appos	_
-8	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+8	Are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 9	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 10	Two	Two	PROPN	NNP	Number=Sing	9	appos	9:appos	SpaceAfter=No
 11	"	"	PUNCT	''	_	7	punct	7:punct	SpaceAfter=No
@@ -19547,11 +19547,11 @@
 16	painting	painting	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	SpaceAfter=No
 17	/	/	SYM	,	_	18	cc	18:cc	SpaceAfter=No
 18	scupltures	scuplture	NOUN	NNS	Number=Plur	16	conj	16:conj|19:nsubj	_
-19	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 20	their	there	PRON	EX	Typo=Yes	19	expl	19:expl	CorrectForm=there
 21	and	and	CCONJ	CC	_	22	cc	22:cc	_
 22	who	who	PRON	WP	PronType=Int	19	conj	19:conj:and	_
-23	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
+23	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	artists	artist	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	SpaceAfter=No
 26	?	?	PUNCT	.	_	19	punct	19:punct	_
@@ -19582,7 +19582,7 @@
 # text = Theyre probably just drawn for the show anyways.
 1-2	Theyre	_	_	_	_	_	_	_	_
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	re	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	re	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	probably	probably	ADV	RB	_	2	advmod	2:advmod	_
 4	just	just	ADV	RB	_	5	advmod	5:advmod	_
 5	drawn	draw	VERB	VBN	Tense=Past|VerbForm=Part	2	advcl	2:advcl	_
@@ -19599,7 +19599,7 @@
 1	Name	name	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	something	something	PRON	NN	Number=Sing	1	obj	1:obj|9:nsubj	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	find	find	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	at	at	ADP	IN	_	7	case	7:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	carnival	carnival	NOUN	NN	Number=Sing	4	obl	4:obl:at	_
@@ -19669,7 +19669,7 @@
 # text = What country are we talking about?
 1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
 2	country	country	NOUN	NN	Number=Sing	5	obl	5:obl:about	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 5	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 6	about	about	ADP	IN	_	2	case	2:case	SpaceAfter=No
@@ -19678,7 +19678,7 @@
 # sent_id = answers-20111107163942AA08rP5_ans-0010
 # text = I like my Monkey Brain on a stick for sure.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	Monkey	monkey	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	Brain	brain	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -19711,7 +19711,7 @@
 # newpar id = answers-20090717130909AAPrVWu_ans-p0002
 # text = I mean besides me of course.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	besides	besides	ADP	IN	_	4	case	4:case	_
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obl	2:obl:besides	_
 5	of	of	ADP	IN	_	2	discourse	2:discourse	_
@@ -19725,7 +19725,7 @@
 2	obviously	obviously	ADV	RB	_	8	advmod	8:advmod	_
 3	most	most	ADJ	JJS	Degree=Sup	4	amod	4:amod	_
 4	people	people	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
-5	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+5	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 6	never	never	ADV	RB	_	8	advmod	8:advmod	_
 7	even	even	ADV	RB	_	8	advmod	8:advmod	_
 8	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
@@ -19738,7 +19738,7 @@
 # newpar id = answers-20090717130909AAPrVWu_ans-p0004
 # text = Someone had to be first.
 1	Someone	someone	PRON	NN	Number=Sing	2	nsubj	2:nsubj|5:nsubj:xsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	5	mark	5:mark	_
 4	be	be	AUX	VB	VerbForm=Inf	5	cop	5:cop	_
 5	first	first	ADJ	JJ	Degree=Pos|NumType=Ord	2	xcomp	2:xcomp	SpaceAfter=No
@@ -19747,7 +19747,7 @@
 # sent_id = answers-20090717130909AAPrVWu_ans-0005
 # text = I have never been there.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	never	never	ADV	RB	_	5	advmod	5:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	cop	5:cop	_
 5	there	there	ADV	RB	PronType=Dem	0	root	0:root	SpaceAfter=No
@@ -19760,14 +19760,14 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	ask	ask	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	questions	question	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 8	here	here	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
 9	because	because	SCONJ	IN	_	11	mark	11:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
+11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
 12	no	no	DET	DT	_	13	det	13:det	_
 13	clue	clue	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	what	what	PRON	WP	PronType=Int	13	acl:relcl	13:acl:relcl	_
@@ -19782,7 +19782,7 @@
 # newpar id = answers-20111108064636AAvIKDE_ans-p0001
 # text = What do you think of Air France?
 1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	of	of	ADP	IN	_	7	case	7:case	_
@@ -19794,7 +19794,7 @@
 # newpar id = answers-20111108064636AAvIKDE_ans-p0002
 # text = I love Air France!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Air	Air	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	France	France	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
 5	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -19810,7 +19810,7 @@
 7	and	and	CCONJ	CC	_	10	cc	10:cc	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	especially	especially	ADV	RB	_	10	advmod	10:advmod	_
-10	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
+10	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 12	free	free	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 13	French	French	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -19825,7 +19825,7 @@
 # text = I also find their food way better than many other airlines.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	find	find	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	food	food	NOUN	NN	Number=Sing	3	obj	3:obj|7:nsubj:xsubj	_
 6	way	way	ADV	RB	_	7	advmod	7:advmod	_
@@ -19840,7 +19840,7 @@
 # text = Plus you land in a preferential terminal...
 1	Plus	plus	CCONJ	CC	_	3	cc	3:cc	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	land	land	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	land	land	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	in	in	ADP	IN	_	7	case	7:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	preferential	preferential	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -19850,7 +19850,7 @@
 # sent_id = answers-20111108064636AAvIKDE_ans-0006
 # text = I go out of my way to use Air France.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	out	out	ADP	IN	_	6	case	6:case	_
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
@@ -19898,7 +19898,7 @@
 7	indian	Indian	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	ringneck	ringneck	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
 9	,	,	PUNCT	,	_	10	punct	10:punct	_
-10	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj	_
+10	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	bunch	bunch	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
@@ -19907,7 +19907,7 @@
 16	(	(	PUNCT	-LRB-	_	23	punct	23:punct	SpaceAfter=No
 17-18	I'm	_	_	_	_	_	_	_	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj	_
-18	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	cop	23:cop	_
+18	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	23	cop	23:cop	_
 19	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 20	very	very	ADV	RB	_	21	advmod	21:advmod	_
 21	experienced	experienced	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
@@ -19925,12 +19925,12 @@
 # sent_id = answers-20111108102612AASRNao_ans-0003
 # text = And noticed two other breeds that look a lot alike.
 1	And	and	CCONJ	CC	_	2	cc	2:cc	_
-2	noticed	notice	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	noticed	notice	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	two	two	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	breeds	breed	NOUN	NNS	Number=Plur	2	obj	2:obj|7:nsubj|10:nsubj:xsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	look	look	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	look	look	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	lot	lot	NOUN	NN	Number=Sing	10	obl:npmod	10:obl:npmod	_
 10	alike	alike	ADJ	JJ	Degree=Pos	7	xcomp	7:xcomp	SpaceAfter=No
@@ -19958,7 +19958,7 @@
 # text = if i preorder a game at gamestop can someone else pick it up for me?
 1	if	if	SCONJ	IN	_	3	mark	3:mark	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	preorder	preorder	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
+3	preorder	preorder	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	game	game	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	at	at	ADP	IN	_	7	case	7:case	_
@@ -19977,7 +19977,7 @@
 # newpar id = answers-20111108084122AAYLqSQ_ans-p0002
 # text = i put $5 bucks down for it too.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	put	put	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	put	put	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	$	$	SYM	$	_	5	compound	5:compound	SpaceAfter=No
 4	5	5	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	bucks	buck	NOUN	NNS	Number=Plur	2	obj	2:obj	_
@@ -20001,7 +20001,7 @@
 8	some	some	DET	DT	_	9	det	9:det	_
 9	gamestops	Gamestop	PROPN	NNPS	Number=Plur	12	nsubj	12:nsubj	_
 10-11	dont	_	_	_	_	_	_	_	_
-10	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+10	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	nt	not	PART	RB	_	12	advmod	12:advmod	_
 12	check	check	VERB	VB	VerbForm=Inf	6	parataxis	6:parataxis	_
 13	ID	id	NOUN	NN	Number=Sing	12	obj	12:obj	_
@@ -20018,11 +20018,11 @@
 24	doing	do	VERB	VBG	VerbForm=Ger	21	advcl	21:advcl:with	_
 25	this	this	PRON	DT	Number=Sing|PronType=Dem	24	obj	24:obj	_
 26	but	but	CCONJ	CC	_	31	cc	31:cc	_
-27	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+27	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 28	lot	lot	NOUN	NN	Number=Sing	31	nsubj	31:nsubj|33:nsubj:xsubj	_
 29	of	of	ADP	IN	_	30	case	30:case	_
 30	store	store	NOUN	NN	Number=Sing	28	nmod	28:nmod:of	_
-31	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	conj	12:conj:but	_
+31	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	conj	12:conj:but	_
 32	to	to	PART	TO	_	33	mark	33:mark	_
 33	see	see	VERB	VB	VerbForm=Inf	31	xcomp	31:xcomp	_
 34	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	35	nmod:poss	35:nmod:poss	_
@@ -20055,7 +20055,7 @@
 # text = I'm considering taking a job with Steiner and noticed I have to pay for all my travel.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj|10:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	considering	consider	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	taking	take	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -20063,9 +20063,9 @@
 7	with	with	ADP	IN	_	8	case	8:case	_
 8	Steiner	Steiner	PROPN	NNP	Number=Sing	6	nmod	6:nmod:with	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	noticed	notice	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+10	noticed	notice	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj|14:nsubj:xsubj	_
-12	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+12	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
 14	pay	pay	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 15	for	for	ADP	IN	_	18	case	18:case	_
@@ -20076,11 +20076,11 @@
 
 # sent_id = answers-20111107214231AA68BMD_ans-0003
 # text = Was wondering if anyone knew a rough estimate of how much it costs with travel and training
-1	Was	be	AUX	VBD	Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin	2	aux	2:aux	_
+1	Was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	aux	2:aux	_
 2	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	anyone	anyone	PRON	NN	Number=Sing	5	nsubj	5:nsubj	_
-5	knew	know	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:if	_
+5	knew	know	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:if	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	rough	rough	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	estimate	estimate	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -20099,18 +20099,18 @@
 # text = I haven't personally but I know a couple of people who have.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	haven't	_	_	_	_	_	_	_	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	personally	personally	ADV	RB	_	0	root	0:root	_
 5	but	but	CCONJ	CC	_	7	cc	7:cc	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+7	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	couple	couple	NOUN	NN	Number=Sing	7	obj	7:obj|13:nsubj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	people	people	NOUN	NNS	Number=Plur	9	nmod	9:nmod:of	_
 12	who	who	PRON	WP	PronType=Rel	13	nsubj	9:ref	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111107214231AA68BMD_ans-0005
@@ -20159,7 +20159,7 @@
 # sent_id = answers-20111024111513AAAQhAO_ans-0003
 # text = I need something reliable and good looking.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	something	something	PRON	NN	Number=Sing	2	obj	2:obj	_
 4	reliable	reliable	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
@@ -20182,14 +20182,14 @@
 # sent_id = answers-20111024111513AAAQhAO_ans-0005
 # text = I use them for my restaurant and always get compliments on the sleek look of the mac system not to mention how good the support is.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|9:nsubj	_
-2	use	use	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	2	obj	2:obj	_
 4	for	for	ADP	IN	_	6	case	6:case	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 6	restaurant	restaurant	NOUN	NN	Number=Sing	2	obl	2:obl:for	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	always	always	ADV	RB	_	9	advmod	9:advmod	_
-9	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 10	compliments	compliment	NOUN	NNS	Number=Plur	9	obj	9:obj	_
 11	on	on	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -20231,7 +20231,7 @@
 # newpar id = answers-20111108081519AAdHz5c_ans-p0001
 # text = What are "good" speakers?
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	"	"	PUNCT	``	_	6	punct	6:punct	SpaceAfter=No
 4	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
 5	"	"	PUNCT	``	_	6	punct	6:punct	_
@@ -20243,7 +20243,7 @@
 # text = I've been looking at the bose sound dock 10 ive currently got a jvc mini hifi system, i was wondering what would be a good set of speakers.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	looking	look	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	at	at	ADP	IN	_	9	case	9:case	_
@@ -20254,7 +20254,7 @@
 10	10	10	NUM	CD	NumType=Card	9	nummod	9:nummod	_
 11-12	ive	_	_	_	_	_	_	_	_
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	currently	currently	ADV	RB	_	14	advmod	14:advmod	_
 14	got	get	VERB	VBN	Tense=Past|VerbForm=Part	4	parataxis	4:parataxis	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
@@ -20279,7 +20279,7 @@
 # sent_id = answers-20111108081519AAdHz5c_ans-0003
 # text = I like music very loud and with a lot of bass.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	music	music	NOUN	NN	Number=Sing	2	obj	2:obj|5:nsubj:xsubj|9:nsubj:xsubj	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	loud	loud	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
@@ -20306,7 +20306,7 @@
 11	bigger	big	ADJ	JJR	Degree=Cmp	16	advcl	16:advcl:the	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	speakers	speaker	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	better	good	ADJ	JJR	Degree=Cmp	8	ccomp	8:ccomp	SpaceAfter=No
 17	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -20346,7 +20346,7 @@
 # newpar id = answers-20111108071652AA8GAZw_ans-p0002
 # text = I have ordered Bose Headfones worth 300USD.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	ordered	order	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Bose	Bose	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Headfones	headfone	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -20358,7 +20358,7 @@
 # sent_id = answers-20111108071652AA8GAZw_ans-0003
 # text = They have been shipped using USPS Priority Mail International Parcels.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux:pass	4:aux:pass	_
 4	shipped	ship	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	using	use	VERB	VBG	VerbForm=Ger	4	advcl	4:advcl	_
@@ -20413,7 +20413,7 @@
 # text = i always thought theres no custom charges for gifts.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	always	always	ADV	RB	_	3	advmod	3:advmod	_
-3	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4-5	theres	_	_	_	_	_	_	_	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
 5	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
@@ -20562,13 +20562,13 @@
 # text = NZers: Have you decided who you're going to vote for?
 1	NZers	NZer	PROPN	NNPS	Abbr=Yes|Number=Plur	5	vocative	5:vocative	SpaceAfter=No
 2	:	:	PUNCT	:	_	5	punct	5:punct	_
-3	Have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+3	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 5	decided	decide	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	who	who	PRON	WP	PronType=Int	11	obl	11:obl:for	_
 7-8	you're	_	_	_	_	_	_	_	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|11:nsubj:xsubj	_
-8	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	going	go	VERB	VBG	VerbForm=Ger	5	ccomp	5:ccomp	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	vote	vote	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
@@ -20591,7 +20591,7 @@
 # text = I'm just curious.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
 4	curious	curious	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -20602,7 +20602,7 @@
 2	of	of	ADP	IN	_	3	case	3:case	_
 3	Plenty	Plenty	PROPN	NNP	Number=Sing	1	nmod	1:nmod:of	SpaceAfter=No
 4	-	-	PUNCT	:	_	8	punct	8:punct	_
-5	Are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
+5	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	even	even	ADV	RB	_	8	advmod	8:advmod	_
 8	old	old	ADJ	JJ	Degree=Pos	0	root	0:root	_
@@ -20656,7 +20656,7 @@
 14	rest	rest	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
 15	of	of	ADP	IN	_	16	case	16:case	_
 16	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	14	nmod	14:nmod:of	_
-17	pay	pay	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:while	SpaceAfter=No
+17	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:while	SpaceAfter=No
 18	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = answers-20111106022931AAwpqXm_ans-0010
@@ -20664,7 +20664,7 @@
 1	Yes	yes	INTJ	UH	_	6	discourse	6:discourse	SpaceAfter=No
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	usually	usually	ADV	RB	_	6	advmod	6:advmod	_
 6	voted	vote	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 7	National	National	PROPN	NNP	Number=Sing	6	obj	6:obj	SpaceAfter=No
@@ -20673,7 +20673,7 @@
 # sent_id = answers-20111106022931AAwpqXm_ans-0011
 # text = I do see myself as a conservative
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	see	see	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	myself	myself	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	3	obj	3:obj	_
 5	as	as	ADP	IN	_	7	case	7:case	_
@@ -20722,7 +20722,7 @@
 3	hand	hand	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	luggage	luggage	NOUN	NN	Number=Sing	0	root	0:root	_
 5	or	or	CCONJ	CC	_	8	cc	8:cc	_
-6	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 8	have	have	VERB	VB	VerbForm=Inf	4	conj	4:conj:or	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -20744,7 +20744,7 @@
 # text = I don't think it matters
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
@@ -20806,7 +20806,7 @@
 # text = If I went into the "pre-university" direction with business administration in mind.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	into	into	ADP	IN	_	9	case	9:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 6	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
@@ -20825,13 +20825,13 @@
 1	Say	say	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	after	after	SCONJ	IN	_	4	mark	4:mark	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	finished	finish	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
+4	finished	finish	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
 5	those	that	DET	DT	Number=Plur|PronType=Dem	7	det	7:det	_
 6	2	2	NUM	CD	NumType=Card	7	nummod	7:nummod	_
 7	years	year	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	found	find	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	1:ccomp|4:conj:and	_
+10	found	find	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	1:ccomp|4:conj:and	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	job	job	NOUN	NN	Number=Sing	10	obj	10:obj	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -20876,7 +20876,7 @@
 
 # sent_id = answers-20111108100703AAo53QA_ans-0006
 # text = Thank you
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	_
 
 # sent_id = answers-20111108100703AAo53QA_ans-0007
@@ -20900,7 +20900,7 @@
 5	whatever	whatever	DET	WDT	PronType=Int	6	det	6:det	_
 6	age	age	NOUN	NN	Number=Sing	3	obl:npmod	3:obl:npmod	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+8	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = answers-20111108074555AAFT8Aj_ans
@@ -20914,7 +20914,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	device	device	NOUN	NN	Number=Sing	4	obj	4:obj|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	hold	hold	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	hold	hold	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 11	photography	photography	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -21048,7 +21048,7 @@
 # newpar id = answers-20111107155815AA6LXXJ_ans-p0002
 # text = I prefer Royal Caribbean out of all these.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	prefer	prefer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	prefer	prefer	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	Royal	Royal	ADJ	NNP	Degree=Pos	4	amod	4:amod	_
 4	Caribbean	Caribbean	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 5	out	out	ADP	IN	_	8	case	8:case	_
@@ -21081,7 +21081,7 @@
 9	although	although	SCONJ	IN	_	13	mark	13:mark	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 11-12	haven't	_	_	_	_	_	_	_	_
-11	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
+11	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	_	13	advmod	13:advmod	_
 13	sailed	sail	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:although	_
 14	on	on	ADP	IN	_	15	case	15:case	_
@@ -21150,7 +21150,7 @@
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10-11	they're	_	_	_	_	_	_	_	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj:pass	12:nsubj:pass	_
-11	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
+11	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
 12	hooked	hook	VERB	VBN	Tense=Past|VerbForm=Part	7	advcl	7:advcl:if	_
 13	up	up	ADP	RP	_	12	compound:prt	12:compound:prt	_
 14	to	to	ADP	IN	_	16	case	16:case	_
@@ -21172,7 +21172,7 @@
 # sent_id = answers-20111108084036AAh8Ws9_ans-0003
 # text = I have the HTC Evo.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	HTC	HTC	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Evo	Evo	PROPN	NNP	Number=Sing	2	obj	2:obj	SpaceAfter=No
@@ -21200,7 +21200,7 @@
 10	USB	USB	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	ports	port	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
 12-13	aren't	_	_	_	_	_	_	_	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	_	14	advmod	14:advmod	_
 14	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 15	power	power	NOUN	NN	Number=Sing	14	obj	14:obj	SpaceAfter=No
@@ -21218,14 +21218,14 @@
 # text = many PCs have sleep & charge now, that allow the PC to go into sleep mode, and still allow the USB ports to charge things like phones.
 1	many	many	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	PCs	pc	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	sleep	sleep	NOUN	NN	Number=Sing	3	obj	3:obj|10:nsubj	_
 5	&	&	CCONJ	CC	_	6	cc	6:cc	_
 6	charge	charge	NOUN	NN	Number=Sing	4	conj	3:obj|4:conj|10:nsubj	_
 7	now	now	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 8	,	,	PUNCT	,	_	10	punct	10:punct	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	4:ref	_
-10	allow	allow	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+10	allow	allow	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	PC	pc	NOUN	NN	Number=Sing	10	obj	10:obj|14:nsubj:xsubj|21:nsubj:xsubj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -21236,7 +21236,7 @@
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
 19	and	and	CCONJ	CC	_	21	cc	21:cc	_
 20	still	still	ADV	RB	_	21	advmod	21:advmod	_
-21	allow	allow	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	conj	10:xcomp|14:conj:and	_
+21	allow	allow	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	conj	10:xcomp|14:conj:and	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 23	USB	USB	NOUN	NN	Number=Sing	24	compound	24:compound	_
 24	ports	port	NOUN	NNS	Number=Plur	21	obj	21:obj|26:nsubj:xsubj	_
@@ -21285,7 +21285,7 @@
 2	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
 3	how	how	SCONJ	WRB	PronType=Int	5	mark	5:mark	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	continue	continue	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	tradition	tradition	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	SpaceAfter=No
@@ -21303,11 +21303,11 @@
 # sent_id = answers-20081218053636AA9vV0u_ans-0005
 # text = Here are some articles that discuss the details of slogan writing.
 1	Here	here	ADV	RB	PronType=Dem	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	_	4	det	4:det	_
 4	articles	article	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	discuss	discuss	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	discuss	discuss	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	details	detail	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -21320,7 +21320,7 @@
 1	Why	why	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	certain	certain	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	slogans	slogan	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6	why	why	SCONJ	WRB	PronType=Int	8	mark	8:mark	_
 7	some	some	DET	DT	_	8	nsubj	8:nsubj	_
@@ -21362,7 +21362,7 @@
 
 # sent_id = answers-20081218053636AA9vV0u_ans-0010
 # text = Goodluck!
-1	Good	good	ADJ	JJ	Degree=Pos	2	amod	2:amod	SpaceAfter=No|CorrectSpaceAfter=Yes
+1	Good	good	ADJ	JJ	Degree=Pos	2	amod	2:amod	CorrectSpaceAfter=Yes|SpaceAfter=No
 2	luck	luck	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 3	!	!	PUNCT	.	_	2	punct	2:punct	_
 
@@ -21395,7 +21395,7 @@
 # text = I'm looking for a camera that has really good zoom during a video and pictures; and good quality pictures /videos
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	looking	look	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	for	for	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -21422,7 +21422,7 @@
 # text = I'm planning on buying a compact system camera at best buy ; so please list the one(s) I should purchase.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	planning	plan	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	on	on	SCONJ	IN	_	5	mark	5:mark	_
 5	buying	buy	VERB	VBG	VerbForm=Ger	3	advcl	3:advcl:on	_
@@ -21452,7 +21452,7 @@
 1	Also	also	ADV	RB	_	8	advmod	8:advmod	_
 2	how	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
 3	much	much	ADJ	JJ	Degree=Pos	8	advmod	8:advmod	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 5	compact	compact	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	system	system	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	cameras	camera	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
@@ -21495,7 +21495,7 @@
 # newpar id = answers-20111108082432AAph0C0_ans-p0001
 # text = I need creative art ideas?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	creative	creative	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	art	art	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	ideas	idea	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
@@ -21505,7 +21505,7 @@
 # newpar id = answers-20111108082432AAph0C0_ans-p0002
 # text = What are some cool ideas for making a postor usint the word MAD on a white paper in a weird or artsy way?
 1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	_	5	det	5:det	_
 4	cool	cool	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	ideas	idea	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	_
@@ -21562,7 +21562,7 @@
 7	,	,	PUNCT	,	_	2	punct	2:punct	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl	_
+10	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	with	with	ADP	IN	_	14	case	14:case	_
@@ -21634,7 +21634,7 @@
 8	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	what	what	PRON	WP	PronType=Int	6	conj	6:conj:and	_
-11	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+11	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 12	place	place	NOUN	NN	Number=Sing	11	obj	11:obj	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -21656,7 +21656,7 @@
 1	When	when	SCONJ	WRB	PronType=Int	4	mark	4:mark	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	French	French	PROPN	NNPS	Number=Plur	4	nsubj	4:nsubj	_
-4	returned	return	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:when	_
+4	returned	return	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:when	_
 5	to	to	ADP	IN	_	6	case	6:case	_
 6	Indochina	Indochina	PROPN	NNP	Number=Sing	4	obl	4:obl:to	_
 7	at	at	ADP	IN	_	9	case	9:case	_
@@ -21668,7 +21668,7 @@
 13	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 14	Viet	Viet	PROPN	NNP	Number=Sing	15	compound	15:compound	_
 15	Minh	Minh	PROPN	NNP	Number=Sing	18	nsubj	18:nsubj	_
-16	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	cop	18:cop	_
+16	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	cop	18:cop	_
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	control	control	NOUN	NN	Number=Sing	0	root	0:root	_
 19	of	of	ADP	IN	_	23	case	23:case	_
@@ -21681,7 +21681,7 @@
 # sent_id = answers-20111107164802AAq8nhF_ans-0005
 # text = They chased the Communists out of the capital (Hanoi) and retook control.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj|13:nsubj	_
-2	chased	chase	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	chased	chase	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	Communists	Communist	PROPN	NNPS	Number=Plur	2	obj	2:obj	_
 5	out	out	ADP	IN	_	8	case	8:case	_
@@ -21692,7 +21692,7 @@
 10	Hanoi	Hanoi	PROPN	NNP	Number=Sing	8	appos	8:appos	SpaceAfter=No
 11	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
-13	retook	retake	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+13	retook	retake	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 14	control	control	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -21702,7 +21702,7 @@
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
 3	what	what	PRON	WP	PronType=Int	0	root	0:root	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 6	referring	refer	VERB	VBG	Tense=Pres|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
 7	to	to	ADP	IN	_	6	obl	6:obl	SpaceAfter=No
 8	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -21710,7 +21710,7 @@
 # sent_id = answers-20111107164802AAq8nhF_ans-0007
 # text = You need to check out the French Indochina War (1946-1954) not the Vietnam War (1957-1975).
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	check	check	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	out	out	ADP	RP	_	4	compound:prt	4:compound:prt	_
@@ -21763,9 +21763,9 @@
 # newpar id = answers-20111108104957AAsMzvU_ans-p0003
 # text = I assume you are talking about a pacman frog.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	assume	assume	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	assume	assume	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	talking	talk	VERB	VBG	VerbForm=Ger	2	ccomp	2:ccomp	_
 6	about	about	ADP	IN	_	9	case	9:case	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
@@ -21779,7 +21779,7 @@
 2	,	,	PUNCT	,	_	7	punct	7:punct	_
 3	technically	technically	ADV	RB	_	7	advmod	7:advmod	_
 4	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-5	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	not	not	PART	RB	_	7	advmod	7:advmod	_
 7	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
@@ -21787,7 +21787,7 @@
 10	light	light	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
 11	;	;	PUNCT	,	_	7	punct	7:punct	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 14	nocturnal	nocturnal	ADJ	JJ	Degree=Pos	7	parataxis	7:parataxis	SpaceAfter=No
 15	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -21803,7 +21803,7 @@
 7	hurt	hurt	VERB	VB	VerbForm=Inf	0	root	0:root	_
 8	if	if	SCONJ	IN	_	10	mark	10:mark	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-10	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	csubj	7:csubj	_
+10	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	7	csubj	7:csubj	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	provide	provide	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	one	one	NUM	CD	NumType=Card	12	obj	12:obj	SpaceAfter=No
@@ -21857,7 +21857,7 @@
 12	;	;	PUNCT	,	_	3	punct	3:punct	_
 13	captive	captive	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	reptiles	reptile	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	_
-15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
+15	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	prone	prone	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	_
 17	to	to	ADP	IN	_	19	case	19:case	_
 18	calcium	calcium	NOUN	NN	Number=Sing	19	compound	19:compound	_
@@ -21935,14 +21935,14 @@
 6	better	good	ADJ	JJR	Degree=Cmp	0	root	0:root	_
 7	(	(	PUNCT	-LRB-	_	10	punct	10:punct	SpaceAfter=No
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 10	trying	try	VERB	VBG	Tense=Pres|VerbForm=Part	6	parataxis	6:parataxis	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	save	save	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	money	money	NOUN	NN	Number=Sing	12	obj	12:obj	_
 14	now	now	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
-16	sooo	so	ADV	RB	Style=Expr	21	advmod	21:advmod	SpaceAfter=No|CorrectForm=so
+16	sooo	so	ADV	RB	Style=Expr	21	advmod	21:advmod	CorrectForm=so|SpaceAfter=No
 17	..	..	PUNCT	.	_	21	punct	21:punct	SpaceAfter=No
 18-19	thatd	_	_	_	_	_	_	_	_
 18	that	that	PRON	DT	Number=Sing|PronType=Dem	21	nsubj	21:nsubj	_
@@ -21990,7 +21990,7 @@
 # newpar id = answers-20111104115933AA30CRJ_ans-p0004
 # text = There are plenty of cheap restaurants.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	plenty	plenty	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	cheap	cheap	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -22011,7 +22011,7 @@
 3	apso	apso	NOUN	NN	Number=Sing	5	compound	5:compound	_
 4	hind	hind	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	legs	leg	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	not	not	PART	RB	_	8	advmod	8:advmod	_
 8	working	work	VERB	VBG	VerbForm=Ger	0	root	0:root	SpaceAfter=No
 9	?	?	PUNCT	.	_	8	punct	8:punct	_
@@ -22041,7 +22041,7 @@
 19	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	21	nmod:poss	21:nmod:poss	_
 20	hid	hind	ADJ	JJ	Degree=Pos|Typo=Yes	21	amod	21:amod	CorrectForm=hind
 21	legs	leg	NOUN	NNS	Number=Plur	24	nsubj	24:nsubj	_
-22	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
+22	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	not	not	PART	RB	_	24	advmod	24:advmod	_
 24	working	work	VERB	VBG	VerbForm=Ger	9	parataxis	9:parataxis	_
 25	but	but	CCONJ	CC	_	28	cc	28:cc	_
@@ -22165,7 +22165,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3-4	i'm	_	_	_	_	_	_	_	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj	_
-4	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	looking	look	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	take	take	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
@@ -22183,7 +22183,7 @@
 19	girl	girl	NOUN	NN	Number=Sing	8	conj	7:obj|8:conj:and	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	really	really	ADV	RB	_	22	advmod	22:advmod	_
-22	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	_
+22	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	_
 23	out	out	ADP	RP	_	7	compound:prt	7:compound:prt	_
 24	to	to	ADP	IN	_	25	case	25:case	_
 25	dinner	dinner	NOUN	NN	Number=Sing	7	obl	7:obl:to	_
@@ -22196,7 +22196,7 @@
 # text = I really want to go to andiamos for my birthday and i was just wondering how much it would cost for the four of us to eat there
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	really	really	ADV	RB	_	3	advmod	3:advmod	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	go	go	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	to	to	ADP	IN	_	7	case	7:case	_
@@ -22228,7 +22228,7 @@
 # sent_id = answers-20111106130843AA7yj7U_ans-0004
 # newpar id = answers-20111106130843AA7yj7U_ans-p0003
 # text = Have no idea what kind of restaurant this is or where it is.
-1	Have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	no	no	DET	DT	_	3	det	3:det	_
 3	idea	idea	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	what	what	DET	WDT	PronType=Int	5	det	5:det	_
@@ -22263,7 +22263,7 @@
 2	more	more	ADJ	JJR	Degree=Cmp	0	root	0:root	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:if	_
 6	drinks	drink	NOUN	NNS	Number=Plur	5	obj	5:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -22272,7 +22272,7 @@
 # newpar id = answers-20111107221352AAlIioO_ans-p0001
 # text = I need suggestions for San Francisco restaurants with good food and good catering service.?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	suggestions	suggestion	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	for	for	ADP	IN	_	7	case	7:case	_
 5	San	San	PROPN	NNP	Number=Sing	7	compound	7:compound	_
@@ -22291,7 +22291,7 @@
 # newpar id = answers-20111107221352AAlIioO_ans-p0002
 # text = I need suggestions on restaurants in San Francisco with good food and good catering service.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	suggestions	suggestion	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 4	on	on	ADP	IN	_	5	case	5:case	_
 5	restaurants	restaurant	NOUN	NNS	Number=Plur	3	nmod	3:nmod:on	_
@@ -22310,7 +22310,7 @@
 # sent_id = answers-20111107221352AAlIioO_ans-0003
 # text = I have two upcoming events one is for 200 and another is for 21.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	two	two	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 4	upcoming	upcoming	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	events	event	NOUN	NNS	Number=Plur	2	obj	2:obj	_
@@ -22339,7 +22339,7 @@
 10	,	,	PUNCT	,	_	12	punct	12:punct	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
 12	Chinese	Chinese	ADJ	JJ	Degree=Pos	2	conj	2:conj:and|15:nsubj	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	options	option	NOUN	NNS	Number=Plur	0	root	0:root	SpaceAfter=No
 16	.	.	PUNCT	.	_	15	punct	15:punct	_
@@ -22369,14 +22369,14 @@
 2	since	since	SCONJ	IN	_	6	mark	6:mark	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	dont	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	nt	not	PART	RB	_	6	advmod	6:advmod	_
 6	know	know	VERB	VB	VerbForm=Inf	11	advcl	11:advcl:since	_
 7	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 8	budget	budget	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+11	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 12	Hakka	Hakka	PROPN	NNP	Number=Sing	13	compound	13:compound	_
 13	Restaurant	Restaurant	PROPN	NNP	Number=Sing	11	obj	11:obj	_
 14	for	for	ADP	IN	_	16	case	16:case	_
@@ -22400,7 +22400,7 @@
 # text = prime ribs have very good food but its super expensive
 1	prime	Prime	ADJ	NNP	Degree=Pos	2	amod	2:amod	_
 2	ribs	Rib	PROPN	NNPS	Number=Plur	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	food	food	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -22441,11 +22441,11 @@
 # sent_id = answers-20111107211645AA391wC_ans-0003
 # text = Ounces measure weight, pints measure volume.
 1	Ounces	ounce	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
-2	measure	measure	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	measure	measure	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	weight	weight	NOUN	NN	Number=Sing	2	obj	2:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	2	punct	2:punct	_
 5	pints	pint	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-6	measure	measure	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+6	measure	measure	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 7	volume	volume	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -22453,7 +22453,7 @@
 # text = If you mean fluid ounces, 20, as opposed to the 16 in America.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	mean	mean	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
 4	fluid	fluid	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	ounces	ounce	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -22499,10 +22499,10 @@
 2	R	R	PROPN	NNP	Number=Sing	4	compound	4:compound	SpaceAfter=No
 3	-	-	PUNCT	HYPH	_	4	punct	4:punct	SpaceAfter=No
 4	G	G	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-5	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:as	SpaceAfter=No
+5	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:as	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	there	there	PRON	EX	_	8	expl	8:expl	_
-8	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 9	only	only	ADV	RB	_	10	advmod	10:advmod	_
 10	16	16	NUM	CD	NumType=Card	8	nsubj	8:nsubj	_
 11	in	in	ADP	IN	_	14	case	14:case	_
@@ -22518,7 +22518,7 @@
 3	well	well	ADV	RB	Degree=Pos	1	advmod	1:advmod	_
 4	because	because	SCONJ	IN	_	6	mark	6:mark	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	remember	remember	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:because	_
+6	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:because	_
 7	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 8	'	'	PUNCT	``	_	11	punct	11:punct	SpaceAfter=No
 9	irish	Irish	ADJ	JJ	Degree=Pos	11	amod	11:amod	SpaceAfter=No
@@ -22530,10 +22530,10 @@
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	canada	Canada	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
 17	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	grew	grow	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+18	grew	grow	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 19	up	up	ADP	RP	_	18	compound:prt	18:compound:prt	_
 20	in	in	ADP	IN	_	18	obl	18:obl	_
-21	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
+21	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
 22	to	to	PART	TO	_	23	mark	23:mark	_
 23	advertise	advertise	VERB	VB	VerbForm=Inf	21	xcomp	21:xcomp	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
@@ -22546,7 +22546,7 @@
 31	,	,	PUNCT	,	_	34	punct	34:punct	_
 32	but	but	CCONJ	CC	_	34	cc	34:cc	_
 33	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	34	nsubj	34:nsubj	_
-34	served	serve	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	21	conj	6:ccomp|21:conj:but	_
+34	served	serve	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	21	conj	6:ccomp|21:conj:but	_
 35	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	34	obj	34:obj	_
 36	in	in	ADP	IN	_	39	case	39:case	_
 37	american	American	ADJ	JJ	Degree=Pos	38	amod	38:amod	_
@@ -22559,7 +22559,7 @@
 1	That	that	DET	DT	Number=Sing|PronType=Dem	2	det	2:det	_
 2	place	place	NOUN	NN	Number=Sing	5	nsubj	5:nsubj|6:nsubj:xsubj	_
 3-4	didn't	_	_	_	_	_	_	_	_
-3	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
+3	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	n't	not	PART	RB	_	5	advmod	5:advmod	_
 5	stay	stay	VERB	VB	VerbForm=Inf	0	root	0:root	_
 6	open	open	ADJ	JJ	Degree=Pos	5	xcomp	5:xcomp	_
@@ -22571,7 +22571,7 @@
 # sent_id = answers-20111107155845AAE3kCA_ans-0001
 # newpar id = answers-20111107155845AAE3kCA_ans-p0001
 # text = need help finding irish music?
-1	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	help	help	NOUN	NN	Number=Sing	1	obj	1:obj	_
 3	finding	find	VERB	VBG	VerbForm=Ger	2	acl	2:acl	_
 4	irish	Irish	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -22582,14 +22582,14 @@
 # newpar id = answers-20111107155845AAE3kCA_ans-p0002
 # text = i love The Script and know there from iraland.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|6:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	The	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	Script	Script	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	know	know	VERB	VB	VerbForm=Inf	2	conj	2:conj:and	_
 7-8	there	_	_	_	_	_	_	_	_
 7	the	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs|Typo=Yes	10	nsubj	10:nsubj	CorrectForm=they
-8	re	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+8	re	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 9	from	from	ADP	IN	_	10	case	10:case	_
 10	iraland	iraland	PROPN	NNP	Number=Sing	6	ccomp	6:ccomp	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -22615,7 +22615,7 @@
 5	Script	Script	PROPN	NNP	Number=Sing	2	nmod	2:nmod:about	_
 6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-8	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+8	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	not	not	PART	RB	_	10	advmod	10:advmod	_
 10	sound	sound	VERB	VB	VerbForm=Inf	6	ccomp	6:ccomp	_
 11	that	that	ADV	RB	_	12	advmod	12:advmod	_
@@ -22627,7 +22627,7 @@
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	hear	hear	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:to	_
 19	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
-20	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	cop	22:cop	_
+20	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	22	cop	22:cop	_
 21	from	from	ADP	IN	_	22	case	22:case	_
 22	Dublin	Dublin	PROPN	NNP	Number=Sing	18	ccomp	18:ccomp	SpaceAfter=No
 23	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -22637,13 +22637,13 @@
 1	Well	well	INTJ	UH	_	8	discourse	8:discourse	_
 2	if	if	SCONJ	IN	_	5	mark	5:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	interested	interested	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:if	SpaceAfter=No
 6	,	,	PUNCT	,	_	8	punct	8:punct	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	suggest	suggest	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	suggest	suggest	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
+10	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	look	look	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	at	at	ADP	IN	_	15	case	15:case	_
@@ -22662,7 +22662,7 @@
 # sent_id = answers-20111107155845AAE3kCA_ans-0006
 # text = I think you will be pleased.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4	will	will	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	be	be	AUX	VB	VerbForm=Inf	6	cop	6:cop	_
@@ -22673,7 +22673,7 @@
 # newpar id = answers-20111107155845AAE3kCA_ans-p0004
 # text = I doubt you will get a sensible answer in the "TRAVEL" section.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	doubt	doubt	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	doubt	doubt	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 4	will	will	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 5	get	get	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
@@ -22718,7 +22718,7 @@
 6	to	to	ADP	IN	_	7	case	7:case	_
 7	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	5	nmod	5:nmod:to	_
 8	that	that	PRON	WDT	PronType=Rel	12	nsubj	5:ref	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 10	from	from	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	UK	UK	PROPN	NNP	Number=Sing	5	acl:relcl	5:acl:relcl	_
@@ -22748,7 +22748,7 @@
 # text = I'm going on a trip to Europe soon, and I need to find a good, quality raincoat.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	on	on	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -22759,7 +22759,7 @@
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	and	and	CCONJ	CC	_	13	cc	13:cc	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj|15:nsubj:xsubj	_
-13	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+13	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	find	find	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
@@ -22773,7 +22773,7 @@
 # text = I've looked and looked, but cannot find one anywhere!
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj|10:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	looked	look	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	looked	look	VERB	VBN	Tense=Past|VerbForm=Part	3	conj	3:conj:and	SpaceAfter=No
@@ -22814,7 +22814,7 @@
 10	last	last	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	one	one	NUM	CD	NumType=Card	14	nsubj	14:nsubj|16:nsubj:xsubj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	bought	buy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	bought	buy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 15	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	16	obj	16:obj	_
 16	soaked	soaked	ADJ	JJ	Degree=Pos	14	xcomp	14:xcomp	_
@@ -22843,7 +22843,7 @@
 10	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obl	3:obl:for	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
 14	to	to	PART	TO	_	13	xcomp	13:xcomp	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -22866,7 +22866,7 @@
 # sent_id = answers-20111108105137AA9BNtk_ans-0009
 # text = they do some good waterproof raincoats
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	do	do	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	some	some	DET	DT	_	6	det	6:det	_
 4	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	waterproof	waterproof	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -22890,7 +22890,7 @@
 # newpar id = answers-20111108081911AAy6QeW_ans-p0001
 # text = I have a Kodak Camera (10.2 Megapixels)... Kodak AF 5x OPTICAL LENS... how do I pause it while recording?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	Kodak	Kodak	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Camera	camera	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -22906,7 +22906,7 @@
 15	LENS	lens	NOUN	NN	Number=Sing	5	appos	5:appos	SpaceAfter=No
 16	...	...	PUNCT	,	_	2	punct	2:punct	_
 17	how	how	ADV	WRB	PronType=Int	20	advmod	20:advmod	_
-18	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+18	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 20	pause	pause	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 21	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	obj	20:obj	_
@@ -22918,7 +22918,7 @@
 # newpar id = answers-20111108081911AAy6QeW_ans-p0002
 # text = I have a Kodak Camera (10.2 Megapixels)... Kodak AF 5x OPTICAL LENS... how do I pause it while recording?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	Kodak	Kodak	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Camera	camera	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -22934,7 +22934,7 @@
 15	LENS	lens	NOUN	NN	Number=Sing	5	appos	5:appos	SpaceAfter=No
 16	...	...	PUNCT	,	_	2	punct	2:punct	_
 17	how	how	ADV	WRB	PronType=Int	20	advmod	20:advmod	_
-18	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+18	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 20	pause	pause	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 21	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	obj	20:obj	_
@@ -22947,7 +22947,7 @@
 # text = You don't... there's no such thing as "pause" in digital recording.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	SpaceAfter=No
-2	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	n't	not	PART	RB	_	2	advmod	2:advmod	_
 4	...	...	PUNCT	,	_	2	punct	2:punct	_
 5-6	there's	_	_	_	_	_	_	_	_
@@ -22996,7 +22996,7 @@
 # text = When you press the button to stop recording the data is moved from the buffer to the memory card - no pause.
 1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	press	press	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:when	_
+3	press	press	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:when	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	button	button	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -23045,7 +23045,7 @@
 # newpar id = answers-20110320195750AAkPbFG_ans-p0001
 # text = I have a Nacho Libre question.?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	Nacho	Nacho	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Libre	Libre	PROPN	NNP	Number=Sing	6	compound	6:compound	_
@@ -23074,12 +23074,12 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	cow	cow	NOUN	NN	Number=Sing	15	nmod	15:nmod:with	_
 19	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	ccomp	12:ccomp	_
+20	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	ccomp	12:ccomp	_
 21	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	22	nmod:poss	22:nmod:poss	_
 22	blouse	blouse	NOUN	NN	Number=Sing	20	obj	20:obj	_
 23	or	or	CCONJ	CC	_	25	cc	25:cc	_
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj	25:nsubj	_
-25	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	conj	12:ccomp|20:conj:or	_
+25	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	20	conj	12:ccomp|20:conj:or	_
 26	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	27	nmod:poss	27:nmod:poss	_
 27	cow	cow	NOUN	NN	Number=Sing	25	obj	25:obj	_
 28	because	because	SCONJ	IN	_	31	mark	31:mark	_
@@ -23089,7 +23089,7 @@
 32	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
 33	says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	ccomp	31:ccomp	_
 34	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	35	nsubj	35:nsubj	_
-35	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	33	ccomp	33:ccomp	_
+35	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	33	ccomp	33:ccomp	_
 36	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	37	nmod:poss	37:nmod:poss	_
 37	blouse	blouse	NOUN	NN	Number=Sing	35	obj	35:obj	SpaceAfter=No
 38	,	,	PUNCT	,	_	43	punct	43:punct	_
@@ -23105,7 +23105,7 @@
 # sent_id = answers-20110320195750AAkPbFG_ans-0003
 # text = I know its in the wrong catagory, but still, I wrote this question for a reason, not for you to critisize me.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3-4	its	_	_	_	_	_	_	_	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
 4	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
@@ -23118,7 +23118,7 @@
 11	still	still	ADV	RB	_	14	advmod	14:advmod	SpaceAfter=No
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	wrote	write	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:but	_
+14	wrote	write	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:but	_
 15	this	this	DET	DT	Number=Sing|PronType=Dem	16	det	16:det	_
 16	question	question	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	for	for	ADP	IN	_	19	case	19:case	_
@@ -23141,7 +23141,7 @@
 3	FIRST	first	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 7	posted	post	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	question	question	NOUN	NN	Number=Sing	7	obj	7:obj	_
@@ -23165,7 +23165,7 @@
 
 # sent_id = answers-20110320195750AAkPbFG_ans-0005
 # text = Do you get what's wrong with this picture?
-1	Do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4-5	what's	_	_	_	_	_	_	_	_
@@ -23239,19 +23239,19 @@
 # text = so i live in Invercargill New Zealand and i want to know if there are any good places to buy an ice-cream sundae from other than mc donalds lol
 1	so	so	ADV	RB	_	3	advmod	3:advmod	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	Invercargill	Invercargill	PROPN	NNP	Number=Sing	3	obl	3:obl:in	_
 6	New	New	ADJ	NNP	Degree=Pos	7	amod	7:amod	_
 7	Zealand	Zealand	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
+10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	know	know	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	there	there	PRON	EX	_	15	expl	15:expl	_
-15	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+15	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 16	any	any	DET	DT	_	18	det	18:det	_
 17	good	good	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	places	place	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
@@ -23285,12 +23285,12 @@
 # newpar id = answers-20111106015552AAj6rCu_ans-p0003
 # text = you live in NZ and you eat McDonalds ice cream?
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	nsubj	2:nsubj	_
-2	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	in	in	ADP	IN	_	4	case	4:case	_
 4	NZ	NZ	PROPN	NNP	Number=Sing	2	obl	2:obl:in	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	eat	eat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+7	eat	eat	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 8-9	McDonalds	_	_	_	_	_	_	_	_
 8	McDonald	McDonald	PROPN	NNP	Number=Sing	11	nmod:poss	11:nmod:poss	_
 9	s	's	PART	POS	_	8	case	8:case	_
@@ -23302,7 +23302,7 @@
 # text = you're mad!
 1-2	you're	_	_	_	_	_	_	_	_
 1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-2	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	mad	mad	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	!	!	PUNCT	.	_	3	punct	3:punct	_
 
@@ -23360,13 +23360,13 @@
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	few	few	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
 28	weeks	week	NOUN	NNS	Number=Plur	22	obl	22:obl:for	_
-29	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	conj	22:conj:and	_
+29	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	22	conj	22:conj:and	_
 30	some	some	DET	DT	_	32	det	32:det	_
 31	Ice	ice	NOUN	NN	Number=Sing	32	compound	32:compound	_
 32	Cream	cream	NOUN	NN	Number=Sing	29	obj	29:obj	_
 33	and	and	CCONJ	CC	_	35	cc	35:cc	_
 34	really	really	ADV	RB	_	35	advmod	35:advmod	_
-35	enjoyed	enjoy	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	22	conj	22:conj:and	_
+35	enjoyed	enjoy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	22	conj	22:conj:and	_
 36	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	35	obj	35:obj	_
 37	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	39	nsubj	39:nsubj	_
 38	will	will	AUX	MD	VerbForm=Fin	39	aux	39:aux	_
@@ -23418,7 +23418,7 @@
 20	castle	castle	PROPN	NNP	Number=Sing	16	conj	6:nmod:like|16:conj	_
 21	which	which	DET	WDT	PronType=Int	22	det	22:det	_
 22	one	one	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	_
-23	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
+23	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 24	like	like	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	best	well	ADV	RBS	Degree=Sup	24	obl:npmod	24:obl:npmod	SpaceAfter=No
@@ -23434,12 +23434,12 @@
 # text = Onion Rings are great and the fries are endless.
 1	Onion	onion	NOUN	NN	Number=Sing	2	compound	2:compound	_
 2	Rings	ring	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 4	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	9	cc	9:cc	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	fries	fry	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 9	endless	endless	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	SpaceAfter=No
 10	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -23453,7 +23453,7 @@
 # sent_id = answers-20111106103415AAqdokn_ans-0006
 # newpar id = answers-20111106103415AAqdokn_ans-p0003
 # text = idk ur choice
-1	idk	idk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	discourse	3:discourse	_
+1	idk	idk	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	discourse	3:discourse	_
 2	ur	ur	PRON	PRP$	_	3	nmod:poss	3:nmod:poss	_
 3	choice	choice	NOUN	NN	Number=Sing	0	root	0:root	_
 
@@ -23483,7 +23483,7 @@
 6	burger	burger	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	formula	formula	NOUN	NN	Number=Sing	3	obj	3:obj|9:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	started	start	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	about	about	ADV	IN	_	11	advmod	11:advmod	_
 11	80	80	NUM	CD	NumType=Card	12	nummod	12:nummod	_
 12	years	year	NOUN	NNS	Number=Plur	13	obl:npmod	13:obl:npmod	_
@@ -23493,7 +23493,7 @@
 # sent_id = answers-20111106103415AAqdokn_ans-0010
 # text = There are currently 5 locations:
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	currently	currently	ADV	RB	_	2	advmod	2:advmod	_
 4	5	5	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	locations	location	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	SpaceAfter=No
@@ -23532,7 +23532,7 @@
 3	DD	DD	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	SpaceAfter=No
 4	&	&	CCONJ	CC	_	5	cc	5:cc	SpaceAfter=No
 5	D	D	PROPN	NNP	Number=Sing	3	conj	3:conj|6:nsubj	_
-6	showed	show	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
+6	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
 7	at	at	ADP	IN	_	10	case	10:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	original	original	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
@@ -23563,7 +23563,7 @@
 11	rings	ring	NOUN	NNS	Number=Plur	8	nmod	8:nmod:of	_
 12	if	if	SCONJ	IN	_	16	mark	16:mark	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 15	with	with	ADP	IN	_	16	case	16:case	_
 16	someone	someone	PRON	NN	Number=Sing	6	advcl	6:advcl:with	SpaceAfter=No
 17	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -23617,7 +23617,7 @@
 # text = I've tried bland white rice but he wont eat anything.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	bland	bland	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	white	white	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -23691,7 +23691,7 @@
 5	-	-	PUNCT	,	_	24	punct	24:punct	_
 6	if	if	SCONJ	IN	_	10	mark	10:mark	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj|14:nsubj	_
-8	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
+8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
 9	only	only	ADV	RB	_	10	advmod	10:advmod	_
 10	happened	happen	VERB	VBN	Tense=Past|VerbForm=Part	24	advcl	24:advcl:if	_
 11	once	once	ADV	RB	NumType=Mult	10	advmod	10:advmod	_
@@ -23709,13 +23709,13 @@
 23	have	have	AUX	VB	VerbForm=Inf	24	aux	24:aux	_
 24	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 25	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
-26	missed	miss	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	24	ccomp	24:ccomp	_
+26	missed	miss	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	24	ccomp	24:ccomp	_
 27	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	29	nmod:poss	29:nmod:poss	_
 28	meal	meal	NOUN	NN	Number=Sing	29	compound	29:compound	_
 29	time	time	NOUN	NN	Number=Sing	26	obj	26:obj	_
 30	and	and	CCONJ	CC	_	32	cc	32:cc	_
 31	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	32	nsubj	32:nsubj|34:nsubj:xsubj	_
-32	needed	need	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	26	conj	24:ccomp|26:conj:and	_
+32	needed	need	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	26	conj	24:ccomp|26:conj:and	_
 33	to	to	PART	TO	_	34	mark	34:mark	_
 34	eat	eat	VERB	VB	VerbForm=Inf	32	xcomp	32:xcomp	_
 35	-	-	PUNCT	,	_	24	punct	24:punct	_
@@ -23774,7 +23774,7 @@
 # newpar id = answers-20111107200249AAIyCy5_ans-p0001
 # text = why are there two statues of David?
 1	why	why	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
-2	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	there	there	PRON	EX	_	2	expl	2:expl	_
 4	two	two	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	statues	statue	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
@@ -23794,10 +23794,10 @@
 7	donatello	donatello	PROPN	NNP	Number=Sing	5	nmod	5:nmod:on	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	notice	notice	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+10	notice	notice	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 11	that	that	SCONJ	IN	_	13	mark	13:mark	_
 12	there	there	PRON	EX	_	13	expl	13:expl	_
-13	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+13	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
 14	two	two	NUM	CD	NumType=Card	15	nummod	15:nummod	_
 15	statues	statue	NOUN	NNS	Number=Plur	13	nsubj	13:nsubj	_
 16	of	of	ADP	IN	_	17	case	17:case	_
@@ -23814,19 +23814,19 @@
 # sent_id = answers-20111107200249AAIyCy5_ans-0003
 # text = Michelangelo made the marble one but why did he do another if Donatello had already made one?
 1	Michelangelo	Michelangelo	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	marble	marble	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	one	one	NOUN	NN	Number=Sing	2	obj	2:obj	_
 6	but	but	CCONJ	CC	_	10	cc	10:cc	_
 7	why	why	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
-8	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
+8	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 10	do	do	VERB	VB	VerbForm=Inf	2	conj	2:conj:but	_
 11	another	another	DET	DT	_	10	obj	10:obj	_
 12	if	if	SCONJ	IN	_	16	mark	16:mark	_
 13	Donatello	Donatello	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj	_
-14	had	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
+14	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	already	already	ADV	RB	_	16	advmod	16:advmod	_
 16	made	make	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	_
 17	one	one	NUM	CD	NumType=Card	16	obj	16:obj	SpaceAfter=No
@@ -23837,7 +23837,7 @@
 1	so	so	ADV	RB	_	6	advmod	6:advmod	_
 2-3	im	_	_	_	_	_	_	_	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-3	m	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+3	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	little	little	ADJ	JJ	Degree=Pos	6	obl:npmod	6:obl:npmod	_
 6	confused	confused	ADJ	JJ	Degree=Pos	0	root	0:root	_
@@ -23888,7 +23888,7 @@
 # text = Because he liked making statues of David! :D
 1	Because	because	SCONJ	IN	_	3	mark	3:mark	_
 2	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
-3	liked	like	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	liked	like	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	making	make	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	statues	statue	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	of	of	ADP	IN	_	7	case	7:case	_
@@ -23960,7 +23960,7 @@
 # newpar id = answers-20111107082312AAPNaxb_ans-p0002
 # text = I have a friend out in Chicago this week, and I am trying to remember the name of an awesome hibachi style restaurant i visited while out there a couple years ago.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	friend	friend	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	out	out	ADV	RB	_	4	advmod	4:advmod	_
@@ -23984,7 +23984,7 @@
 23	style	style	NOUN	NN	Number=Sing	24	compound	24:compound	_
 24	restaurant	restaurant	NOUN	NN	Number=Sing	18	nmod	18:nmod:of	_
 25	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	visited	visit	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	_
+26	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	_
 27	while	while	SCONJ	IN	_	29	mark	29:mark	_
 28	out	out	ADV	RB	_	29	advmod	29:advmod	_
 29	there	there	ADV	RB	PronType=Dem	26	advcl	26:advcl:while	_
@@ -23997,7 +23997,7 @@
 # sent_id = answers-20111107082312AAPNaxb_ans-0003
 # text = I think it was in the Lincoln Square area but don't quote me on that.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|13:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 4	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	cop	9:cop	_
 5	in	in	ADP	IN	_	9	case	9:case	_
@@ -24060,7 +24060,7 @@
 6	square	square	NOUN	NN	Number=Sing	8	compound	8:compound	_
 7	open	open	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	hibachi	hibachi	NOUN	NN	Number=Sing	2	nmod	2:nmod:around	_
-9	cook	cook	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+9	cook	cook	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 10	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	food	food	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
 12	,	,	PUNCT	,	_	20	punct	20:punct	_
@@ -24099,7 +24099,7 @@
 4	epic	epic	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	as	as	SCONJ	IN	_	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	remember	remember	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:as	_
+7	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:as	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	would	would	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 10	love	love	VERB	VB	VerbForm=Inf	4	conj	4:conj:and	_
@@ -24151,7 +24151,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	SpaceAfter=No
 3-4	I'm	_	_	_	_	_	_	_	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj	_
-4	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	about	about	ADV	RB	_	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	graduate	graduate	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
@@ -24164,7 +24164,7 @@
 14	and	and	CCONJ	CC	_	17	cc	17:cc	_
 15-16	I'm	_	_	_	_	_	_	_	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj|19:nsubj:xsubj	_
-16	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
+16	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 17	planning	plan	VERB	VBG	VerbForm=Ger	5	conj	5:conj:and	_
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	study	study	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	_
@@ -24188,7 +24188,7 @@
 12	,	,	PUNCT	,	_	15	punct	15:punct	SpaceAfter=No
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj|17:nsubj:xsubj	_
-15	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	conj	7:conj:and|25:advcl:since	_
+15	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	conj	7:conj:and|25:advcl:since	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	go	go	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	aground	around	ADP	IN	Typo=Yes	20	case	20:case	CorrectForm=around
@@ -24196,7 +24196,7 @@
 20	world	world	NOUN	NN	Number=Sing	17	obl	17:obl:aground	SpaceAfter=No
 21	,	,	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
 22	what	what	PRON	WP	PronType=Int	25	obj	25:obj	_
-23	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
+23	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	25	nsubj	25:nsubj	_
 25	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
 26	,	,	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
@@ -24234,7 +24234,7 @@
 # text = If you have to wait, due to financial reasons, then wait.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	wait	wait	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
@@ -24270,7 +24270,7 @@
 19	as	as	SCONJ	IN	_	22	mark	22:mark	_
 20-21	I'm	_	_	_	_	_	_	_	_
 20	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
-21	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
+21	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
 22	sure	sure	ADJ	JJ	Degree=Pos	13	advcl	13:advcl:as	_
 23	this	this	DET	DT	Number=Sing|PronType=Dem	24	det	24:det	_
 24	trip	trip	NOUN	NN	Number=Sing	26	nsubj:pass	26:nsubj:pass|28:nsubj:xsubj	_
@@ -24292,7 +24292,7 @@
 8	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	6	ccomp	6:ccomp	_
 9	sure	sure	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
+11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	money	money	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	and	and	CCONJ	CC	_	18	cc	18:cc	_
@@ -24364,12 +24364,12 @@
 7	again	again	ADV	RB	_	6	advmod	6:advmod	_
 8	when	when	SCONJ	WRB	PronType=Int	10	mark	10:mark	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|15:nsubj	_
-10	take	take	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:when	_
+10	take	take	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	advcl	4:advcl:when	_
 11	out	out	ADP	RP	_	10	compound:prt	10:compound:prt	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	battery	battery	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
-15	put	put	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	conj	4:advcl:when|10:conj:and	_
+15	put	put	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	conj	4:advcl:when|10:conj:and	_
 16	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	obj	15:obj	_
 17	back	back	ADV	RB	_	15	advmod	15:advmod	_
 18	in	in	ADV	RB	_	15	advmod	15:advmod	SpaceAfter=No
@@ -24377,7 +24377,7 @@
 
 # sent_id = answers-20111108074455AAiMwmn_ans-0004
 # text = did anyone have this issue?
-1	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
+1	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing	3	nsubj	3:nsubj	_
 3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
@@ -24423,7 +24423,7 @@
 6	normally	normally	ADV	RB	_	5	advmod	5:advmod	SpaceAfter=No
 7	,	,	PUNCT	,	_	5	punct	5:punct	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	parataxis	5:parataxis	_
+9	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	parataxis	5:parataxis	_
 10	warranty	warranty	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
 11	,	,	PUNCT	,	_	5	punct	5:punct	_
 12	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	5	parataxis	5:parataxis	_
@@ -24444,12 +24444,12 @@
 # sent_id = answers-20111108074455AAiMwmn_ans-0010
 # text = I shoot a t1i and haven't had such an issue.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|8:nsubj	_
-2	shoot	shoot	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	shoot	shoot	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	t1i	t1i	PROPN	NNP	Number=Sing	2	obj	2:obj	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6-7	haven't	_	_	_	_	_	_	_	_
-6	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	_	8	advmod	8:advmod	_
 8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj:and	_
 9	such	such	DET	PDT	_	11	det:predet	11:det:predet	_
@@ -24461,7 +24461,7 @@
 # text = I also agree it's under warranty so get in touch with Canon.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	also	also	ADV	RB	_	3	advmod	3:advmod	_
-3	agree	agree	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	agree	agree	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4-5	it's	_	_	_	_	_	_	_	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 5	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -24539,7 +24539,7 @@
 # text = I'm going on a vacation to the Philippines in May 2012, and I'm starting from Raleigh, NC (RDU Airport).
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 4	on	on	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -24554,7 +24554,7 @@
 14	and	and	CCONJ	CC	_	17	cc	17:cc	_
 15-16	I'm	_	_	_	_	_	_	_	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-16	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
+16	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 17	starting	start	VERB	VBG	VerbForm=Ger	3	conj	3:conj:and	_
 18	from	from	ADP	IN	_	19	case	19:case	_
 19	Raleigh	Raleigh	PROPN	NNP	Number=Sing	17	obl	17:obl:from	SpaceAfter=No
@@ -24612,7 +24612,7 @@
 6	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	_
 7	what	what	PRON	WP	PronType=Int	9	obl	9:obl:with	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
+9	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
 10	up	up	ADV	RB	_	9	advmod	9:advmod	_
 11	with	with	ADP	IN	_	7	case	7:case	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -24701,7 +24701,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	states	State	PROPN	NNPS	Number=Plur	5	nmod	5:nmod:from	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+11	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 12	"	"	PUNCT	``	_	14	punct	14:punct	SpaceAfter=No
 13	Fly	Fly	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	genesis	genesis	PROPN	NNP	Number=Sing	11	obj	11:obj	SpaceAfter=No
@@ -24716,7 +24716,7 @@
 # sent_id = answers-20111108102205AArwNzY_ans-0011
 # text = They gave the best service & rates I could find.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	best	good	ADJ	JJS	Degree=Sup	5	amod	5:amod	_
 5	service	service	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -24750,7 +24750,7 @@
 # text = I just moved into the city, and I'm wondering if there's a place I can get good deals on restaurants here.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	moved	move	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	moved	move	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	into	into	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	city	city	NOUN	NN	Number=Sing	3	obl	3:obl:into	SpaceAfter=No
@@ -24758,7 +24758,7 @@
 8	and	and	CCONJ	CC	_	11	cc	11:cc	_
 9-10	I'm	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-10	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	wondering	wonder	VERB	VBG	VerbForm=Ger	3	conj	3:conj:and	_
 12	if	if	SCONJ	IN	_	14	mark	14:mark	_
 13-14	there's	_	_	_	_	_	_	_	_
@@ -24780,7 +24780,7 @@
 # text = I don't want to have to deal with those deal-a-day websites like Groupon.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj|8:nsubj:xsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -24803,7 +24803,7 @@
 # text = I just want a simple way to get a good deal to whatever Restaurant I want, whenever I want.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	simple	simple	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	way	way	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -24816,11 +24816,11 @@
 13	whatever	whatever	DET	WDT	PronType=Int	14	det	14:det	_
 14	Restaurant	restaurant	NOUN	NN	Number=Sing	11	nmod	11:nmod:to	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
+16	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	8	punct	8:punct	_
 18	whenever	whenever	SCONJ	WRB	PronType=Int	20	mark	20:mark	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:whenever	SpaceAfter=No
+20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:whenever	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111103205154AAOod9K_ans-0005
@@ -24840,7 +24840,7 @@
 # text = I usually use ZebraKlub.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	usually	usually	ADV	RB	_	3	advmod	3:advmod	_
-3	use	use	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	ZebraKlub	ZebraKlub	PROPN	NNP	Number=Sing	3	obj	3:obj	SpaceAfter=No
 5	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -24848,7 +24848,7 @@
 # text = They basically buy daily deals from Groupon, Living Social, and all sorts of other places.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	basically	basically	ADV	RB	_	3	advmod	3:advmod	_
-3	buy	buy	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	buy	buy	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	daily	daily	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	deals	deal	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	from	from	ADP	IN	_	7	case	7:case	_
@@ -24876,7 +24876,7 @@
 7	whatever	whatever	DET	WDT	PronType=Int	8	det	8:det	_
 8	deal	deal	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	anytime	anytime	NOUN	NN	Number=Sing	6	obl:tmod	6:obl:tmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -24907,7 +24907,7 @@
 # text = If you want to eat cheaply without worrying about all those daily deal emails every day, ZebraKlub should be perfect for you.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	eat	eat	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	cheaply	cheaply	ADV	RB	_	5	advmod	5:advmod	_
@@ -24959,7 +24959,7 @@
 7	side	side	NOUN	NN	Number=Sing	3	nmod	3:nmod:on	_
 8	and	and	CCONJ	CC	_	10	cc	10:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
+10	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
 11	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	obj	10:obj|14:nsubj:xsubj	_
 12	to	to	PART	TO	_	14	mark	14:mark	_
 13	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
@@ -25030,7 +25030,7 @@
 19	,	,	PUNCT	,	_	2	punct	2:punct	_
 20	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
 21	also	also	ADV	RB	_	22	advmod	22:advmod	_
-22	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+22	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 23	many	many	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 24	inside	inside	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	exhibits	exhibit	NOUN	NNS	Number=Plur	22	obj	22:obj	_
@@ -25078,12 +25078,12 @@
 # sent_id = answers-20111106230959AAuYQ5Q_ans-0007
 # text = You are busy, you don't have to sit face to face to try
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	busy	busy	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 6-7	don't	_	_	_	_	_	_	_	_
-6	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	_	8	advmod	8:advmod	_
 8	have	have	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -25108,7 +25108,7 @@
 9	so	so	ADV	RB	_	16	advmod	16:advmod	_
 10	if	if	SCONJ	IN	_	12	mark	12:mark	_
 11	things	thing	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-12	go	go	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
+12	go	go	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
 13	great	great	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
@@ -25121,7 +25121,7 @@
 3	and	and	CCONJ	CC	_	13	cc	13:cc	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|8:nsubj:xsubj	_
-6	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
+6	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	end	end	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obj	8:obj	SpaceAfter=No
@@ -25145,7 +25145,7 @@
 # newpar id = answers-20111108104517AAw5v4L_ans-p0001
 # text = I decided to get a 150 gal aquarium, what can I fill it with?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	decided	decide	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	get	get	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -25190,7 +25190,7 @@
 # text = I've never kept cichlids though.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	never	never	ADV	RB	_	4	advmod	4:advmod	_
 4	kept	keep	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	cichlids	cichlid	NOUN	NNS	Number=Plur	4	obj	4:obj	_
@@ -25200,7 +25200,7 @@
 # sent_id = answers-20111108104517AAw5v4L_ans-0005
 # text = I know saltwater is a possibility, can you give me a possible stocking option for that too?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	saltwater	saltwater	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -25252,7 +25252,7 @@
 8	gallon	gallon	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	tank	tank	NOUN	NN	Number=Sing	4	nmod	4:nmod:for	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	upgraded	upgrade	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+11	upgraded	upgrade	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	_
 13	to	to	ADP	IN	_	14	case	14:case	_
 14	200	200	NUM	CD	NumType=Card	11	obl	11:obl:to	_
@@ -25301,7 +25301,7 @@
 # text = If you took out the clown loach it would make a nice 150 gallon tank.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:if	_
+3	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:if	_
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	clown	clown	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -25351,7 +25351,7 @@
 # newpar id = reviews-219984-p0001
 # text = never response the phone call
 1	never	never	ADV	RB	_	2	advmod	2:advmod	_
-2	response	response	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	response	response	VERB	VBP	Mood=Imp|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	phone	phone	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	call	call	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -25431,7 +25431,7 @@
 2	A	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 3	GREAT	great	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	DEAL	deal	NOUN	NN	Number=Sing	0	root	0:root	_
-5	THANK	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+5	THANK	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 6	YOU	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	obj	5:obj	_
 
 # newdoc id = reviews-166983
@@ -25440,7 +25440,7 @@
 # text = The pancakes are to die for.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	pancakes	pancake	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	die	die	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
 6	for	for	ADP	IN	_	5	obl	5:obl	SpaceAfter=No
@@ -25477,7 +25477,7 @@
 1	Friendliest	friendly	ADJ	JJS	Degree=Sup	2	amod	2:amod	_
 2	place	place	NOUN	NN	Number=Sing	0	root	0:root	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	ever	ever	ADV	RB	_	6	advmod	6:advmod	_
 6	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	SpaceAfter=No
 7	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -25500,7 +25500,7 @@
 # newpar id = reviews-058009-p0001
 # text = It taste better than In and Out....
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	taste	taste	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	taste	taste	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	better	good	ADJ	JJR	Degree=Cmp	2	xcomp	2:xcomp	_
 4	than	than	ADP	IN	_	5	case	5:case	_
 5	In	In	PROPN	NNP	Number=Sing	3	obl	3:obl:than	_
@@ -25517,7 +25517,7 @@
 3	steakhouse	steakhouse	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+6	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	obj	6:obj	SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	_
 
@@ -25560,7 +25560,7 @@
 2	Informative	informative	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	website	website	NOUN	NN	Number=Sing	0	root	0:root	_
 4	with	with	ADP	IN	_	6	case	6:case	_
-5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 6	lot	lot	NOUN	NN	Number=Sing	3	nmod	3:nmod:with	_
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	good	good	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -25639,11 +25639,11 @@
 # newpar id = reviews-255757-p0001
 # text = they recovered the pics geeksquad deleted.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	recovered	recover	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	recovered	recover	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	pics	pic	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	geeksquad	geeksquad	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	deleted	delete	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+6	deleted	delete	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-255757-0002
@@ -25696,7 +25696,7 @@
 3	that	that	PRON	WDT	PronType=Rel	6	obj	2:ref	_
 4-5	I'd	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-5	'd	have	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
+5	'd	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
 6	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	_
 7	so	so	ADV	RB	_	8	advmod	8:advmod	_
 8	far	far	ADV	RB	Degree=Pos	6	advmod	6:advmod	SpaceAfter=No
@@ -25737,7 +25737,7 @@
 1	and	and	CCONJ	CC	_	5	cc	5:cc	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	people	people	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	sweet	sweet	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	:)	:)	SYM	NFP	_	5	discourse	5:discourse	_
 
@@ -25747,11 +25747,11 @@
 # text = Yeah they ruined some shirts I had too.
 1	Yeah	yeah	INTJ	UH	_	3	discourse	3:discourse	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	ruined	ruin	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	ruined	ruin	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	some	some	DET	DT	_	5	det	5:det	_
 5	shirts	shirt	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	too	too	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -25823,7 +25823,7 @@
 # sent_id = reviews-034858-0001
 # newpar id = reviews-034858-p0001
 # text = Thank you for fixing the leak on my bathroom!
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	obj	1:obj	_
 3	for	for	SCONJ	IN	_	4	mark	4:mark	_
 4	fixing	fix	VERB	VBG	VerbForm=Ger	1	advcl	1:advcl:for	_
@@ -25853,7 +25853,7 @@
 7	club	club	NOUN	NN	Number=Sing	0	root	0:root	_
 8-9	I've	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-9	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	_	11	advmod	11:advmod	_
 11	been	be	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
 12	to	to	ADP	IN	_	11	obl	11:obl	_
@@ -25942,10 +25942,10 @@
 # sent_id = reviews-124492-0002
 # newpar id = reviews-124492-p0002
 # text = Installed Biometrics and Got Excellent Service.
-1	Installed	install	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Installed	install	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	Biometrics	Biometrics	PROPN	NNPS	Number=Plur	1	obj	1:obj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
-4	Got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+4	Got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 5	Excellent	excellent	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	Service	service	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -25957,7 +25957,7 @@
 1	Feels	feel	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	like	like	SCONJ	IN	_	6	mark	6:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	Brooklyn	Brooklyn	PROPN	NNP	Number=Sing	1	advcl	1:advcl:in	SpaceAfter=No
 7	,	,	PUNCT	,	_	12	punct	12:punct	_
@@ -26021,7 +26021,7 @@
 4	in	in	ADP	IN	_	6	case	6:case	_
 5	Bay	Bay	PROPN	NNP	Number=Sing	6	compound	6:compound	_
 6	Ridge	Ridge	PROPN	NNP	Number=Sing	3	nmod	3:nmod:in	_
-7	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	everything	everything	PRON	NN	Number=Sing	7	obj	7:obj|12:obj	_
 9	what	what	DET	WDT	PronType=Rel	12	obj	8:ref	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
@@ -26042,12 +26042,12 @@
 # newpar id = reviews-086914-p0002
 # text = I refer to VNHH often and love you guys.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|7:nsubj	_
-2	refer	refer	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	refer	refer	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	4	case	4:case	_
 4	VNHH	VNHH	PROPN	NNP	Number=Sing	2	obl	2:obl:to	_
 5	often	often	ADV	RB	_	2	advmod	2:advmod	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+7	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	det	9:det	_
 9	guys	guy	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -26056,7 +26056,7 @@
 # sent_id = reviews-346074-0001
 # newpar id = reviews-346074-p0001
 # text = Did a great job of removing my tree in Conyers.
-1	Did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 3	great	great	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	job	job	NOUN	NN	Number=Sing	1	obj	1:obj	_
@@ -26143,7 +26143,7 @@
 1	Quality	quality	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	service	service	NOUN	NN	Number=Sing	1	conj	1:conj:and|4:nsubj	_
-4	come	come	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	first	first	ADV	RB	_	4	advmod	4:advmod	_
 6	here	here	ADV	RB	PronType=Dem	4	advmod	4:advmod	SpaceAfter=No
 7	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -26160,7 +26160,7 @@
 # sent_id = reviews-212369-0002
 # text = We got upgraded to a corner suite!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	upgraded	upgrade	VERB	VBN	Tense=Past|VerbForm=Part	2	xcomp	2:xcomp	_
 4	to	to	ADP	IN	_	7	case	7:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -26229,7 +26229,7 @@
 # newpar id = reviews-223040-p0001
 # text = I love this place lots of people to talk to and school is across the street!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	place	place	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	lots	lot	NOUN	NNS	Number=Plur	2	parataxis	2:parataxis	_
@@ -26250,7 +26250,7 @@
 # sent_id = reviews-224117-0001
 # newpar id = reviews-224117-p0001
 # text = Drove all the way over from the highway... closed at 7.
-1	Drove	drive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	all	all	DET	PDT	_	4	det:predet	4:det:predet	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	way	way	NOUN	NN	Number=Sing	1	obl:npmod	1:obl:npmod	_
@@ -26259,7 +26259,7 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	highway	highway	NOUN	NN	Number=Sing	1	obl	1:obl:from	SpaceAfter=No
 9	...	...	PUNCT	,	_	1	punct	1:punct	_
-10	closed	close	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+10	closed	close	VERB	VBD	Tense=Past|VerbForm=Part	1	parataxis	1:parataxis	_
 11	at	at	ADP	IN	_	12	case	12:case	_
 12	7	7	NUM	CD	NumType=Card	10	obl	10:obl:at	SpaceAfter=No
 13	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -26276,7 +26276,7 @@
 # newpar id = reviews-232278-p0001
 # text = You are the only one auto glass repair shop in the area I would count on.
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 4	only	only	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 5	one	one	NUM	CD	NumType=Card	9	nummod	9:nummod	_
@@ -26336,12 +26336,12 @@
 
 # sent_id = reviews-192399-0003
 # text = Listened to my problem and took care of it.
-1	Listened	listen	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Listened	listen	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	to	to	ADP	IN	_	4	case	4:case	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	problem	problem	NOUN	NN	Number=Sing	1	obl	1:obl:to	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+6	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 7	care	care	NOUN	NN	Number=Sing	6	obj	6:obj	_
 8	of	of	ADP	IN	_	9	case	9:case	_
 9	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	obl	6:obl:of	SpaceAfter=No
@@ -26397,7 +26397,7 @@
 # text = I just called this number and it is a Ralph's Market.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	number	number	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	12	cc	12:cc	_
@@ -26510,7 +26510,7 @@
 # newpar id = reviews-138110-p0002
 # text = I had to get a permit here, it was cool
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	get	get	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -26534,7 +26534,7 @@
 3	mani	mani	NOUN	NN	Number=Sing	0	root	0:root	_
 4-5	Ive	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-5	ve	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+5	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	ever	ever	ADV	RB	_	7	advmod	7:advmod	_
 7	had	have	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -26559,7 +26559,7 @@
 # text = You guys do everything wonderful!
 1	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	do	do	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	everything	everything	PRON	NN	Number=Sing	3	obj	3:obj	_
 5	wonderful	wonderful	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 6	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -26578,7 +26578,7 @@
 9	thing	thing	NOUN	NN	Number=Sing	5	obl	5:obl:of	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 11-12	didn't	_	_	_	_	_	_	_	_
-11	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
+11	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	_	13	advmod	13:advmod	_
 13	like	like	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 14	!	!	PUNCT	.	_	5	punct	5:punct	_
@@ -26601,7 +26601,7 @@
 2	staff	staff	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|8:nsubj|11:nsubj	_
 3	in	in	ADP	IN	_	4	case	4:case	_
 4	Allentown	Allentown	PROPN	NNP	Number=Sing	2	nmod	2:nmod:in	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	friendly	friendly	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
 8	helpful	helpful	ADJ	JJ	Degree=Pos	6	conj	6:conj:and	_
@@ -26655,7 +26655,7 @@
 # text = I just had the best experience at this Kal Tire location.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	best	good	ADJ	JJS	Degree=Sup	6	amod	6:amod	_
 6	experience	experience	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -26723,10 +26723,10 @@
 
 # sent_id = reviews-241108-0004
 # text = Did services I asked them NOTto do and was still charged.
-1	Did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	services	service	NOUN	NNS	Number=Plur	1	obj	1:obj	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	asked	ask	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	obj	4:obj|8:nsubj:xsubj	_
 6-7	NOTto	_	_	_	_	_	_	_	_
 6	NOT	not	ADV	RB	_	8	advmod	8:advmod	_
@@ -26791,7 +26791,7 @@
 # sent_id = reviews-363482-0002
 # text = How do you run a cafe, with no refills on coffee-?
 1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 4	run	run	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
@@ -26835,7 +26835,7 @@
 
 # sent_id = reviews-002317-0003
 # text = thank you
-1	thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	obj	1:obj	_
 
 # newdoc id = reviews-059655
@@ -26856,7 +26856,7 @@
 # sent_id = reviews-059655-0002
 # text = and did great job .
 1	and	and	CCONJ	CC	_	2	cc	2:cc	_
-2	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	great	great	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	job	job	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -26877,7 +26877,7 @@
 # newpar id = reviews-390330-p0001
 # text = I appreciate the quick, good service and the reasonable prices and will definitely use American Pride Irrigation & Landscaping again.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|15:nsubj	_
-2	appreciate	appreciate	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	appreciate	appreciate	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 4	quick	quick	ADJ	JJ	Degree=Pos	7	amod	7:amod	SpaceAfter=No
 5	,	,	PUNCT	,	_	7	punct	7:punct	_
@@ -26904,9 +26904,9 @@
 # newpar id = reviews-126086-p0001
 # text = I like I Move CA - Los Angeles Movers, they moved me before, but this time they were awesome :)
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	like	like	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	Move	move	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	compound	9:compound	_
+4	Move	move	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	compound	9:compound	_
 5	CA	CA	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 6	-	-	PUNCT	HYPH	_	9	punct	9:punct	_
 7	Los	Los	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -26914,7 +26914,7 @@
 9	Movers	Mover	PROPN	NNPS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 10	,	,	PUNCT	,	_	2	punct	2:punct	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	moved	move	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
+12	moved	move	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	obj	12:obj	_
 14	before	before	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
@@ -26922,7 +26922,7 @@
 17	this	this	DET	DT	Number=Sing|PronType=Dem	18	det	18:det	_
 18	time	time	NOUN	NN	Number=Sing	21	obl:tmod	21:obl:tmod	_
 19	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-20	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	21	cop	21:cop	_
+20	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	21	cop	21:cop	_
 21	awesome	awesome	ADJ	JJ	Degree=Pos	12	conj	12:conj:but	_
 22	:)	:)	SYM	NFP	_	2	discourse	2:discourse	_
 
@@ -26981,7 +26981,7 @@
 
 # sent_id = reviews-025516-0002
 # text = Sent scented flowers home instead of postcards.
-1	Sent	send	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	scented	scent	VERB	VBN	Tense=Past|VerbForm=Part	3	amod	3:amod	_
 3	flowers	flower	NOUN	NNS	Number=Plur	1	obj	1:obj	_
 4	home	home	ADV	RB	_	1	advmod	1:advmod	_
@@ -26992,7 +26992,7 @@
 
 # sent_id = reviews-025516-0003
 # text = Recommend you call in for a look.
-1	Recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
 3	call	call	VERB	VB	VerbForm=Inf	1	ccomp	1:ccomp	_
 4	in	in	ADP	RP	_	3	compound:prt	3:compound:prt	_
@@ -27021,7 +27021,7 @@
 14	rudest	rude	ADJ	JJS	Degree=Sup	15	amod	15:amod	_
 15	person	person	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
-17	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
+17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	ever	ever	ADV	RB	_	19	advmod	19:advmod	_
 19	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	15	acl:relcl	15:acl:relcl	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -27076,7 +27076,7 @@
 # text = These guys took Customer Service 101 from a Neanderthal.
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	took	take	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	Customer	customer	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	Service	service	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	101	101	NUM	CD	NumType=Card	5	nummod	5:nummod	_
@@ -27088,7 +27088,7 @@
 # sent_id = reviews-245928-0003
 # text = They are especially rude to women.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	especially	especially	ADV	RB	_	4	advmod	4:advmod	_
 4	rude	rude	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	to	to	ADP	IN	_	6	case	6:case	_
@@ -27124,7 +27124,7 @@
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	servers	server	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 4-5	don't	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	_	6	advmod	6:advmod	_
 6	pay	pay	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	attention	attention	NOUN	NN	Number=Sing	6	obj	6:obj	_
@@ -27151,7 +27151,7 @@
 6	sandwiches	sandwich	NOUN	NNS	Number=Plur	1	nmod	1:nmod:of	_
 7-8	I've	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-8	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Seattle	Seattle	PROPN	NNP	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
@@ -27184,7 +27184,7 @@
 5	best	good	ADJ	JJS	Degree=Sup	6	amod	6:amod	_
 6	steaks	steak	NOUN	NNS	Number=Plur	3	appos	3:appos	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-8	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+8	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	_	10	advmod	10:advmod	_
 10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 11	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -27194,7 +27194,7 @@
 1	Great	great	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	meats	meat	NOUN	NNS	Number=Plur	0	root	0:root|6:nsubj|8:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	6	nsubj	2:ref	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 5	already	already	ADV	RB	_	6	advmod	6:advmod	_
 6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
@@ -27303,7 +27303,7 @@
 # text = The workers sped up and down the street with no mind to the small children playing.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	workers	worker	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	sped	speed	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	sped	speed	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	up	up	ADP	IN	_	8	case	8:case	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	down	down	ADP	IN	_	4	conj	4:conj:and|8:case	_
@@ -27330,7 +27330,7 @@
 # newpar id = reviews-171877-p0002
 # text = they are the best orthodontics in the world.
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	best	good	ADJ	JJS	Degree=Sup	5	amod	5:amod	_
 5	orthodontics	orthodontics	NOUN	NNS	Number=Plur	0	root	0:root	_
@@ -27342,7 +27342,7 @@
 # sent_id = reviews-171877-0003
 # text = i went there since i was four.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	there	there	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
 4	since	since	SCONJ	IN	_	7	mark	7:mark	_
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
@@ -27412,7 +27412,7 @@
 3	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	assistant	assistant	NOUN	NN	Number=Sing	1	conj	1:conj:and|6:nsubj	_
 5	both	both	DET	DT	_	1	advmod	1:advmod	_
-6	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	great	great	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	job	job	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
@@ -27447,7 +27447,7 @@
 # text = what a mindblowing servicing
 1	what	what	DET	WDT	PronType=Int	5	det:predet	5:det:predet	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-3	mind	mind	NOUN	NN	Number=Sing	4	compound	4:compound	SpaceAfter=No|CorrectSpaceAfter=Yes
+3	mind	mind	NOUN	NN	Number=Sing	4	compound	4:compound	CorrectSpaceAfter=Yes|SpaceAfter=No
 4	blowing	blow	VERB	VBG	VerbForm=Ger	5	amod	5:amod	_
 5	servicing	servicing	NOUN	NN	Number=Sing	0	root	0:root	_
 
@@ -27455,7 +27455,7 @@
 # newpar id = reviews-171255-p0002
 # text = They treat there employees with respect and concern and expect that they will extend the same politeness to there customers.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj|10:nsubj	_
-2	treat	treat	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	treat	treat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	there	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs|Typo=Yes	4	nmod:poss	4:nmod:poss	CorrectForm=their
 4	employees	employee	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	with	with	ADP	IN	_	6	case	6:case	_
@@ -27463,7 +27463,7 @@
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	concern	concern	NOUN	NN	Number=Sing	6	conj	2:obl:with|6:conj:and	_
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
-10	expect	expect	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+10	expect	expect	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 11	that	that	SCONJ	IN	_	14	mark	14:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
@@ -27529,7 +27529,7 @@
 # sent_id = reviews-122514-0002
 # text = Rooms were clean, plenty of things to do near hotel, and safe part of town.
 1	Rooms	room	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|15:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	cop	3:cop	_
 3	clean	clean	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
 5	plenty	plenty	NOUN	NN	Number=Sing	3	parataxis	3:parataxis	_
@@ -27560,7 +27560,7 @@
 # newpar id = reviews-329807-p0002
 # text = I have been using Steele Electric for years.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	using	use	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	Steele	Steele	PROPN	NNP	Number=Sing	6	compound	6:compound	_
@@ -27572,7 +27572,7 @@
 # sent_id = reviews-329807-0003
 # text = They have always done a great job at a reasonable price.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	always	always	ADV	RB	_	4	advmod	4:advmod	_
 4	done	do	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
@@ -27604,10 +27604,10 @@
 2	and	and	CCONJ	CC	_	5	cc	5:cc	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	doctor	doctor	NOUN	NN	Number=Sing	5	nsubj	5:nsubj|6:nsubj:xsubj|8:nsubj	_
-5	acted	act	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+5	acted	act	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 6	arrogant	arrogant	ADJ	JJ	Degree=Pos	5	xcomp	5:xcomp	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	rushed	rush	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+8	rushed	rush	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 9	at	at	ADP	IN	_	11	case	11:case	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	time	time	NOUN	NN	Number=Sing	8	obl	8:obl:at	_
@@ -27646,7 +27646,7 @@
 9	best	well	ADV	RBS	Degree=Sup	13	advmod	13:advmod	_
 10	of	of	ADP	IN	_	9	obl	9:obl	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 13	transparent	transparent	ADJ	JJ	Degree=Pos	7	conj	7:conj:and	_
 14	with	with	ADP	IN	_	16	case	16:case	_
 15	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
@@ -27667,7 +27667,7 @@
 # newpar id = reviews-313126-p0001
 # text = I gave Dr. Rohatgi 2 stars because her assistant was very pleasant.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	Dr.	Dr.	PROPN	NNP	Number=Sing	2	iobj	2:iobj	_
 4	Rohatgi	Rohatgi	PROPN	NNP	Number=Sing	3	flat	3:flat	_
 5	2	2	NUM	CD	NumType=Card	6	nummod	6:nummod	_
@@ -27685,7 +27685,7 @@
 1	However	however	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
+4	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
 6	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	obj	6:obj|9:nsubj:xsubj	_
@@ -27721,14 +27721,14 @@
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	fries	fry	NOUN	NNS	Number=Plur	6	nsubj:pass	6:nsubj:pass	_
 3-4	weren't	_	_	_	_	_	_	_	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 4	n't	not	PART	RB	_	6	advmod	6:advmod	_
 5	fully	fully	ADV	RB	_	6	advmod	6:advmod	_
 6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 7	last	last	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	time	time	NOUN	NN	Number=Sing	6	obl:tmod	6:obl:tmod	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	there	there	ADV	RB	PronType=Dem	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -27750,19 +27750,19 @@
 2	management	management	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	staff	staff	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj	_
-5	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
+5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	superb	superb	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 7	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-369608-0002
 # text = I worked with Sam Mones who took great care of me.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	worked	work	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	with	with	ADP	IN	_	4	case	4:case	_
 4	Sam	Sam	PROPN	NNP	Number=Sing	2	obl	2:obl:with|7:nsubj	_
 5	Mones	Mones	PROPN	NNP	Number=Sing	4	flat	4:flat	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	4:ref	_
-7	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 8	great	great	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	care	care	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
@@ -27794,18 +27794,18 @@
 5	but	but	CCONJ	CC	_	8	cc	8:cc	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 7	never	never	ADV	RB	_	8	advmod	8:advmod	_
-8	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+8	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	wait	wait	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	long	long	ADV	RB	Degree=Pos	10	advmod	10:advmod	_
 12	because	because	SCONJ	IN	_	15	mark	15:mark	_
 13	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-14	ARE	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+14	ARE	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 15	orginizied	organized	ADJ	JJ	Degree=Pos|Typo=Yes	8	advcl	8:advcl:because	CorrectForm=organized|SpaceAfter=No
 16	,	,	PUNCT	,	_	15	punct	15:punct	_
 17	so	so	ADV	RB	_	19	advmod	19:advmod	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
-19	are	be	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl	_
 20	in	in	ADV	RB	_	19	advmod	19:advmod	SpaceAfter=No
 21	,	,	PUNCT	,	_	22	punct	22:punct	_
 22	out	out	ADV	RB	_	20	conj	19:advmod|20:conj:and	SpaceAfter=No
@@ -27839,7 +27839,7 @@
 9	Rated	rate	VERB	VBN	Tense=Past|VerbForm=Part	10	amod	10:amod	_
 10	Attorney	attorney	NOUN	NN	Number=Sing	0	root	0:root	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	Have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
+12	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	Ever	ever	ADV	RB	_	14	advmod	14:advmod	_
 14	Met	meet	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	10	punct	10:punct	_
@@ -27848,7 +27848,7 @@
 # text = I Highly Recommend, The Law Offices Of Dale Gribow!!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	Highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	Recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	Recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	The	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	Law	law	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -27891,7 +27891,7 @@
 # text = The employees are really friendly.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	employees	employee	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-3	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	really	really	ADV	RB	_	5	advmod	5:advmod	_
 5	friendly	friendly	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -27900,7 +27900,7 @@
 # text = And they deliver!
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	deliver	deliver	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	deliver	deliver	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 4	!	!	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = reviews-336285
@@ -27917,7 +27917,7 @@
 # text = If you want the best for your child, don't hesitate in visiting this wornderful school.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	best	good	ADJ	JJS	Degree=Sup	3	obj	3:obj	_
 6	for	for	ADP	IN	_	8	case	8:case	_
@@ -28011,13 +28011,13 @@
 # text = Mrs. Tolchin provided us with excellent service and came with a great deal of knowledge and professionalism!
 1	Mrs.	Mrs.	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj|9:nsubj	_
 2	Tolchin	Tolchin	PROPN	NNP	Number=Sing	1	flat	1:flat	_
-3	provided	provide	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	3	obj	3:obj	_
 5	with	with	ADP	IN	_	7	case	7:case	_
 6	excellent	excellent	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	service	service	NOUN	NN	Number=Sing	3	obl	3:obl:with	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 10	with	with	ADP	IN	_	13	case	13:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	great	great	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
@@ -28034,7 +28034,7 @@
 2	flexibility	flexibility	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	accessibility	accessibility	NOUN	NN	Number=Sing	2	conj	2:conj:and|5:nsubj	_
-5	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	for	for	ADP	IN	_	9	case	9:case	_
 7	an	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	easy	easy	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -28065,7 +28065,7 @@
 4	than	than	SCONJ	IN	_	5	mark	5:mark	_
 5	not	not	PART	RB	_	2	ccomp	2:ccomp	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	end	end	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	end	end	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 8	up	up	ADP	RP	_	7	compound:prt	7:compound:prt	_
 9	with	with	ADP	IN	_	12	case	12:case	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -28091,14 +28091,14 @@
 # newpar id = reviews-101864-p0002
 # text = I have no complaints about the service I received.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	no	no	DET	DT	_	4	det	4:det	_
 4	complaints	complaint	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	about	about	ADP	IN	_	7	case	7:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	service	service	NOUN	NN	Number=Sing	4	nmod	4:nmod:about	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	received	receive	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	SpaceAfter=No
+9	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
 # sent_id = reviews-101864-0003
@@ -28119,10 +28119,10 @@
 # text = I never felt worried and walked away satisfied.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj|6:nsubj|8:nsubj:xsubj	_
 2	never	never	ADV	RB	_	3	advmod	3:advmod	_
-3	felt	feel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	worried	worried	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
-6	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+6	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 7	away	away	ADV	RB	_	6	advmod	6:advmod	_
 8	satisfied	satisfied	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -28148,7 +28148,7 @@
 7	SO	so	ADV	RB	_	8	advmod	8:advmod	_
 8	MEAN	mean	ADJ	JJ	Degree=Pos	0	root	0:root	_
 9	THEY	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-10	GET	get	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+10	GET	get	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 11	MAD	mad	ADJ	JJ	Degree=Pos	8	parataxis	8:parataxis	_
 12	AT	at	ADP	IN	_	13	case	13:case	_
 13	YOU	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	11	obl	11:obl:at	_
@@ -28165,7 +28165,7 @@
 5	SCHOOL	school	NOUN	NN	Number=Sing	0	root	0:root	_
 6-7	IVE	_	_	_	_	_	_	_	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-7	VE	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+7	VE	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	BEEN	be	AUX	VBN	Tense=Past|VerbForm=Part	9	cop	9:cop	_
 9	TO	to	ADP	IN	_	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 10	!!!!!!	!!!!!!	PUNCT	.	_	5	punct	5:punct	_
@@ -28189,14 +28189,14 @@
 6	through	through	ADP	RP	_	5	compound:prt	5:compound:prt	_
 7	when	when	SCONJ	WRB	PronType=Int	9	mark	9:mark	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
+9	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:when	_
 10	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-270889-0003
 # text = We have tried many different computer people until now - we will stick with Qualitech Computers!!!
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	many	many	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 5	different	different	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -28233,7 +28233,7 @@
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7-8	I'm	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-8	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
+8	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 9	just	just	ADV	RB	_	12	advmod	12:advmod	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	little	little	ADJ	JJ	Degree=Pos	12	obl:npmod	12:obl:npmod	_
@@ -28270,7 +28270,7 @@
 # sent_id = reviews-217747-0002
 # text = "Thank you so much for the superior job well done.
 1	"	"	PUNCT	``	_	2	punct	2:punct	SpaceAfter=No
-2	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	obj	2:obj	_
 4	so	so	ADV	RB	_	5	advmod	5:advmod	_
 5	much	much	ADV	RB	_	2	advmod	2:advmod	_
@@ -28285,7 +28285,7 @@
 # sent_id = reviews-217747-0003
 # text = We love everything about the fence.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	everything	everything	PRON	NN	Number=Sing	2	obj	2:obj	_
 4	about	about	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
@@ -28323,7 +28323,7 @@
 # newpar id = reviews-264993-p0002
 # text = I schedule my weekly appointment here just to get a chance to lie comfortably on my tummy.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	schedule	schedule	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	schedule	schedule	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	weekly	weekly	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	appointment	appointment	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -28346,7 +28346,7 @@
 1	And	and	CCONJ	CC	_	5	cc	5:cc	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	massages	massage	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	heavenly	heavenly	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	!	!	PUNCT	.	_	5	punct	5:punct	_
 
@@ -28361,7 +28361,7 @@
 # sent_id = reviews-256677-0001
 # newpar id = reviews-256677-p0001
 # text = Love Hop City
-1	Love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	Hop	Hop	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	City	City	PROPN	NNP	Number=Sing	1	obj	1:obj	_
 
@@ -28379,14 +28379,14 @@
 1	Craig	Craig	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 2	and	and	CCONJ	CC	_	3	cc	3:cc	_
 3	Nate	Nate	PROPN	NNP	Number=Sing	1	conj	1:conj:and|5:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	wonderful	wonderful	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = reviews-256677-0004
 # text = I know now where to get all of my wine and beer.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	now	now	ADV	RB	_	2	advmod	2:advmod	_
 4	where	where	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -28427,7 +28427,7 @@
 2	's	's	PART	POS	_	1	case	1:case	_
 3	Corona	Corona	PROPN	NNP	Number=Sing	4	compound	4:compound	_
 4	dryers	dryer	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	remove	remove	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	remove	remove	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	at	at	ADP	IN	_	7	case	7:case	_
 7	least	least	ADJ	JJS	Degree=Sup	8	obl	8:obl:at	_
 8	twice	twice	ADV	RB	NumType=Mult	9	advmod	9:advmod	_
@@ -28467,7 +28467,7 @@
 7	emergency	emergency	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	plumbers	plumber	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	8:ref	_
-10	visted	visit	VERB	VBD	Mood=Ind|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited
+10	visted	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited
 11	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	shop	shop	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	in	in	ADP	IN	_	15	case	15:case	_
@@ -28482,12 +28482,12 @@
 2	fast	fast	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	service	service	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	SpaceAfter=No
 4	,	,	PUNCT	,	_	5	punct	5:punct	_
-5	saved	save	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	saved	save	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	bad	bad	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	situation	situation	NOUN	NN	Number=Sing	5	obj	5:obj	_
 9	getting	get	AUX	VBG	VerbForm=Ger	12	aux	12:aux	_
-10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 11	lot	lot	NOUN	NN	Number=Sing	12	obl:npmod	12:obl:npmod	_
 12	worse	bad	ADJ	JJR	Degree=Cmp	8	acl	8:acl	SpaceAfter=No
 13	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -28509,7 +28509,7 @@
 4	food	food	NOUN	NN	Number=Sing	0	root	0:root	_
 5-6	I've	_	_	_	_	_	_	_	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-6	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
+6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	_	8	advmod	8:advmod	_
 8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 9	in	in	ADP	IN	_	10	case	10:case	_
@@ -28540,7 +28540,7 @@
 10	Geelong	Geelong	PROPN	NNP	Number=Sing	8	nmod	8:nmod:in	SpaceAfter=No
 11	...	...	PUNCT	,	_	8	punct	8:punct	_
 12	just	just	ADV	RB	_	13	advmod	13:advmod	_
-13	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	8	parataxis	8:parataxis	_
+13	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	parataxis	8:parataxis	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 
 # newdoc id = reviews-034320
@@ -28660,12 +28660,12 @@
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
 3	really	really	ADV	RB	_	4	advmod	4:advmod	_
-4	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 6	stuff	stuff	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	..	..	PUNCT	,	_	4	punct	4:punct	_
 8	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+9	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 10	almost	almost	ADV	RB	_	11	advmod	11:advmod	_
 11	anything	anything	PRON	NN	Number=Sing	9	obj	9:obj	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
@@ -28739,11 +28739,11 @@
 # text = These guys know what they're doing!
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
 5-6	they're	_	_	_	_	_	_	_	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-6	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+6	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 7	doing	do	VERB	VBG	VerbForm=Ger	3	ccomp	3:ccomp	SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	_
 
@@ -28773,7 +28773,7 @@
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	literally	literally	ADV	RB	_	9	advmod	9:advmod	_
-9	taste	taste	VERB	VBP	Mood=Ind|Tense=Pres|Typo=Yes|VerbForm=Fin	3	parataxis	3:parataxis	CorrectForm=taste
+9	taste	taste	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	3	parataxis	3:parataxis	CorrectForm=taste
 10	like	like	ADP	IN	_	11	case	11:case	_
 11	water	water	NOUN	NN	Number=Sing	9	obl	9:obl:like	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -28782,16 +28782,16 @@
 # text = When I tried to return it they refused, so I had to leave without a refund and still hungry.
 1	When	when	SCONJ	WRB	PronType=Int	3	mark	3:mark	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
+3	tried	try	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	return	return	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	obj	5:obj	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
-8	refused	refuse	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+8	refused	refuse	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 9	,	,	PUNCT	,	_	8	punct	8:punct	_
 10	so	so	ADV	RB	_	12	advmod	12:advmod	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj|14:nsubj:xsubj	_
-12	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	parataxis	8:parataxis	_
+12	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	parataxis	8:parataxis	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
 14	leave	leave	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 15	without	without	ADP	IN	_	17	case	17:case	_
@@ -28810,7 +28810,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	representative	representative	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
-5	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	way	way	ADV	RB	_	7	advmod	7:advmod	_
 7	above	above	ADV	RB	_	5	advmod	5:advmod	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
@@ -28828,16 +28828,16 @@
 # sent_id = reviews-186235-0002
 # text = i wish the other utilities i had to set up had people to work with like this..
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	wish	wish	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	wish	wish	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	utilities	utility	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	set	set	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	up	up	ADP	RP	_	9	compound:prt	9:compound:prt	_
-11	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
 12	people	people	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
 14	work	work	VERB	VB	VerbForm=Inf	12	acl	12:acl:to	_
@@ -28866,7 +28866,7 @@
 
 # sent_id = reviews-343813-0003
 # text = Travelled 40mins after calling to see if a product was in stock.
-1	Travelled	travel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Travelled	travel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	40	40	NUM	CD	NumType=Card	3	nummod	3:nummod	SpaceAfter=No
 3	mins	minute	NOUN	NNS	Abbr=Yes|Number=Plur	1	obj	1:obj	_
 4	after	after	SCONJ	IN	_	5	mark	5:mark	_
@@ -28886,17 +28886,17 @@
 1	Told	tell	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 2	that	that	SCONJ	IN	_	4	mark	4:mark	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
+4	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
 5	plenty	plenty	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-343813-0005
 # text = Get there and there was nothing.
-1	Get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	there	there	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 3	and	and	CCONJ	CC	_	5	cc	5:cc	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
 6	nothing	nothing	PRON	NN	Number=Sing	5	nsubj	5:nsubj	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -28982,7 +28982,7 @@
 # sent_id = reviews-307170-0003
 # text = I use their limo services for all of my airport car services and airport transportation needs
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	use	use	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 4	limo	limo	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	services	service	NOUN	NNS	Number=Plur	2	obj	2:obj	_
@@ -29014,7 +29014,7 @@
 # sent_id = reviews-012047-0002
 # text = They specialize in financial institutions, medical, and retail projects.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	specialize	specialize	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	specialize	specialize	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	in	in	ADP	IN	_	5	case	5:case	_
 4	financial	financial	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	institutions	institution	NOUN	NNS	Number=Plur	2	obl	2:obl:in	SpaceAfter=No
@@ -29030,14 +29030,14 @@
 # text = These guys know what they're doing and helped me in all phases of our project.
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|9:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
 5-6	they're	_	_	_	_	_	_	_	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-6	're	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+6	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 7	doing	do	VERB	VBG	VerbForm=Ger	3	ccomp	3:ccomp	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	helped	help	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+9	helped	help	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	all	all	DET	DT	_	13	det	13:det	_
@@ -29100,11 +29100,11 @@
 # newpar id = reviews-035993-p0001
 # text = They have fresh flowers, lasted a long while in the vase, and the two ladies at the shop know the business well.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	fresh	fresh	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	flowers	flower	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
-6	lasted	last	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	lasted	last	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	long	long	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	while	while	NOUN	NN	Number=Sing	6	obl:tmod	6:obl:tmod	_
@@ -29119,7 +29119,7 @@
 18	at	at	ADP	IN	_	20	case	20:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	shop	shop	NOUN	NN	Number=Sing	17	nmod	17:nmod:at	_
-21	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+21	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	business	business	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	well	well	ADV	RB	Degree=Pos	21	advmod	21:advmod	SpaceAfter=No
@@ -29128,7 +29128,7 @@
 # sent_id = reviews-035993-0002
 # text = I had no problem with my delivery.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	no	no	DET	DT	_	4	det	4:det	_
 4	problem	problem	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	with	with	ADP	IN	_	7	case	7:case	_
@@ -29158,7 +29158,7 @@
 # newpar id = reviews-290238-p0002
 # text = I think this location is no longer in business.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	location	location	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
@@ -29172,12 +29172,12 @@
 # text = If you check RecWarehouse.com, they don't list this as a location.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	check	check	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	check	check	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	RecWarehouse.com	recwarehouse.com	X	ADD	_	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	9	punct	9:punct	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 7-8	don't	_	_	_	_	_	_	_	_
-7	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
+7	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	n't	not	PART	RB	_	9	advmod	9:advmod	_
 9	list	list	VERB	VB	VerbForm=Inf	0	root	0:root	_
 10	this	this	PRON	DT	Number=Sing|PronType=Dem	9	obj	9:obj	_
@@ -29215,7 +29215,7 @@
 # text = MFJ Inc transformed our run down back yard into a place of beauty.
 1	MFJ	MFJ	PROPN	NNP	Number=Sing	2	compound	2:compound	_
 2	Inc	Inc	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	transformed	transform	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	transformed	transform	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 5	run	run	VERB	VBN	Tense=Past|VerbForm=Part	8	amod	8:amod	_
 6	down	down	ADP	RP	_	5	compound	5:compound	_
@@ -29306,7 +29306,7 @@
 # sent_id = reviews-045972-0001
 # newpar id = reviews-045972-p0001
 # text = Feel good
-1	Feel	feel	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	good	good	ADJ	JJ	Degree=Pos	1	xcomp	1:xcomp	_
 
 # sent_id = reviews-045972-0002
@@ -29314,7 +29314,7 @@
 # text = I just wanted to try your clinic because I was not totally happy with my current therapist I regularly see.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	try	try	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	7	nmod:poss	7:nmod:poss	_
@@ -29331,7 +29331,7 @@
 17	therapist	therapist	NOUN	NN	Number=Sing	13	obl	13:obl:with	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 19	regularly	regularly	ADV	RB	_	20	advmod	20:advmod	_
-20	see	see	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+20	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-045972-0003
@@ -29339,7 +29339,7 @@
 1	Now	now	ADV	RB	_	4	advmod	4:advmod	_
 2-3	I've	_	_	_	_	_	_	_	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-3	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+3	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 4	found	find	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	someone	someone	PRON	NN	Number=Sing	4	obj	4:obj|8:nsubj|10:nsubj:xsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
@@ -29350,7 +29350,7 @@
 11	what	what	PRON	WP	PronType=Int	10	obj	10:obj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	really	really	ADV	RB	_	14	advmod	14:advmod	_
-14	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # newdoc id = reviews-024306
@@ -29366,13 +29366,13 @@
 # text = This place had the worst tasting pizza I have ever tasted it was possible the worst food I've ever eaten.
 1	This	this	DET	DT	Number=Sing|PronType=Dem	2	det	2:det	_
 2	place	place	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 5	worst	bad	ADV	RBS	Degree=Sup	6	advmod	6:advmod	_
 6	tasting	taste	VERB	VBG	VerbForm=Ger	7	amod	7:amod	_
 7	pizza	pizza	NOUN	NN	Number=Sing	3	obj	3:obj	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-9	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
+9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	_	11	advmod	11:advmod	_
 11	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
@@ -29383,7 +29383,7 @@
 17	food	food	NOUN	NN	Number=Sing	3	parataxis	3:parataxis	_
 18-19	I've	_	_	_	_	_	_	_	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-19	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
+19	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
 20	ever	ever	ADV	RB	_	21	advmod	21:advmod	_
 21	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -29392,7 +29392,7 @@
 # text = I don't recommend this place to anyone or even anything to eat.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	don't	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	_	4	advmod	4:advmod	_
 4	recommend	recommend	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
@@ -29434,7 +29434,7 @@
 # sent_id = reviews-341750-0004
 # text = I felt as if I was in an over priced Olive Garden.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	felt	feel	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	as	as	SCONJ	IN	_	12	mark	12:mark	_
 4	if	if	SCONJ	IN	_	12	mark	12:mark	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
@@ -29474,7 +29474,7 @@
 # newpar id = reviews-214912-p0001
 # text = I have used Bright Futures for the last 7 years.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	used	use	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Bright	Bright	ADJ	NNP	Degree=Pos	5	amod	5:amod	_
 5	Futures	Future	PROPN	NNPS	Number=Plur	3	obj	3:obj	_
@@ -29488,13 +29488,13 @@
 # sent_id = reviews-214912-0002
 # text = I have 3 children there and they are the Best.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	3	3	NUM	CD	NumType=Card	4	nummod	4:nummod	_
 4	children	child	NOUN	NNS	Number=Plur	2	obj	2:obj	_
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
 6	and	and	CCONJ	CC	_	10	cc	10:cc	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
+8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	Best	good	ADJ	JJS	Degree=Sup	2	conj	2:conj:and	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -29502,7 +29502,7 @@
 # sent_id = reviews-214912-0003
 # text = They are like family.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
+2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	like	like	ADP	IN	_	4	case	4:case	_
 4	family	family	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -29537,7 +29537,7 @@
 # newpar id = reviews-263909-p0002
 # text = Bisconti wanted over $300 to fix my laptop and these guys fixed it for $90!
 1	Bisconti	Bisconti	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
-2	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	over	over	ADV	RB	_	4	advmod	4:advmod	_
 4	$	$	SYM	$	_	2	obj	2:obj|7:nsubj:xsubj	SpaceAfter=No
 5	300	300	NUM	CD	NumType=Card	4	nummod	4:nummod	_
@@ -29548,7 +29548,7 @@
 10	and	and	CCONJ	CC	_	13	cc	13:cc	_
 11	these	this	DET	DT	Number=Plur|PronType=Dem	12	det	12:det	_
 12	guys	guy	NOUN	NNS	Number=Plur	13	nsubj	13:nsubj	_
-13	fixed	fix	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+13	fixed	fix	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	for	for	ADP	IN	_	16	case	16:case	_
 16	$	$	SYM	$	_	13	obl	13:obl:for	SpaceAfter=No
@@ -29564,7 +29564,7 @@
 
 # sent_id = reviews-263909-0004
 # text = Had it fixed within a few days (had to order a part).
-1	Had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	obj	1:obj|3:nsubj:xsubj	_
 3	fixed	fix	VERB	VBN	Tense=Past|VerbForm=Part	1	xcomp	1:xcomp	_
 4	within	within	ADP	IN	_	7	case	7:case	_
@@ -29572,7 +29572,7 @@
 6	few	few	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	days	day	NOUN	NNS	Number=Plur	3	obl	3:obl:within	_
 8	(	(	PUNCT	-LRB-	_	1	punct	1:punct	SpaceAfter=No
-9	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
+9	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	order	order	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
@@ -29604,7 +29604,7 @@
 # text = My nails looked great for the better part of 2 weeks!
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	nails	nail	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|4:nsubj:xsubj	_
-3	looked	look	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	looked	look	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	great	great	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 5	for	for	ADP	IN	_	8	case	8:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
@@ -29623,7 +29623,7 @@
 4	and	and	CCONJ	CC	_	18	cc	18:cc	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	stylists	stylist	NOUN	NNS	Number=Plur	18	nsubj	18:nsubj	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 8	not	not	PART	RB	_	18	advmod	18:advmod	_
 9	in	in	ADP	IN	_	18	case	18:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
@@ -29643,7 +29643,7 @@
 # text = Fast Service Called them one hour ago and they just left my house five minutes ago.
 1	Fast	fast	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	Service	service	NOUN	NN	Number=Sing	0	root	0:root	_
-3	Called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
+3	Called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	obj	3:obj	_
 5	one	one	NUM	CD	NumType=Card	6	nummod	6:nummod	_
 6	hour	hour	NOUN	NN	Number=Sing	7	obl:npmod	7:obl:npmod	_
@@ -29651,7 +29651,7 @@
 8	and	and	CCONJ	CC	_	11	cc	11:cc	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	just	just	ADV	RB	_	11	advmod	11:advmod	_
-11	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
+11	left	leave	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 12	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	house	house	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	five	five	NUM	CD	NumType=Card	15	nummod	15:nummod	_
@@ -29676,7 +29676,7 @@
 13	Pest	Pest	PROPN	NNP	Number=Sing	8	nmod	8:nmod:to	_
 14-15	I'm	_	_	_	_	_	_	_	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-15	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
+15	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 16	enjoying	enjoy	VERB	VBG	VerbForm=Ger	4	conj	4:conj:and	_
 17	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 18	time	time	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -29703,13 +29703,13 @@
 4	upset	upset	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:when	_
+7	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:when	_
 8	to	to	ADP	IN	_	9	case	9:case	_
 9	Mother	Mother	PROPN	NNP	Number=Sing	7	obl	7:obl:to	_
 10	Plucker	Plucker	PROPN	NNP	Number=Sing	9	flat	9:flat	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-13	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+13	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 14	NO	no	DET	DT	_	15	det	15:det	_
 15	FEATHERS	feather	NOUN	NNS	Number=Plur	13	obj	13:obj	_
 16	and	and	CCONJ	CC	_	20	cc	20:cc	_
@@ -29722,7 +29722,7 @@
 # sent_id = reviews-252791-0003
 # text = I had to dig in a bag to find one nice feather, what a joke!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	had	have	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	dig	dig	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	in	in	ADP	IN	_	7	case	7:case	_
@@ -29752,7 +29752,7 @@
 # newpar id = reviews-193257-p0002
 # text = We have utilized Mr. Pozza and his firm twice now in our family and both times have been very pleased.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj|20:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	utilized	utilize	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	Mr.	Mr.	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 5	Pozza	Pozza	PROPN	NNP	Number=Sing	4	flat	4:flat	_
@@ -29767,7 +29767,7 @@
 14	and	and	CCONJ	CC	_	20	cc	20:cc	_
 15	both	both	DET	DT	_	16	det	16:det	_
 16	times	time	NOUN	NNS	Number=Plur	20	obl:tmod	20:obl:tmod	_
-17	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
+17	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
 18	been	be	AUX	VBN	Tense=Past|VerbForm=Part	20	cop	20:cop	_
 19	very	very	ADV	RB	_	20	advmod	20:advmod	_
 20	pleased	pleased	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	SpaceAfter=No
@@ -29811,11 +29811,11 @@
 # text = I'm pleased that someone referred me to them for my commercial business.
 1-2	I'm	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
+2	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	pleased	pleased	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	that	that	SCONJ	IN	_	6	mark	6:mark	_
 5	someone	someone	PRON	NN	Number=Sing	6	nsubj	6:nsubj	_
-6	referred	refer	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	referred	refer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
 7	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	obj	6:obj	_
 8	to	to	ADP	IN	_	9	case	9:case	_
 9	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	6	obl	6:obl:to	_
@@ -29828,13 +29828,13 @@
 # sent_id = reviews-028996-0003
 # text = I own a property management firm and need a contractor with the credentials that Farrell Electric has.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|8:nsubj	_
-2	own	own	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	own	own	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	property	property	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	management	management	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	firm	firm	NOUN	NN	Number=Sing	2	obj	2:obj	_
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
-8	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+8	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 10	contractor	contractor	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	with	with	ADP	IN	_	13	case	13:case	_
@@ -29853,14 +29853,14 @@
 1	Cleanest	clean	ADJ	JJS	Degree=Sup	2	amod	2:amod	_
 2	guesthouse	guesthouse	NOUN	NN	Number=Sing	0	root	0:root	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-4	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
 6	to	to	ADP	IN	_	2	acl:relcl	2:acl:relcl	_
 
 # sent_id = reviews-335490-0002
 # newpar id = reviews-335490-p0002
 # text = Stayed here for 2 nights.
-1	Stayed	stay	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Stayed	stay	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	here	here	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 3	for	for	ADP	IN	_	5	case	5:case	_
 4	2	2	NUM	CD	NumType=Card	5	nummod	5:nummod	_
@@ -29882,7 +29882,7 @@
 # text = The rooms were very clean and the breakfast was excellent.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	rooms	room	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 4	very	very	ADV	RB	_	5	advmod	5:advmod	_
 5	clean	clean	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	and	and	CCONJ	CC	_	10	cc	10:cc	_
@@ -29900,7 +29900,7 @@
 4	off	off	ADP	IN	_	5	case	5:case	_
 5	road	road	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	parking	parking	NOUN	NN	Number=Sing	2	conj	2:conj:and|7:nsubj	_
-7	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+7	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 8	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	stay	stay	NOUN	NN	Number=Sing	7	obj	7:obj|11:nsubj:xsubj	_
 10	very	very	ADV	RB	_	11	advmod	11:advmod	_
@@ -29913,7 +29913,7 @@
 # text = These guys do great work at VERY reasonable prices.
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
-3	do	do	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	do	do	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	great	great	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	work	work	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	at	at	ADP	IN	_	9	case	9:case	_
@@ -29925,7 +29925,7 @@
 # sent_id = reviews-138249-0002
 # text = I have use them four times for fixing items from pushing out a dent in a bumper to fixing the fender on my beloved Miata.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	use	use	VERB	VBN	Tense=Past|Typo=Yes|VerbForm=Part	0	root	0:root	CorrectForm=use
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	obj	3:obj	_
 5	four	four	NUM	CD	NumType=Card	6	nummod	6:nummod	_
@@ -29954,7 +29954,7 @@
 # sent_id = reviews-138249-0003
 # text = I have never been disappointed.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	never	never	ADV	RB	_	5	advmod	5:advmod	_
 4	been	be	AUX	VBN	Tense=Past|VerbForm=Part	5	aux:pass	5:aux:pass	_
 5	disappointed	disappoint	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	SpaceAfter=No
@@ -30004,7 +30004,7 @@
 24	,	,	PUNCT	,	_	27	punct	27:punct	_
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
-27	end	end	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+27	end	end	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
 28	up	up	ADP	RP	_	27	compound:prt	27:compound:prt	_
 29	paying	pay	VERB	VBG	VerbForm=Ger	27	xcomp	27:xcomp	_
 30	for	for	ADP	IN	_	31	case	31:case	_
@@ -30039,7 +30039,7 @@
 8	undergone	undergo	VERB	VBN	Tense=Past|VerbForm=Part	7	acl	7:acl	_
 9	here	here	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
 10	which	which	PRON	WDT	PronType=Rel	11	nsubj	7:ref	_
-11	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+11	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 12	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	life	life	NOUN	NN	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	step	step	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
@@ -30082,7 +30082,7 @@
 # sent_id = reviews-042085-0002
 # newpar id = reviews-042085-p0002
 # text = Took 1+ hour to deliver to Chatham, hair in food, driver didn't know area.
-1	Took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	1	1	NUM	CD	NumType=Card	4	nummod	4:nummod	SpaceAfter=No
 3	+	+	SYM	SYM	_	2	advmod	2:advmod	_
 4	hour	hour	NOUN	NN	Number=Sing	1	obj	1:obj	_
@@ -30097,7 +30097,7 @@
 13	,	,	PUNCT	,	_	10	punct	10:punct	_
 14	driver	driver	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
 15-16	didn't	_	_	_	_	_	_	_	_
-15	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
+15	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
 16	n't	not	PART	RB	_	17	advmod	17:advmod	_
 17	know	know	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 18	area	area	NOUN	NN	Number=Sing	17	obj	17:obj	SpaceAfter=No
@@ -30105,7 +30105,7 @@
 
 # sent_id = reviews-042085-0003
 # text = Noticed a few of these Cookie cutter places opening in Summit and New Providence.
-1	Noticed	notice	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	Noticed	notice	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	a	a	DET	DT	Definite=Ind|PronType=Art	3	det	3:det	_
 3	few	few	NOUN	NN	Number=Sing	1	obj	1:obj	_
 4	of	of	ADP	IN	_	8	case	8:case	_
@@ -30160,13 +30160,13 @@
 4	inexpensive	inexpensive	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	so	so	ADV	RB	_	4	conj	4:conj:and	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	salon	salon	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	services	service	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
 11	(	(	PUNCT	-LRB-	_	14	punct	14:punct	SpaceAfter=No
 12	eyebrows	eyebrow	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
-13	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
+13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 14	cheap	cheap	ADJ	JJ	Degree=Pos	4	parataxis	4:parataxis	SpaceAfter=No
 15	!	!	PUNCT	.	_	14	punct	14:punct	SpaceAfter=No
 16	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
@@ -30193,7 +30193,7 @@
 # sent_id = reviews-302465-0005
 # text = I plan on going again.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	plan	plan	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	plan	plan	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	on	on	SCONJ	IN	_	4	mark	4:mark	_
 4	going	go	VERB	VBG	VerbForm=Ger	2	advcl	2:advcl:on	_
 5	again	again	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
@@ -30211,13 +30211,13 @@
 # newpar id = reviews-030430-p0002
 # text = I think the women at this salon know that their business is based primarily from referrals. :)
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	think	think	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	women	woman	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
 5	at	at	ADP	IN	_	7	case	7:case	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	salon	salon	NOUN	NN	Number=Sing	4	nmod	4:nmod:at	_
-8	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+8	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
 9	that	that	SCONJ	IN	_	13	mark	13:mark	_
 10	their	they	PRON	PRP$	Number=Plur|Person=3|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	business	business	NOUN	NN	Number=Sing	13	nsubj:pass	13:nsubj:pass	_
@@ -30232,7 +30232,7 @@
 # sent_id = reviews-030430-0003
 # text = They were amazingly hospitable.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-2	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
+2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	cop	4:cop	_
 3	amazingly	amazingly	ADV	RB	_	4	advmod	4:advmod	_
 4	hospitable	hospitable	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -30247,7 +30247,7 @@
 6	therapist	therapist	NOUN	NN	Number=Sing	0	root	0:root	_
 7-8	I've	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-8	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
+8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	_	10	advmod	10:advmod	_
 10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 11	and	and	CCONJ	CC	_	15	cc	15:cc	_
@@ -30307,12 +30307,12 @@
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	terrible	terrible	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 8	,	,	PUNCT	,	_	7	punct	7:punct	_
-9	did	do	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
+9	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
 10	not	not	PART	RB	_	11	advmod	11:advmod	_
 11	solve	solve	VERB	VB	VerbForm=Inf	7	parataxis	7:parataxis	_
 12	anything	anything	PRON	NN	Number=Sing	11	obj	11:obj	_
 13	only	only	ADV	RB	_	14	advmod	14:advmod	_
-14	say	say	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	parataxis	11:parataxis	_
+14	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	parataxis	11:parataxis	_
 15	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 17	do	do	VERB	VB	VerbForm=Inf	14	ccomp	14:ccomp	_
@@ -30336,7 +30336,7 @@
 4	verizon	verizon	PROPN	NNP	Number=Sing	0	root	0:root	_
 5	and	and	CCONJ	CC	_	7	cc	7:cc	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	checked	check	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+7	checked	check	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	service	service	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	with	with	ADP	IN	_	11	case	11:case	_
@@ -30347,7 +30347,7 @@
 15	great	great	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	_
 16	so	so	ADV	RB	_	18	advmod	18:advmod	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	thought	think	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+18	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	would	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 21	try	try	VERB	VB	VerbForm=Inf	18	ccomp	18:ccomp	_
@@ -30357,7 +30357,7 @@
 # sent_id = reviews-384229-0003
 # text = It turned out being very good quality tmobile service and I was happy with the new tmobile phone.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj|9:nsubj:xsubj	_
-2	turned	turn	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	turned	turn	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	out	out	ADP	RP	_	2	compound:prt	2:compound:prt	_
 4	being	be	AUX	VBG	VerbForm=Ger	9	cop	9:cop	_
 5	very	very	ADV	RB	_	6	advmod	6:advmod	_
@@ -30400,7 +30400,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	pharmacy	pharmacy	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	staff	staff	NOUN	NNS	Number=Plur	17	nsubj	17:nsubj|23:nsubj|25:nsubj:xsubj|26:nsubj:xsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
 15	always	always	ADV	RB	_	17	advmod	17:advmod	_
 16	very	very	ADV	RB	_	17	advmod	17:advmod	_
 17	short	short	ADJ	JJ	Degree=Pos	6	conj	6:conj:and	_
@@ -30408,7 +30408,7 @@
 19	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	obl	17:obl:with	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
 21-22	don't	_	_	_	_	_	_	_	_
-21	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
+21	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	n't	not	PART	RB	_	23	advmod	23:advmod	_
 23	seem	seem	VERB	VB	VerbForm=Inf	17	conj	17:conj:and	_
 24	to	to	PART	TO	_	25	mark	25:mark	_
@@ -30448,7 +30448,7 @@
 # sent_id = reviews-229100-0002
 # newpar id = reviews-229100-p0002
 # text = Love this place!!
-1	Love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	this	this	DET	DT	Number=Sing|PronType=Dem	3	det	3:det	_
 3	place	place	NOUN	NN	Number=Sing	1	obj	1:obj	SpaceAfter=No
 4	!!	!!	PUNCT	.	_	1	punct	1:punct	_
@@ -30489,7 +30489,7 @@
 8	pepco	pepco	PROPN	NNP	Number=Sing	6	nmod	6:nmod:by	SpaceAfter=No
 9	,	,	PUNCT	,	_	3	punct	3:punct	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	got	get	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
+11	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 12	confused	confused	ADJ	JJ	Degree=Pos	11	obj	11:obj	SpaceAfter=No
 13	!!!	!!!	PUNCT	.	_	3	punct	3:punct	_
 
@@ -30510,7 +30510,7 @@
 # sent_id = reviews-229100-0008
 # text = I love them!!!
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	2	obj	2:obj	SpaceAfter=No
 4	!!!	!!!	PUNCT	.	_	2	punct	2:punct	_
 
@@ -30536,7 +30536,7 @@
 # sent_id = reviews-227515-0003
 # text = I have had several dentists in my life, but Dr. Deters is by far my favorite.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	several	several	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	dentists	dentist	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -30570,7 +30570,7 @@
 12	and	and	CCONJ	CC	_	16	cc	16:cc	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	cleanings	cleaning	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj|18:nsubj	_
-15	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
+15	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	quick	quick	ADJ	JJ	Degree=Pos	3	conj	3:conj:and	_
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	painless	painless	ADJ	JJ	Degree=Pos	16	conj	16:conj:and	SpaceAfter=No
@@ -30593,7 +30593,7 @@
 # text = I've been a regular customer at this store since it opened, and love the fact that all of the employees are friendly locals.
 1-2	I've	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj|15:nsubj	_
-2	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+2	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	regular	regular	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -30603,10 +30603,10 @@
 9	store	store	NOUN	NN	Number=Sing	6	nmod	6:nmod:at	_
 10	since	since	SCONJ	IN	_	12	mark	12:mark	_
 11	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	opened	open	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:since	SpaceAfter=No
+12	opened	open	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:since	SpaceAfter=No
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
-15	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
+15	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	fact	fact	NOUN	NN	Number=Sing	15	obj	15:obj	_
 18	that	that	SCONJ	IN	_	25	mark	25:mark	_
@@ -30667,7 +30667,7 @@
 # text = If you enjoy amazing things, you must go to World's Finest Donair.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	enjoy	enjoy	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	enjoy	enjoy	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
 4	amazing	amazing	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	things	thing	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -30693,7 +30693,7 @@
 # sent_id = reviews-374344-0006
 # text = I give this place 11/10.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	give	give	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	place	place	NOUN	NN	Number=Sing	2	iobj	2:iobj	_
 5	11	11	NUM	CD	NumType=Card	2	obj	2:obj	SpaceAfter=No
@@ -30755,7 +30755,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	installation	installation	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	staff	staff	NOUN	NNS	Number=Plur	3	conj	3:conj:and|10:nsubj	_
-8	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
+8	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
 9	all	all	ADV	RB	_	10	advmod	10:advmod	_
 10	easy	easy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
@@ -30768,7 +30768,7 @@
 # text = I highly recommend Garage Pros to my friends.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	Garage	Garage	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Pros	Pro	PROPN	NNPS	Number=Plur	3	obj	3:obj	_
 6	to	to	ADP	IN	_	8	case	8:case	_
@@ -30790,7 +30790,7 @@
 2	,	,	PUNCT	,	_	6	punct	6:punct	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4-5	dont	_	_	_	_	_	_	_	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	nt	not	PART	RB	_	6	advmod	6:advmod	_
 6	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -30829,7 +30829,7 @@
 1	Like	like	INTJ	UH	_	5	discourse	5:discourse	_
 2-3	I'm	_	_	_	_	_	_	_	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-3	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
+3	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	legitimately	legitimately	ADV	RB	_	5	advmod	5:advmod	_
 5	concerned	concerned	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	at	at	ADP	IN	_	8	case	8:case	_
@@ -30851,7 +30851,7 @@
 # newpar id = reviews-153921-p0002
 # text = We order take out from here all the time and we are never disappointed.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	order	order	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	order	order	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	take	take	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	out	out	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	from	from	ADP	IN	_	6	case	6:case	_
@@ -30861,7 +30861,7 @@
 9	time	time	NOUN	NN	Number=Sing	2	obl:tmod	2:obl:tmod	_
 10	and	and	CCONJ	CC	_	14	cc	14:cc	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	never	never	ADV	RB	_	14	advmod	14:advmod	_
 14	disappointed	disappointed	ADJ	JJ	Degree=Pos	2	conj	2:conj:and	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -30895,10 +30895,10 @@
 14	exactly	exactly	ADV	RB	_	17	advmod	17:advmod	_
 15	what	what	PRON	WP	PronType=Int	12	obj	12:obj	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
-17	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
 19	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
-20	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
+20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
 21	very	very	ADV	RB	_	22	advmod	22:advmod	_
 22	helpful	helpful	ADJ	JJ	Degree=Pos	12	conj	12:conj:and	SpaceAfter=No
 23	.	.	PUNCT	.	_	9	punct	9:punct	_
@@ -30909,14 +30909,14 @@
 # text = I really want to like this place since I work right around the corner.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
 2	really	really	ADV	RB	_	3	advmod	3:advmod	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	like	like	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	place	place	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	since	since	SCONJ	IN	_	10	mark	10:mark	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
+10	work	work	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:since	_
 11	right	right	ADV	RB	_	14	advmod	14:advmod	_
 12	around	around	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -30929,7 +30929,7 @@
 2	,	,	PUNCT	,	_	5	punct	5:punct	_
 3-4	I've	_	_	_	_	_	_	_	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj|15:nsubj|17:nsubj:xsubj|18:nsubj:xsubj	_
-4	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
+4	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	given	give	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	iobj	5:iobj	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
@@ -30940,7 +30940,7 @@
 12	different	different	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	times	time	NOUN	NNS	Number=Plur	5	obl	5:obl:at	_
 14	and	and	CCONJ	CC	_	15	cc	15:cc	_
-15	decided	decide	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+15	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	stop	stop	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	going	go	VERB	VBG	VerbForm=Ger	17	xcomp	17:xcomp	SpaceAfter=No
@@ -30951,7 +30951,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	employees	employee	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|8:nsubj:xsubj	_
 3-4	don't	_	_	_	_	_	_	_	_
-3	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 4	n't	not	PART	RB	_	6	advmod	6:advmod	_
 5	really	really	ADV	RB	_	6	advmod	6:advmod	_
 6	seem	seem	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -30959,7 +30959,7 @@
 8	enjoy	enjoy	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	what	what	PRON	WP	PronType=Int	8	obj	8:obj	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-11	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 12	doing	do	VERB	VBG	VerbForm=Ger	9	acl:relcl	9:acl:relcl	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
@@ -31005,14 +31005,14 @@
 # sent_id = reviews-325741-0003
 # text = They picked my car up in Yarmouth and towed to Bath for a great price.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj|9:nsubj	_
-2	picked	pick	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	picked	pick	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4	car	car	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	up	up	ADP	RP	_	2	compound:prt	2:compound:prt	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	Yarmouth	Yarmouth	PROPN	NNP	Number=Sing	2	obl	2:obl:in	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	towed	tow	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+9	towed	tow	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 10	to	to	ADP	IN	_	11	case	11:case	_
 11	Bath	Bath	PROPN	NNP	Number=Sing	9	obl	9:obl:to	_
 12	for	for	ADP	IN	_	15	case	15:case	_
@@ -31046,7 +31046,7 @@
 3	R&L	R&L	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 4	Plumbing	Plumbing	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Services	Service	PROPN	NNP	Number=Sing	1	nmod	1:nmod:at	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	pleased	pleased	ADJ	JJ	Degree=Pos	0	root	0:root	_
 8	with	with	ADP	IN	_	10	case	10:case	_
 9	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -31056,7 +31056,7 @@
 13	extra	extra	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	mile	mile	NOUN	NN	Number=Sing	10	conj	7:obl:with|10:conj:and	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	get	get	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:to	_
 19	out	our	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs|Typo=Yes	20	nmod:poss	20:nmod:poss	CorrectForm=our
@@ -31155,7 +31155,7 @@
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	and	and	CCONJ	CC	_	8	cc	8:cc	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj	_
-8	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+8	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	great	great	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	selection	selection	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
@@ -31178,7 +31178,7 @@
 4	Gulf	Gulf	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	Coast	Coast	PROPN	NNP	Number=Sing	6	compound	6:compound	_
 6	Siding	Siding	PROPN	NNP	Number=Sing	2	nmod	2:nmod:at	_
-7	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	9	cop	9:cop	_
+7	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	9	cop	9:cop	_
 8	very	very	ADV	RB	_	9	advmod	9:advmod	_
 9	easy	easy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
@@ -31191,7 +31191,7 @@
 # sent_id = reviews-354474-0003
 # text = They walked me through all the steps involved in the the installation project so that there were no surprises.
 1	They	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	walked	walk	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	walked	walk	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj	_
 4	through	through	ADP	IN	_	7	case	7:case	_
 5	all	all	DET	PDT	_	7	det:predet	7:det:predet	_
@@ -31206,7 +31206,7 @@
 14	so	so	SCONJ	IN	_	17	mark	17:mark	_
 15	that	that	SCONJ	IN	_	14	fixed	14:fixed	_
 16	there	there	PRON	EX	_	17	expl	17:expl	_
-17	were	be	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so_that	_
+17	were	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so_that	_
 18	no	no	DET	DT	_	19	det	19:det	_
 19	surprises	surprise	NOUN	NNS	Number=Plur	17	nsubj	17:nsubj	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -31214,7 +31214,7 @@
 # sent_id = reviews-354474-0004
 # text = I found them extremely professional and would highly recommend them.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|9:nsubj	_
-2	found	find	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	found	find	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	2	obj	2:obj|5:nsubj:xsubj	_
 4	extremely	extremely	ADV	RB	_	5	advmod	5:advmod	_
 5	professional	professional	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
@@ -31254,7 +31254,7 @@
 4	reliable	reliable	ADJ	JJ	Degree=Pos	2	conj	2:conj:and	SpaceAfter=No
 5	,	,	PUNCT	,	_	9	punct	9:punct	_
 6	sessions	session	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj|12:nsubj	_
-7	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
+7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 8	good	good	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	fun	fun	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	_
 10	and	and	CCONJ	CC	_	12	cc	12:cc	_
@@ -31308,14 +31308,14 @@
 # newpar id = reviews-309258-p0002
 # text = I used to take my cars there all thetime, but management changes hands too frequently, the service has been slow, and they often try to "add on" extra services, which sometimes is not needed.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	used	use	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	take	take	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	6	nmod:poss	6:nmod:poss	_
 6	cars	car	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 7	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
 8	all	all	DET	PDT	_	10	det:predet	10:det:predet	_
-9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 10	time	time	NOUN	NN	Number=Sing	4	obl:tmod	4:obl:tmod	SpaceAfter=No
 11	,	,	PUNCT	,	_	14	punct	14:punct	_
 12	but	but	CCONJ	CC	_	14	cc	14:cc	_
@@ -31334,7 +31334,7 @@
 25	and	and	CCONJ	CC	_	28	cc	28:cc	_
 26	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	28	nsubj	28:nsubj|31:nsubj:xsubj	_
 27	often	often	ADV	RB	_	28	advmod	28:advmod	_
-28	try	try	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
+28	try	try	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:but	_
 29	to	to	PART	TO	_	31	mark	31:mark	_
 30	"	"	PUNCT	``	_	31	punct	31:punct	SpaceAfter=No
 31	add	add	VERB	VB	VerbForm=Inf	28	xcomp	28:xcomp	_
@@ -31354,7 +31354,7 @@
 # text = I dont go there anymore
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2-3	dont	_	_	_	_	_	_	_	_
-2	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	nt	not	PART	RB	_	4	advmod	4:advmod	_
 4	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
@@ -31372,13 +31372,13 @@
 # text = These people were so helpful this week and did everything to sort out my windscreen and insurance.
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	people	people	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj|9:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 4	so	so	ADV	RB	_	5	advmod	5:advmod	_
 5	helpful	helpful	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	week	week	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	did	do	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
+9	did	do	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	conj	5:conj:and	_
 10	everything	everything	PRON	NN	Number=Sing	9	obj	9:obj	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	sort	sort	VERB	VB	VerbForm=Inf	9	advcl	9:advcl:to	_
@@ -31403,12 +31403,12 @@
 10	and	and	CCONJ	CC	_	14	cc	14:cc	_
 11-12	I'm	_	_	_	_	_	_	_	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-12	'm	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+12	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	really	really	ADV	RB	_	14	advmod	14:advmod	_
 14	grateful	grateful	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	_
 15	-	-	PUNCT	:	_	4	punct	4:punct	_
 16	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
-17	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	cop	18:cop	_
+17	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	18	cop	18:cop	_
 18	fab	fab	ADJ	JJ	Degree=Pos	4	parataxis	4:parataxis	SpaceAfter=No
 19	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -31420,7 +31420,7 @@
 4	service	service	NOUN	NN	Number=Sing	0	root	0:root	_
 5-6	I've	_	_	_	_	_	_	_	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-6	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
+6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 7	come	come	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 8	across	across	ADP	IN	_	7	obl	7:obl	_
 9	for	for	ADP	IN	_	11	case	11:case	_
@@ -31450,7 +31450,7 @@
 8	tailor	tailor	NOUN	NN	Number=Sing	6	conj	6:conj	_
 9-10	I've	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-10	've	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
+10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	ever	ever	ADV	RB	_	12	advmod	12:advmod	_
 12	come	come	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 13	across	across	ADP	IN	_	12	obl	12:obl	_
@@ -31511,7 +31511,7 @@
 # text = this dentist want to pull the tooth out always.. always wants to do the cheapest for his benefit.. not unless he knows you.
 1	this	this	DET	DT	Number=Sing|PronType=Dem	2	det	2:det	_
 2	dentist	dentist	NOUN	NN	Number=Sing	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	pull	pull	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
@@ -31541,7 +31541,7 @@
 1	and	and	CCONJ	CC	_	6	cc	6:cc	_
 2	hopefully	hopefully	ADV	RB	_	6	advmod	6:advmod	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-4	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
+4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	_	6	advmod	6:advmod	_
 6	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -31571,7 +31571,7 @@
 # newpar id = reviews-254908-p0001
 # text = I hired this company to unlock my car.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	hired	hire	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	hired	hire	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	company	company	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
@@ -31585,12 +31585,12 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	price	price	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 6	good	good	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	so	so	ADV	RB	_	9	mark	9:mark	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	said	say	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:so	_
+9	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:so	_
 10	hey	hey	INTJ	UH	_	12	discourse	12:discourse	_
 11	this	this	PRON	DT	Number=Sing|PronType=Dem	12	nsubj	12:nsubj|13:nsubj:xsubj	_
 12	seems	seem	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
@@ -31601,10 +31601,10 @@
 # text = After they showed up there was a little trouble to get my car unlocked, it took quite a bit of time but the job was well done.
 1	After	after	SCONJ	IN	_	3	mark	3:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	showed	show	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:after	_
+3	showed	show	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:after	_
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	little	little	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	trouble	trouble	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
@@ -31615,7 +31615,7 @@
 14	unlocked	unlock	VERB	VBN	Tense=Past|VerbForm=Part	11	xcomp	11:xcomp	SpaceAfter=No
 15	,	,	PUNCT	,	_	17	punct	17:punct	_
 16	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
-17	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	conj	6:conj:but	_
+17	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:but	_
 18	quite	quite	DET	PDT	_	20	det:predet	20:det:predet	_
 19	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 20	bit	bit	NOUN	NN	Number=Sing	17	obj	17:obj	_
@@ -31643,19 +31643,19 @@
 # newpar id = reviews-210875-p0002
 # text = Just wanted you to know that Eric came by as scheduled today and sprayed our house for scorpions.
 1	Just	just	ADV	RB	_	2	advmod	2:advmod	_
-2	wanted	want	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	2	obj	2:obj|5:nsubj:xsubj	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 6	that	that	SCONJ	IN	_	8	mark	8:mark	_
 7	Eric	Eric	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|14:nsubj	_
-8	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	ccomp	5:ccomp	_
+8	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	ccomp	5:ccomp	_
 9	by	by	ADV	RB	_	8	advmod	8:advmod	_
 10	as	as	SCONJ	IN	_	11	mark	11:mark	_
 11	scheduled	schedule	VERB	VBN	Tense=Past|VerbForm=Part	8	advcl	8:advcl:as	_
 12	today	today	NOUN	NN	Number=Sing	8	obl:tmod	8:obl:tmod	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
-14	sprayed	spray	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	8	conj	5:ccomp|8:conj:and	_
+14	sprayed	spray	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	conj	5:ccomp|8:conj:and	_
 15	our	we	PRON	PRP$	Number=Plur|Person=1|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 16	house	house	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	for	for	ADP	IN	_	18	case	18:case	_
@@ -31665,7 +31665,7 @@
 # sent_id = reviews-210875-0003
 # text = He seemed to understand how important it was for us to make sure the whole house was sprayed so he took his time.
 1	He	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	seemed	seem	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	seemed	seem	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	understand	understand	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	how	how	SCONJ	WRB	PronType=Int	6	mark	6:mark	_
@@ -31684,14 +31684,14 @@
 18	sprayed	spray	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	ccomp	13:ccomp	_
 19	so	so	ADV	RB	_	21	mark	21:mark	_
 20	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	took	take	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so	_
+21	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so	_
 22	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	23	nmod:poss	23:nmod:poss	_
 23	time	time	NOUN	NN	Number=Sing	21	obj	21:obj	SpaceAfter=No
 24	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-210875-0004
 # text = Thank you!
-1	Thank	thank	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Thank	thank	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	1	obj	1:obj	SpaceAfter=No
 3	!	!	PUNCT	.	_	1	punct	1:punct	_
 
@@ -31707,7 +31707,7 @@
 # sent_id = reviews-346563-0002
 # text = I remain unhappy.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	remain	remain	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	remain	remain	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	unhappy	unhappy	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	SpaceAfter=No
 4	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -31715,7 +31715,7 @@
 # text = I still have noticeable scarring.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	still	still	ADV	RB	_	3	advmod	3:advmod	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	noticeable	noticeable	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	scarring	scarring	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -31724,7 +31724,7 @@
 # text = I still have surgically induced hair loss.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	still	still	ADV	RB	_	3	advmod	3:advmod	_
-3	have	have	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	surgically	surgically	ADV	RB	_	5	advmod	5:advmod	_
 5	induced	induce	VERB	VBN	Tense=Past|VerbForm=Part	7	amod	7:amod	_
 6	hair	hair	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -31735,7 +31735,7 @@
 # text = My results were just AWFUL.
 1	My	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	2	nmod:poss	2:nmod:poss	_
 2	results	result	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 4	just	just	ADV	RB	_	5	advmod	5:advmod	_
 5	AWFUL	awful	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
 6	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -31801,7 +31801,7 @@
 6	not	not	PART	RB	_	7	advmod	7:advmod	_
 7	think	think	VERB	VB	VerbForm=Inf	1	conj	1:conj:and	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-9	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Chesapeake	Chesapeake	PROPN	NNP	Number=Sing	7	ccomp	7:ccomp	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -31829,7 +31829,7 @@
 
 # sent_id = reviews-118668-0005
 # text = Get great service, fantastic menu, and relax.
-1	Get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	great	great	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	service	service	NOUN	NN	Number=Sing	1	obj	1:obj	SpaceAfter=No
 4	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -31837,7 +31837,7 @@
 6	menu	menu	NOUN	NN	Number=Sing	3	conj	1:obj|3:conj	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
-9	relax	relax	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	SpaceAfter=No
+9	relax	relax	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-118668-0006
@@ -31861,13 +31861,13 @@
 # sent_id = reviews-178726-0002
 # text = Highly recommend
 1	Highly	highly	ADV	RB	_	2	advmod	2:advmod	_
-2	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 
 # sent_id = reviews-178726-0003
 # newpar id = reviews-178726-p0002
 # text = I went to this urgent care center and was blown away with their service.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj|10:nsubj:pass	_
-2	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	ADP	IN	_	7	case	7:case	_
 4	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 5	urgent	urgent	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -31925,7 +31925,7 @@
 4	back	back	ADV	RB	_	3	advmod	3:advmod	_
 5	when	when	SCONJ	WRB	PronType=Int	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:when	_
 8	medical	medical	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	care	care	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -31943,7 +31943,7 @@
 # text = Iv just had my bmw z3 rear window replaced by the guys at kelvin trimmers.
 1-2	Iv	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-2	v	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	v	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
 4	had	have	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
@@ -31965,9 +31965,9 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	team	team	NOUN	NN	Number=Sing	7	nsubj	4:nsubj|7:nsubj|9:nsubj|12:nsubj|15:nsubj	_
 3	who	who	PRON	WP	PronType=Rel	4	nsubj	2:ref	_
-4	work	work	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	work	work	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
-6	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
+6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	helpfull	helpful	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	CorrectForm=helpful|SpaceAfter=No
 8	,	,	PUNCT	,	_	9	punct	9:punct	_
 9	friendly	friendly	ADJ	JJ	Degree=Pos	7	conj	7:conj:and	_
@@ -32014,7 +32014,7 @@
 2	daughter	daughter	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	conj	2:conj:and|5:nsubj	_
-5	stayed	stay	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	stayed	stay	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	here	here	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
 7	again	again	ADV	RB	_	5	advmod	5:advmod	_
 8	from	from	ADP	IN	_	10	case	10:case	_
@@ -32053,7 +32053,7 @@
 7	noisy	noisy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 8	but	but	CCONJ	CC	_	10	cc	10:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	were	be	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	7	conj	7:conj:but	_
+10	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	7	conj	7:conj:but	_
 11	in	in	ADP	IN	_	15	case	15:case	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 13	mega	mega	ADV	AFX	_	14	advmod	14:advmod	_
@@ -32104,14 +32104,14 @@
 # text = The investors put big bucks into the building but are clueless about what makes a good dining or bar experience.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	investors	investor	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|11:nsubj	_
-3	put	put	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+3	put	put	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4	big	big	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	bucks	buck	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	into	into	ADP	IN	_	8	case	8:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	building	building	NOUN	NN	Number=Sing	3	obl	3:obl:into	_
 9	but	but	CCONJ	CC	_	11	cc	11:cc	_
-10	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
+10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 11	clueless	clueless	ADJ	JJ	Degree=Pos	3	conj	3:conj:but	_
 12	about	about	SCONJ	IN	_	13	case	13:case	_
 13	what	what	PRON	WP	PronType=Int	11	obl	11:obl:about	_
@@ -32153,7 +32153,7 @@
 # newpar id = reviews-268952-p0002
 # text = I have been going there since I was a little girl and love the friendly and relaxing atmosphere.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|13:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	been	be	AUX	VBN	Tense=Past|VerbForm=Part	4	aux	4:aux	_
 4	going	go	VERB	VBG	VerbForm=Ger	0	root	0:root	_
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
@@ -32164,7 +32164,7 @@
 10	little	little	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	girl	girl	NOUN	NN	Number=Sing	4	advcl	4:advcl:since	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
-13	love	love	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
+13	love	love	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj:and	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 15	friendly	friendly	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 16	and	and	CCONJ	CC	_	17	cc	17:cc	_
@@ -32239,10 +32239,10 @@
 16	family	family	NOUN	NN	Number=Sing	17	compound	17:compound	_
 17	members	member	NOUN	NNS	Number=Plur	13	obl	13:obl:to|19:nsubj|23:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	17:ref	_
-19	visit	visit	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+19	visit	visit	VERB	VBP	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
 21-22	don't	_	_	_	_	_	_	_	_
-21	do	do	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
+21	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	n't	not	PART	RB	_	23	advmod	23:advmod	_
 23	know	know	VERB	VB	VerbForm=Inf	19	conj	17:acl:relcl|19:conj:and	_
 24	where	where	SCONJ	WRB	PronType=Int	26	mark	26:mark	_
@@ -32261,7 +32261,7 @@
 # text = I just give them guide and they can find anything they need.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	just	just	ADV	RB	_	3	advmod	3:advmod	_
-3	give	give	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 4	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	3	iobj	3:iobj	_
 5	guide	guide	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	and	and	CCONJ	CC	_	9	cc	9:cc	_
@@ -32270,7 +32270,7 @@
 9	find	find	VERB	VB	VerbForm=Inf	3	conj	3:conj:and	_
 10	anything	anything	PRON	NN	Number=Sing	9	obj	9:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	need	need	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	SpaceAfter=No
+12	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-235190-0004
@@ -32286,7 +32286,7 @@
 # newpar id = reviews-165032-p0001
 # text = Michael helped shoot the majority of my firm's website and we could not have been happier.
 1	Michael	Michael	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj|3:nsubj:xsubj	_
-2	helped	help	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	shoot	shoot	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	majority	majority	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -32308,7 +32308,7 @@
 # sent_id = reviews-165032-0002
 # text = We went through six photographers to find the right photographers that would represent our firm in the light we wished to and Michael and his team made that happen.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	went	go	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	through	through	ADP	IN	_	5	case	5:case	_
 4	six	six	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 5	photographers	photographer	NOUN	NNS	Number=Plur	2	obl	2:obl:through	_
@@ -32326,14 +32326,14 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	light	light	NOUN	NN	Number=Sing	13	obl	13:obl:in	_
 19	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	wished	wish	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+20	wished	wish	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 21	to	to	PART	TO	_	20	xcomp	20:xcomp	_
 22	and	and	CCONJ	CC	_	27	cc	27:cc	_
 23	Michael	Michael	PROPN	NNP	Number=Sing	27	nsubj	27:nsubj	_
 24	and	and	CCONJ	CC	_	26	cc	26:cc	_
 25	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	26	nmod:poss	26:nmod:poss	_
 26	team	team	NOUN	NN	Number=Sing	23	conj	23:conj:and|27:nsubj	_
-27	made	make	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
+27	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 28	that	that	PRON	DT	Number=Sing|PronType=Dem	29	nsubj	29:nsubj	_
 29	happen	happen	VERB	VB	VerbForm=Inf	27	ccomp	27:ccomp	SpaceAfter=No
 30	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -32363,13 +32363,13 @@
 # newpar id = reviews-025894-p0002
 # text = I have eaten here several times and everytime the service is slower than slow.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-2	have	have	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
+2	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 3	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 4	here	here	ADV	RB	PronType=Dem	3	advmod	3:advmod	_
 5	several	several	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	times	time	NOUN	NNS	Number=Plur	3	obl:tmod	3:obl:tmod	_
 7	and	and	CCONJ	CC	_	13	cc	13:cc	_
-8	every	every	DET	DT	_	9	det	9:det	SpaceAfter=No|CorrectSpaceAfter=Yes
+8	every	every	DET	DT	_	9	det	9:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 9	time	time	NOUN	NN	Number=Sing	13	obl:tmod	13:obl:tmod	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	service	service	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
@@ -32385,7 +32385,7 @@
 2	time	time	NOUN	NN	Number=Sing	5	obl:tmod	5:obl:tmod	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	even	even	ADV	RB	_	5	advmod	5:advmod	_
-5	left	leave	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	left	leave	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 6	after	after	SCONJ	IN	_	7	mark	7:mark	_
 7	sitting	sit	VERB	VBG	VerbForm=Ger	5	advcl	5:advcl:after	_
 8	at	at	ADP	IN	_	10	case	10:case	_
@@ -32443,7 +32443,7 @@
 1	Last	last	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	10	obl:tmod	10:obl:tmod	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	went	go	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	however	however	ADV	RB	_	10	advmod	10:advmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	10	punct	10:punct	_
 7	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
@@ -32462,7 +32462,7 @@
 # sent_id = reviews-314880-0003
 # text = I get that careless teenager kind of treatment from some of their staff...perhaps they should hire more serious adults to help serve/cook.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	that	that	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
 4	careless	careless	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	teenager	teenager	NOUN	NN	Number=Sing	6	compound	6:compound	_
@@ -32518,7 +32518,7 @@
 14	but	but	CCONJ	CC	_	19	cc	19:cc	_
 15	Family	Family	PROPN	NNP	Number=Sing	16	compound	16:compound	_
 16	Bagels	Bagel	PROPN	NNPS	Number=Plur	19	nsubj	19:nsubj|22:nsubj|25:nsubj	_
-17	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
+17	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 18	nice	nice	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	people	people	NOUN	NNS	Number=Plur	10	conj	3:nsubj|10:conj:but	SpaceAfter=No
 20	,	,	PUNCT	,	_	22	punct	22:punct	_
@@ -32543,7 +32543,7 @@
 10	Town	Town	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	Bagel	Bagel	PROPN	NNP	Number=Sing	6	obl	6:obl:at	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-13	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
+13	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 14	happy	happy	ADJ	JJ	Degree=Pos	0	root	0:root	_
 15	with	with	ADP	IN	_	17	case	17:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
@@ -32551,7 +32551,7 @@
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	service	service	NOUN	NN	Number=Sing	17	conj	14:obl:with|17:conj:and	_
 20	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	get	get	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+21	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 22	at	at	ADP	IN	_	24	case	24:case	_
 23	Family	Family	PROPN	NNP	Number=Sing	24	compound	24:compound	_
 24	Bagels	Bagel	PROPN	NNPS	Number=Plur	21	obl	21:obl:at	_
@@ -32570,7 +32570,7 @@
 # text = The Donuts were very over proofed, making them stale and bready.
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	Donuts	donut	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
-3	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
+3	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 4	very	very	ADV	RB	_	6	advmod	6:advmod	_
 5	over	over	ADV	RB	_	6	advmod	6:advmod	_
 6	proofed	proofed	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -32610,7 +32610,7 @@
 # sent_id = reviews-048201-0004
 # text = We tried 4 different style of donuts, they were all the same when it came to quality.
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	tried	try	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	tried	try	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	4	4	NUM	CD	NumType=Card	5	nummod	5:nummod	_
 4	different	different	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	style	style	NOUN	NN	Number=Sing	2	obj	2:obj	_
@@ -32618,13 +32618,13 @@
 7	donuts	donut	NOUN	NNS	Number=Plur	5	nmod	5:nmod:of	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-10	were	be	AUX	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
+10	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
 11	all	all	ADV	RB	_	13	advmod	13:advmod	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	same	same	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 14	when	when	SCONJ	WRB	PronType=Int	16	mark	16:mark	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	came	come	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:when	_
+16	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:when	_
 17	to	to	ADP	IN	_	18	case	18:case	_
 18	quality	quality	NOUN	NN	Number=Sing	16	obl	16:obl:to	SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -32641,7 +32641,7 @@
 # newpar id = reviews-042530-p0002
 # text = I live in the neighborhood and this place is one of my favorites for a tasty, quick and inexpensive meal.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	live	live	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	in	in	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	neighborhood	neighborhood	NOUN	NN	Number=Sing	2	obl	2:obl:in	_
@@ -32678,7 +32678,7 @@
 11	,	,	PUNCT	,	_	1	punct	1:punct	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	curries	curry	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
-14	are	be	AUX	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
+14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 15	fantastic	fantastic	ADJ	JJ	Degree=Pos	1	parataxis	1:parataxis	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -32690,12 +32690,12 @@
 4	service	service	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	know	know	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
+7	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 8	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	order	order	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	when	when	SCONJ	WRB	PronType=Int	12	mark	12:mark	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	walk	walk	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
+12	walk	walk	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
 13	in	in	ADP	IN	_	15	case	15:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	door	door	NOUN	NN	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
@@ -32717,7 +32717,7 @@
 # newpar id = reviews-216281-p0002
 # text = I called over the weekend due to clogged kitchen sink.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	called	call	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	over	over	ADP	IN	_	5	case	5:case	_
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	weekend	weekend	NOUN	NN	Number=Sing	2	obl	2:obl:over	_
@@ -32762,7 +32762,7 @@
 9	work	work	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:to	_
 10	with	with	ADP	IN	_	9	obl	9:obl	_
 11	and	and	CCONJ	CC	_	12	cc	12:cc	_
-12	gave	give	VERB	VBD	Mood=Ind|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+12	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 14	very	very	ADV	RB	_	15	advmod	15:advmod	_
 15	reasonable	reasonable	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -32772,7 +32772,7 @@
 # sent_id = reviews-216281-0006
 # text = HIGHLY recommend.
 1	HIGHLY	highly	ADV	RB	_	2	advmod	2:advmod	_
-2	recommend	recommend	VERB	VBP	Mood=Ind|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+2	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-216281-0007


### PR DESCRIPTION
Added missing Person and Number for the indicative verbs in the test/dev/train corpora

Most of these (about 10 000) were inserted using a Python script that found the Person and Number of the subject and inserted it for the verb. 

Some (a few hundred) that could not be identified were added manually.

In a few cases, this revealed bad head links or bad tenses that were corrected.