### PR TITLE
x so y update2

### DIFF
--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -16156,7 +16156,7 @@
 19	,	,	PUNCT	,	_	22	punct	22:punct	_
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
-22	complained	complain	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	conj	11:conj	_
+22	complained	complain	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	parataxis	11:parataxis	_
 23	to	to	ADP	IN	_	25	case	25:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	corporation	corporation	NOUN	NN	Number=Sing	22	obl	22:obl:to	SpaceAfter=No
@@ -16272,7 +16272,7 @@
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	plant	plant	NOUN	NN	Number=Sing	21	nsubj:pass	21:nsubj:pass	_
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	conj	10:conj	_
+21	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	parataxis	10:parataxis	_
 22	down	down	ADP	RP	_	21	compound:prt	21:compound:prt	_
 23	last	last	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
 24	week	week	NOUN	NN	Number=Sing	21	obl:tmod	21:obl:tmod	SpaceAfter=No
@@ -20403,7 +20403,7 @@
 12-13	doesn't	_	_	_	_	_	_	_	_
 12	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	_	14	advmod	14:advmod	_
-14	matter	matter	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	SpaceAfter=No
+14	matter	matter	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108072305AAPJTjj_ans-0007
@@ -20854,7 +20854,7 @@
 17	so	so	ADV	RB	_	20	advmod	20:advmod	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
 19	can	can	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	take	take	VERB	VB	VerbForm=Inf	15	conj	15:conj	_
+20	take	take	VERB	VB	VerbForm=Inf	15	parataxis	15:parataxis	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 22	romantic	romantic	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	walk	walk	NOUN	NN	Number=Sing	20	obj	20:obj	_

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -8654,7 +8654,7 @@
 7	response	response	NOUN	NN	Number=Sing	4	obj	4:obj	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+10	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 11	shanna	shanna	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj|17:nsubj:xsubj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	conj	11:conj:and|15:nsubj|17:nsubj:xsubj	_
@@ -10933,7 +10933,7 @@
 14	,	,	PUNCT	,	_	17	punct	17:punct	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
-17	lacking	lack	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	_
+17	lacking	lack	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 18	Fax	fax	NOUN	NN	Number=Sing	22	compound	22:compound	_
 19	and	and	CCONJ	CC	_	21	cc	21:cc	_
 20	bank	bank	NOUN	NN	Number=Sing	21	compound	21:compound	_
@@ -13686,7 +13686,7 @@
 35	time	time	NOUN	NN	Number=Sing	32	obl	32:obl:of	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
 37	there	there	PRON	EX	_	38	expl	38:expl	_
-38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	conj	32:conj	_
+38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	parataxis	32:parataxis	_
 39	no	no	DET	DT	_	41	det	41:det	_
 40	real	real	ADJ	JJ	Degree=Pos	41	amod	41:amod	_
 41	pictures	picture	NOUN	NNS	Number=Plur	38	nsubj	38:nsubj	_
@@ -19298,7 +19298,7 @@
 7	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nmod	5:nmod:on	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	please	please	INTJ	UH	_	10	discourse	10:discourse	_
-10	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
+10	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	3	parataxis	3:parataxis	_
 11	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	10	iobj	10:iobj	CorrectSpaceAfter=Yes|SpaceAfter=No
 12	as	as	ADV	RB	_	13	advmod	13:advmod	_
 13	much	much	ADV	RB	_	17	amod	17:amod	_
@@ -23899,7 +23899,7 @@
 19	touch	touch	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but|25:advcl:if	_
 20	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	obj	19:obj	_
 21	then	then	ADV	RB	PronType=Dem	22	advmod	22:advmod	_
-22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	conj	19:obj|20:conj	_
+22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	parataxis	19:obj|20:parataxis	_
 23	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	25:nsubj|30:nsubj	_
 24	will	will	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
 25	smell	smell	VERB	VB	VerbForm=Inf	0	root	0:root	_
@@ -24848,7 +24848,7 @@
 19	of	of	ADP	IN	_	18	fixed	18:fixed	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
 21	big	big	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
-22	deal	deal	NOUN	NN	Number=Sing	7	advcl	7:advcl	SpaceAfter=No
+22	deal	deal	NOUN	NN	Number=Sing	7	parataxis	7:parataxis	SpaceAfter=No
 23	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108071348AAWu2FU_ans-0005
@@ -27920,7 +27920,7 @@
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	face	face	NOUN	NN	Number=Sing	1	obl	1:obl:to	_
 6	then	then	ADV	RB	PronType=Dem	7	advmod	7:advmod	_
-7	denied	deny	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
+7	denied	deny	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
 

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -2635,7 +2635,7 @@
 30	,	,	PUNCT	,	_	29	punct	29:punct	_
 31	thus	thus	ADV	RB	_	33	advmod	33:advmod	_
 32	fatally	fatally	ADV	RB	_	33	advmod	33:advmod	_
-33	weakening	weaken	VERB	VBG	VerbForm=Ger	29	advcl	29:advcl	_
+33	weakening	weaken	VERB	VBG	VerbForm=Ger	13	parataxis	13:parataxis	_
 34	the	the	DET	DT	Definite=Def|PronType=Art	35	det	35:det	_
 35	legitimacy	legitimacy	NOUN	NN	Number=Sing	33	obj	33:obj	_
 36	of	of	ADP	IN	_	39	case	39:case	_
@@ -8114,7 +8114,7 @@
 11	perhaps	perhaps	ADV	RB	_	14	advmod	14:advmod	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	can	can	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	leave	leave	VERB	VB	VerbForm=Inf	2	conj	2:conj	_
+14	leave	leave	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	appropriate	appropriate	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	sections	section	NOUN	NNS	Number=Plur	14	obj	14:obj|18:nsubj:xsubj	_
@@ -12855,7 +12855,7 @@
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	not	not	PART	RB	_	12	advmod	12:advmod	_
-12	sure	sure	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
+12	sure	sure	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 13	why	why	SCONJ	WRB	PronType=Int	17	mark	17:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
 15-16	aren't	_	_	_	_	_	_	_	_
@@ -24285,7 +24285,7 @@
 5	incredibly	incredibly	ADV	RB	_	6	advmod	6:advmod	_
 6	expensive	expensive	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	so	so	ADV	RB	_	8	advmod	8:advmod	_
-8	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	6	ccomp	6:ccomp	_
+8	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	6	parataxis	6:parataxis	_
 9	sure	sure	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
 11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
@@ -24464,7 +24464,7 @@
 6	under	under	ADP	IN	_	7	case	7:case	_
 7	warranty	warranty	NOUN	NN	Number=Sing	3	ccomp	3:ccomp	_
 8	so	so	ADV	RB	_	9	advmod	9:advmod	_
-9	get	get	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
+9	get	get	VERB	VB	Mood=Imp|VerbForm=Fin	3	parataxis	3:parataxis	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	touch	touch	NOUN	NN	Number=Sing	9	obl	9:obl:in	_
 12	with	with	ADP	IN	_	13	case	13:case	_
@@ -28046,7 +28046,7 @@
 3	often	often	ADV	RB	_	4	advmod	4:advmod	_
 4	expired	expired	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	so	so	ADV	RB	_	6	advmod	6:advmod	_
-6	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	4	advcl	4:advcl	_
+6	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	4	parataxis	4:parataxis	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	dates	date	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	every	every	DET	DT	_	10	det	10:det	_
@@ -30343,7 +30343,7 @@
 15	great	great	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	_
 16	so	so	ADV	RB	_	18	advmod	18:advmod	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+18	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	would	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 21	try	try	VERB	VB	VerbForm=Inf	18	ccomp	18:ccomp	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -10139,7 +10139,7 @@
 36	bar	bar	NOUN	NN	Number=Sing	31	obl	31:obl:at	SpaceAfter=No
 37	,	,	PUNCT	,	_	39	punct	39:punct	_
 38	then	then	ADV	RB	PronType=Dem	39	advmod	39:advmod	_
-39	go	go	VERB	VB	VerbForm=Inf	31	conj	29:csubj|31:conj:and	_
+39	go	go	VERB	VB	VerbForm=Inf	31	parataxis	29:csubj|31:parataxis	_
 40	to	to	ADP	IN	_	41	case	41:case	_
 41	dinner	dinner	NOUN	NN	Number=Sing	39	obl	39:obl:to	_
 42	where	where	SCONJ	WRB	PronType=Rel	46	mark	46:mark	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -1732,7 +1732,7 @@
 39	gifts	gift	NOUN	NNS	Number=Plur	42	nsubj	42:nsubj	_
 40	now	now	ADV	RB	_	39	advmod	39:advmod	_
 41	would	would	AUX	MD	VerbForm=Fin	42	aux	42:aux	_
-42	mean	mean	VERB	VB	VerbForm=Inf	25	advcl	25:advcl	_
+42	mean	mean	VERB	VB	VerbForm=Inf	20	parataxis	20:parataxis	_
 43	significantly	significantly	ADV	RB	_	44	advmod	44:advmod	_
 44	less	less	ADJ	JJR	Degree=Cmp	45	amod	45:amod	_
 45	money	money	NOUN	NN	Number=Sing	42	obj	42:obj	_
@@ -2066,7 +2066,7 @@
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	28:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	good	good	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
-28	idea	idea	NOUN	NN	Number=Sing	13	advcl	13:advcl	SpaceAfter=No
+28	idea	idea	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	SpaceAfter=No
 29	,	,	PUNCT	,	_	34	punct	34:punct	_
 30	but	but	CCONJ	CC	_	34	cc	34:cc	_
 31	Buffet	Buffet	PROPN	NNP	Number=Sing	34	nsubj	34:nsubj	_
@@ -6273,7 +6273,7 @@
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 15	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	not	not	PART	RB	_	17	advmod	17:advmod	_
-17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj	SpaceAfter=No
+17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	2	parataxis	2:parataxis	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent21_01-0010
@@ -7978,7 +7978,7 @@
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 11	should	should	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 12	be	be	AUX	VB	VerbForm=Inf	13	cop	13:cop	_
-13	fine	fine	ADJ	JJ	Degree=Pos	3	conj	3:conj	SpaceAfter=No
+13	fine	fine	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	SpaceAfter=No
 14	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent36_01-0023
@@ -8253,7 +8253,7 @@
 10	crazy	crazy	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
 12	so	so	ADV	RB	_	13	advmod	13:advmod	_
-13	now	now	ADV	RB	_	8	conj	2:ccomp|8:conj	_
+13	now	now	ADV	RB	_	8	parataxis	8:parataxis	_
 14	may	may	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 15	not	not	PART	RB	_	13	advmod	13:advmod	_
 16	be	be	AUX	VB	VerbForm=Inf	13	cop	13:cop	_
@@ -8540,7 +8540,7 @@
 8-9	I'll	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
 9	'll	will	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	try	try	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	_
+10	try	try	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	bump	bump	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_
@@ -13451,7 +13451,7 @@
 33	with	with	ADP	IN	_	32	obl	32:obl	_
 34	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	36	nsubj	36:nsubj	_
 35	would	would	AUX	MD	VerbForm=Fin	36	aux	36:aux	_
-36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	conj	8:conj	_
+36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	parataxis	8:parataxis	_
 37	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	obj	36:obj	SpaceAfter=No
 38	.	.	PUNCT	.	_	8	punct	8:punct	_
 
@@ -15354,7 +15354,7 @@
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	stuck	stuck	ADJ	JJ	Degree=Pos	2	advcl	2:advcl	_
+10	stuck	stuck	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 11	at	at	ADP	IN	_	12	case	12:case	_
 12	home	home	NOUN	NN	Number=Sing	10	obl	10:obl:at	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -21559,7 +21559,7 @@
 7	,	,	PUNCT	,	_	2	punct	2:punct	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl	_
+10	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	with	with	ADP	IN	_	14	case	14:case	_
@@ -21945,7 +21945,7 @@
 18	that	that	PRON	DT	Number=Sing|PronType=Dem	21	nsubj	21:nsubj	_
 19	d	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 20	b	be	AUX	VB	Abbr=Yes|VerbForm=Inf	21	cop	21:cop	_
-21	helpful	helpful	ADJ	JJ	Degree=Pos	10	conj	10:conj	SpaceAfter=No
+21	helpful	helpful	ADJ	JJ	Degree=Pos	10	parataxis	10:parataxis	SpaceAfter=No
 22	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 23	thanks	thanks	NOUN	NN	Number=Sing	6	discourse	6:discourse	_
 
@@ -25108,7 +25108,7 @@
 13	great	great	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	can	can	AUX	MD	VerbForm=Fin	7	conj	7:conj	_
+16	can	can	AUX	MD	VerbForm=Fin	7	parataxis	7:parataxis	_
 
 # sent_id = answers-20111106230959AAuYQ5Q_ans-0009
 # text = extend, and if you want to end it, you just say bye,
@@ -27801,7 +27801,7 @@
 16	,	,	PUNCT	,	_	15	punct	15:punct	_
 17	so	so	ADV	RB	_	19	advmod	19:advmod	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
-19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 20	in	in	ADV	RB	_	19	advmod	19:advmod	SpaceAfter=No
 21	,	,	PUNCT	,	_	22	punct	22:punct	_
 22	out	out	ADV	RB	_	20	conj	19:advmod|20:conj:and	SpaceAfter=No

--- a/not-to-release/sources/answers/20111031103114AA61BW3_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111031103114AA61BW3_ans.xml.conllu
@@ -150,7 +150,7 @@
 16	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 17	not	not	PART	RB	_	19	advmod	19:advmod	_
 18	an	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
-19	expert	expert	NOUN	NN	Number=Sing	3	conj	3:conj	_
+19	expert	expert	NOUN	NN	Number=Sing	3	parataxis	3:parataxis	_
 20	on	on	ADP	IN	_	22	case	22:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	area	area	NOUN	NN	Number=Sing	19	nmod	19:nmod:on	SpaceAfter=No

--- a/not-to-release/sources/answers/20111101180811AAZtKpz_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111101180811AAZtKpz_ans.xml.conllu
@@ -120,7 +120,7 @@
 16	would	would	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
 17	be	be	AUX	VB	VerbForm=Inf	19	cop	19:cop	_
 18	most	most	ADV	RBS	Degree=Sup	19	advmod	19:advmod	_
-19	welcome	welcome	ADJ	JJ	Degree=Pos	6	conj	6:conj	SpaceAfter=No
+19	welcome	welcome	ADJ	JJ	Degree=Pos	6	parataxis	6:parataxis	SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111101180811AAZtKpz_ans-0007

--- a/not-to-release/sources/answers/20111104115933AA30CRJ_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111104115933AA30CRJ_ans.xml.conllu
@@ -82,7 +82,7 @@
 18	that	that	PRON	DT	Number=Sing|PronType=Dem	21	nsubj	21:nsubj	_
 19	d	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 20	b	be	AUX	VB	Abbr=Yes|VerbForm=Inf	21	cop	21:cop	_
-21	helpful	helpful	ADJ	JJ	Degree=Pos	10	conj	10:conj	SpaceAfter=No
+21	helpful	helpful	ADJ	JJ	Degree=Pos	10	parataxis	10:parataxis	SpaceAfter=No
 22	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 23	thanks	thanks	NOUN	NN	Number=Sing	6	discourse	6:discourse	_
 

--- a/not-to-release/sources/answers/20111104175256AAL21Ha_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111104175256AAL21Ha_ans.xml.conllu
@@ -162,7 +162,7 @@
 42	so	so	ADV	RB	_	44	advmod	44:advmod	_
 43-44	that's	_	_	_	_	_	_	_	_
 43	that	that	PRON	DT	Number=Sing|PronType=Dem	44	nsubj	44:nsubj	_
-44	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	34	conj	27:advcl:because|34:conj:and	_
+44	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	34	parataxis	27:advcl:because|34:parataxis	_
 45	who	who	PRON	WP	PronType=Int	49	nmod	49:nmod:of	_
 46	the	the	DET	DT	Definite=Def|PronType=Art	47	det	47:det	_
 47	photographers	photographer	NOUN	NNS	Number=Plur	48	nsubj	48:nsubj	_
@@ -343,7 +343,7 @@
 13	immigrants	immigrant	NOUN	NNS	Number=Plur	16	nsubj:pass	16:nsubj:pass	_
 14	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	aux:pass	16:aux:pass	_
 15	not	not	PART	RB	_	16	advmod	16:advmod	_
-16	counted	count	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	conj	2:conj	SpaceAfter=No
+16	counted	count	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	parataxis	2:parataxis	SpaceAfter=No
 17	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111104175256AAL21Ha_ans-0017
@@ -497,7 +497,7 @@
 9	so	so	ADV	RB	_	12	advmod	12:advmod	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 11	might	might	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
-12	get	get	VERB	VB	VerbForm=Inf	8	conj	1:appos|8:conj	_
+12	get	get	VERB	VB	VerbForm=Inf	8	parataxis	1:appos|8:parataxis	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 14	more	more	ADV	RBR	Degree=Cmp	15	advmod	15:advmod	_
 15	accurate	accurate	ADJ	JJ	Degree=Pos	16	amod	16:amod	_

--- a/not-to-release/sources/answers/20111105112131AA6gIX6_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111105112131AA6gIX6_ans.xml.conllu
@@ -73,7 +73,7 @@
 13	now	now	ADV	RB	_	16	advmod	16:advmod	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 15	all	all	DET	DT	_	14	det	14:det	_
-16	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	conj	9:conj	_
+16	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	parataxis	9:parataxis	_
 17	ours	ours	PRON	PRP	_	16	obj	16:obj	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	20:nsubj	_

--- a/not-to-release/sources/answers/20111106215236AAycANO_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111106215236AAycANO_ans.xml.conllu
@@ -59,7 +59,7 @@
 19	shower	shower	NOUN	NN	Number=Sing	16	obj	16:obj	_
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	brunch	brunch	NOUN	NN	Number=Sing	22	nsubj	22:nsubj	_
-22	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	3:conj:but	_
+22	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 23	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	22	expl	22:expl	_
 24	but	but	CCONJ	CC	_	31	cc	31:cc	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_

--- a/not-to-release/sources/answers/20111106230959AAuYQ5Q_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111106230959AAuYQ5Q_ans.xml.conllu
@@ -180,7 +180,7 @@
 13	great	great	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	can	can	AUX	MD	VerbForm=Fin	7	conj	7:conj	_
+16	can	can	AUX	MD	VerbForm=Fin	7	parataxis	7:parataxis	_
 
 # sent_id = answers-20111106230959AAuYQ5Q_ans-0009
 # text = extend, and if you want to end it, you just say bye,

--- a/not-to-release/sources/answers/20111107080027AA9zCIG_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107080027AA9zCIG_ans.xml.conllu
@@ -68,7 +68,7 @@
 17	so	so	ADV	RB	_	20	advmod	20:advmod	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
 19	can	can	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	take	take	VERB	VB	VerbForm=Inf	15	conj	15:conj	_
+20	take	take	VERB	VB	VerbForm=Inf	15	parataxis	15:parataxis	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 22	romantic	romantic	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	walk	walk	NOUN	NN	Number=Sing	20	obj	20:obj	_

--- a/not-to-release/sources/answers/20111107092617AAgKm4X_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107092617AAgKm4X_ans.xml.conllu
@@ -103,7 +103,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	adapted	adapt	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj	_
+10	adapted	adapt	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 12	Search	search	VERB	VB	VerbForm=Inf	15	compound	15:compound	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_

--- a/not-to-release/sources/answers/20111107211742AAHZaPe_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111107211742AAHZaPe_ans.xml.conllu
@@ -613,7 +613,7 @@
 9	salary	salary	NOUN	NN	Number=Sing	2	obl	2:obl:on	SpaceAfter=No
 10	,	,	PUNCT	,	_	12	punct	12:punct	_
 11	then	then	ADV	RB	PronType=Dem	12	advmod	12:advmod	_
-12	compare	compare	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj	_
+12	compare	compare	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_
 14	to	to	ADP	IN	_	15	case	15:case	_
 15	somewhere	somewhere	NOUN	NN	Number=Sing	12	obl	12:obl:to	_

--- a/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108050147AAOkFgL_ans.xml.conllu
@@ -162,7 +162,7 @@
 5	incredibly	incredibly	ADV	RB	_	6	advmod	6:advmod	_
 6	expensive	expensive	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	so	so	ADV	RB	_	8	advmod	8:advmod	_
-8	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	6	ccomp	6:ccomp	_
+8	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	6	parataxis	6:parataxis	_
 9	sure	sure	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
 11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_

--- a/not-to-release/sources/answers/20111108064026AA86V9T_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108064026AA86V9T_ans.xml.conllu
@@ -84,7 +84,7 @@
 9	would	would	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 10	probably	probably	ADV	RB	_	12	advmod	12:advmod	_
 11	be	be	AUX	VB	VerbForm=Inf	12	aux	12:aux	_
-12	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	_
+12	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 13	at	at	ADP	IN	_	16	case	16:case	_
 14	2	2	NUM	CD	NumType=Card	16	nummod	16:nummod	_
 15	twin	twin	NOUN	NN	Number=Sing	16	compound	16:compound	_

--- a/not-to-release/sources/answers/20111108065616AAKtL2c_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108065616AAKtL2c_ans.xml.conllu
@@ -821,7 +821,7 @@
 13	sooner	soon	ADV	RBR	Degree=Cmp	16	advmod	16:advmod	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	have	have	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	_
+16	have	have	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 17	fun	fun	NOUN	NN	Number=Sing	16	obj	16:obj	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/answers/20111108071348AAWu2FU_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108071348AAWu2FU_ans.xml.conllu
@@ -82,7 +82,7 @@
 19	of	of	ADP	IN	_	18	fixed	18:fixed	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
 21	big	big	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
-22	deal	deal	NOUN	NN	Number=Sing	7	advcl	7:advcl	SpaceAfter=No
+22	deal	deal	NOUN	NN	Number=Sing	7	parataxis	7:parataxis	SpaceAfter=No
 23	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108071348AAWu2FU_ans-0005

--- a/not-to-release/sources/answers/20111108072305AAPJTjj_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108072305AAPJTjj_ans.xml.conllu
@@ -91,7 +91,7 @@
 12-13	doesn't	_	_	_	_	_	_	_	_
 12	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	_	14	advmod	14:advmod	_
-14	matter	matter	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	SpaceAfter=No
+14	matter	matter	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111108072305AAPJTjj_ans-0007

--- a/not-to-release/sources/answers/20111108072912AAccket_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108072912AAccket_ans.xml.conllu
@@ -151,7 +151,7 @@
 13	in	in	ADP	IN	_	14	case	14:case	_
 14	Calcutta	Calcutta	PROPN	NNP	Number=Sing	12	nmod	12:nmod:in	_
 15	so	so	ADV	RB	_	16	advmod	16:advmod	_
-16	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
+16	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	3	parataxis	3:parataxis	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 18	few	few	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 19	big	big	ADJ	JJ	Degree=Pos	20	amod	20:amod	_

--- a/not-to-release/sources/answers/20111108074455AAiMwmn_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108074455AAiMwmn_ans.xml.conllu
@@ -155,7 +155,7 @@
 6	under	under	ADP	IN	_	7	case	7:case	_
 7	warranty	warranty	NOUN	NN	Number=Sing	3	ccomp	3:ccomp	_
 8	so	so	ADV	RB	_	9	advmod	9:advmod	_
-9	get	get	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
+9	get	get	VERB	VB	Mood=Imp|VerbForm=Fin	3	parataxis	3:parataxis	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	touch	touch	NOUN	NN	Number=Sing	9	obl	9:obl:in	_
 12	with	with	ADP	IN	_	13	case	13:case	_

--- a/not-to-release/sources/answers/20111108075111AAmNees_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108075111AAmNees_ans.xml.conllu
@@ -27,7 +27,7 @@
 7	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nmod	5:nmod:on	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	please	please	INTJ	UH	_	10	discourse	10:discourse	_
-10	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	3	advcl	3:advcl	_
+10	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	3	parataxis	3:parataxis	_
 11	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	10	iobj	10:iobj	CorrectSpaceAfter=Yes|SpaceAfter=No
 12	as	as	ADV	RB	_	13	advmod	13:advmod	_
 13	much	much	ADV	RB	_	17	amod	17:amod	_

--- a/not-to-release/sources/answers/20111108080049AAgT0iA_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108080049AAgT0iA_ans.xml.conllu
@@ -128,7 +128,7 @@
 8	baby	baby	NOUN	NN	Number=Sing	5	obl	5:obl:for	_
 9	so	so	ADV	RB	_	11	advmod	11:advmod	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	moved	move	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	advcl	2:advcl	_
+11	moved	move	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 12	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/answers/20111108082432AAph0C0_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108082432AAph0C0_ans.xml.conllu
@@ -70,7 +70,7 @@
 7	,	,	PUNCT	,	_	2	punct	2:punct	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl	_
+10	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	with	with	ADP	IN	_	14	case	14:case	_

--- a/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
@@ -113,7 +113,7 @@
 12	parties	party	NOUN	NNS	Number=Plur	10	conj	8:obl:in|10:conj:or	SpaceAfter=No
 13	,	,	PUNCT	,	_	8	punct	8:punct	_
 14	then	then	ADV	RB	PronType=Dem	15	advmod	15:advmod	_
-15	pairing	pair	VERB	VBG	VerbForm=Ger	8	advcl	8:advcl	_
+15	pairing	pair	VERB	VBG	VerbForm=Ger	8	parataxis	8:parataxis	_
 16	off	off	ADP	RP	_	15	compound:prt	15:compound:prt	SpaceAfter=No
 17	.	.	PUNCT	.	_	7	punct	7:punct	_
 

--- a/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108082831AAco5PI_ans.xml.conllu
@@ -375,7 +375,7 @@
 17	"	"	PUNCT	''	_	20	punct	20:punct	_
 18	may	may	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 19	not	not	PART	RB	_	20	advmod	20:advmod	_
-20	apply	apply	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+20	apply	apply	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 21	to	to	ADP	IN	_	22	case	22:case	_
 22	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	20	obl	20:obl:to	_
 23	when	when	SCONJ	WRB	PronType=Int	25	mark	25:mark	_

--- a/not-to-release/sources/answers/20111108083754AAEw5Xc_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108083754AAEw5Xc_ans.xml.conllu
@@ -182,7 +182,7 @@
 12	so	so	ADV	RB	_	15	advmod	15:advmod	_
 13	cruise	cruise	NOUN	NN	Number=Sing	14	compound	14:compound	_
 14	lines	line	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
-15	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl	_
+15	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	parataxis	8:parataxis	_
 16	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	15	iobj	15:iobj	_
 17	more	more	ADJ	JJR	Degree=Cmp	15	obj	15:obj	_
 18	to	to	PART	TO	_	19	mark	19:mark	_

--- a/not-to-release/sources/answers/20111108085734AATXy0E_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108085734AATXy0E_ans.xml.conllu
@@ -155,7 +155,7 @@
 8	to	to	ADP	IN	_	9	case	9:case	_
 9	hot	hot	ADJ	JJ	Degree=Pos	6	obl	6:obl:to	_
 10	then	then	ADV	RB	PronType=Dem	11	advmod	11:advmod	_
-11	cools	cool	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
+11	cools	cool	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
 12	down	down	ADP	RP	_	11	compound:prt	11:compound:prt	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	hard	hard	ADJ	JJ	Degree=Pos	6	conj	6:conj:and	_

--- a/not-to-release/sources/answers/20111108101300AAIAKXN_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108101300AAIAKXN_ans.xml.conllu
@@ -31,7 +31,7 @@
 10	so	so	ADV	RB	_	13	advmod	13:advmod	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
-13	wondering	wonder	VERB	VBG	VerbForm=Ger	5	conj	5:conj	_
+13	wondering	wonder	VERB	VBG	VerbForm=Ger	5	parataxis	5:parataxis	_
 14	what	what	PRON	WP	PronType=Int	13	ccomp	13:ccomp	_
 15	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 16	some	some	DET	DT	_	18	det	18:det	_
@@ -59,7 +59,7 @@
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	be	be	AUX	VB	VerbForm=Inf	15	cop	15:cop	_
-15	anything	anything	PRON	NN	Number=Sing	6	conj	6:conj|7:amod	SpaceAfter=No
+15	anything	anything	PRON	NN	Number=Sing	6	parataxis	6:parataxis|7:amod	SpaceAfter=No
 16	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108101300AAIAKXN_ans-0004

--- a/not-to-release/sources/answers/20111108103333AA3eSCk_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103333AA3eSCk_ans.xml.conllu
@@ -193,7 +193,7 @@
 14	n't	not	PART	RB	_	15	advmod	15:advmod	_
 15	work	work	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
 16	would	would	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	be	be	VERB	VB	VerbForm=Inf	6	conj	6:conj	_
+17	be	be	VERB	VB	VerbForm=Inf	6	parataxis	6:parataxis	_
 18	if	if	SCONJ	IN	_	20	mark	20:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
 20	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	ccomp	17:ccomp	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108103957AAcF3iZ_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108103957AAcF3iZ_ans.xml.conllu
@@ -364,7 +364,7 @@
 15	wile	wile	NOUN	NN	Number=Sing	11	obl	11:obl:for	SpaceAfter=No
 16	,	,	PUNCT	,	_	11	punct	11:punct	_
 17	then	then	ADV	RB	PronType=Dem	18	advmod	18:advmod	_
-18	up	up	ADV	RB	_	7	conj	5:xcomp|7:conj	_
+18	up	up	ADV	RB	_	7	parataxis	5:xcomp|7:parataxis	_
 19	2	2	NUM	CD	NumType=Card	18	obl:npmod	18:obl:npmod	_
 20	down	down	ADV	RB	_	11	conj	11:conj	_
 21	1	1	NUM	CD	NumType=Card	20	obl:npmod	20:obl:npmod	_

--- a/not-to-release/sources/answers/20111108104131AAWUQHU_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104131AAWUQHU_ans.xml.conllu
@@ -148,7 +148,7 @@
 19	touch	touch	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but|25:advcl:if	_
 20	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	obj	19:obj	_
 21	then	then	ADV	RB	PronType=Dem	22	advmod	22:advmod	_
-22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	conj	19:obj|20:conj	_
+22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	parataxis	19:obj|20:parataxis	_
 23	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	25:nsubj|30:nsubj	_
 24	will	will	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
 25	smell	smell	VERB	VB	VerbForm=Inf	0	root	0:root	_

--- a/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
@@ -114,7 +114,7 @@
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	so	so	ADV	RB	_	13	advmod	13:advmod	_
 12	there	there	PRON	EX	_	13	expl	13:expl	_
-13	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	conj	1:conj	_
+13	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
 14	hope	hope	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
 15	there	there	ADV	RB	PronType=Dem	13	advmod	13:advmod	SpaceAfter=No
 16	.	.	PUNCT	.	_	1	punct	1:punct	_

--- a/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108104551AAVAVQR_ans.xml.conllu
@@ -409,7 +409,7 @@
 13	smaller	small	ADJ	JJR	Degree=Cmp	16	nsubj	16:nsubj	_
 14	one	one	NUM	CD	NumType=Card	13	nummod	13:nummod	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	fit	fit	VERB	VB	VerbForm=Inf	4	conj	4:conj:and	_
+16	fit	fit	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	one	one	NUM	CD	NumType=Card	16	obl	16:obl:in	_
 19	of	of	ADP	IN	_	21	case	21:case	_

--- a/not-to-release/sources/answers/20111108105629AAiZUDY_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105629AAiZUDY_ans.xml.conllu
@@ -621,7 +621,7 @@
 6-7	i'm	_	_	_	_	_	_	_	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
-8	sure	sure	ADJ	JJ	Degree=Pos	3	conj	3:conj	_
+8	sure	sure	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj|18:nsubj	_
 10	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
 11	what	what	PRON	WP	PronType=Int	10	ccomp	10:ccomp	_

--- a/not-to-release/sources/answers/20111108105749AABv7vx_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105749AABv7vx_ans.xml.conllu
@@ -444,7 +444,7 @@
 11	his	he	PRON	PRP$	Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	territory	territory	NOUN	NN	Number=Sing	9	obl	9:obl:to	_
 13	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	make	make	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+14	make	make	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 15	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	obj	14:obj|17:nsubj:xsubj	_
 16	much	much	ADV	RB	_	17	advmod	17:advmod	_
 17	happier	happy	ADJ	JJR	Degree=Cmp	14	xcomp	14:xcomp	SpaceAfter=No

--- a/not-to-release/sources/answers/20111108105919AAHXkZF_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108105919AAHXkZF_ans.xml.conllu
@@ -211,7 +211,7 @@
 12	your	you	PRON	PRP$	Person=2|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	cat	cat	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 14	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	15:aux	_
-15	done	do	VERB	VBN	Tense=Past|VerbForm=Part	4	conj	4:conj	_
+15	done	do	VERB	VBN	Tense=Past|VerbForm=Part	4	parataxis	4:parataxis	_
 16	very	very	ADV	RB	_	17	advmod	17:advmod	_
 17	well	well	ADV	RB	Degree=Pos	15	advmod	15:advmod	SpaceAfter=No
 18	.	.	PUNCT	.	_	4	punct	4:punct	_

--- a/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110012AAK8Azy_ans.xml.conllu
@@ -981,7 +981,7 @@
 14	so	so	ADV	RB	_	19	advmod	19:advmod	_
 15-16	its	_	_	_	_	_	_	_	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	expl	16:expl	_
-16	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	conj	7:conj	_
+16	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	parataxis	7:parataxis	_
 17-18	anyone's	_	_	_	_	_	_	_	_
 17	anyone	anyone	PRON	NN	Number=Sing	19	nmod:poss	19:nmod:poss	_
 18	's	's	PART	POS	_	17	case	17:case	_

--- a/not-to-release/sources/answers/20111108110329AAxl1pb_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108110329AAxl1pb_ans.xml.conllu
@@ -225,7 +225,7 @@
 22-23	im	_	_	_	_	_	_	_	_
 22	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 23	m	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
-24	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	5	conj	5:conj	_
+24	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	5	parataxis	5:parataxis	_
 25	if	if	SCONJ	IN	_	27	mark	27:mark	_
 26	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	27:nsubj	_
 27	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	24	advcl	24:advcl:if	_

--- a/not-to-release/sources/answers/20111108111128AAwfype_ans.xml.conllu
+++ b/not-to-release/sources/answers/20111108111128AAwfype_ans.xml.conllu
@@ -425,7 +425,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	no	no	DET	DT	_	10	det	10:det	_
-10	worries	worry	NOUN	NNS	Number=Plur	3	conj	3:conj	_
+10	worries	worry	NOUN	NNS	Number=Plur	3	parataxis	3:parataxis	_
 11	there	there	ADV	RB	PronType=Dem	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
 

--- a/not-to-release/sources/email/enronsent01_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent01_01.xml.conllu
@@ -419,7 +419,7 @@
 7	response	response	NOUN	NN	Number=Sing	4	obj	4:obj	_
 8	so	so	ADV	RB	_	10	advmod	10:advmod	_
 9	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+10	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 11	shanna	shanna	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj|17:nsubj:xsubj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	conj	11:conj:and|15:nsubj|17:nsubj:xsubj	_

--- a/not-to-release/sources/email/enronsent04_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent04_01.xml.conllu
@@ -122,7 +122,7 @@
 36	bar	bar	NOUN	NN	Number=Sing	31	obl	31:obl:at	SpaceAfter=No
 37	,	,	PUNCT	,	_	39	punct	39:punct	_
 38	then	then	ADV	RB	PronType=Dem	39	advmod	39:advmod	_
-39	go	go	VERB	VB	VerbForm=Inf	31	conj	29:csubj|31:conj:and	_
+39	go	go	VERB	VB	VerbForm=Inf	31	parataxis	29:csubj|31:parataxis	_
 40	to	to	ADP	IN	_	41	case	41:case	_
 41	dinner	dinner	NOUN	NN	Number=Sing	39	obl	39:obl:to	_
 42	where	where	SCONJ	WRB	PronType=Rel	46	mark	46:mark	_

--- a/not-to-release/sources/email/enronsent08_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent08_02.xml.conllu
@@ -980,7 +980,7 @@
 10-11	haven't	_	_	_	_	_	_	_	_
 10	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	n't	not	PART	RB	_	12	advmod	12:advmod	_
-12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	conj	6:conj	_
+12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	parataxis	6:parataxis	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 14	chance	chance	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	to	to	PART	TO	_	16	mark	16:mark	_

--- a/not-to-release/sources/email/enronsent09_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent09_01.xml.conllu
@@ -714,7 +714,7 @@
 22	one	one	NOUN	NN	Number=Sing	25	nsubj:pass	25:nsubj:pass	_
 23	should	should	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
 24	be	be	AUX	VB	VerbForm=Inf	25	aux:pass	25:aux:pass	_
-25	assigned	assign	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	conj	8:conj	_
+25	assigned	assign	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	parataxis	8:parataxis	_
 26	to	to	ADP	IN	_	27	case	27:case	_
 27	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	25	obl	25:obl:to	_
 28	as	as	ADV	RB	_	25	advmod	25:advmod	_

--- a/not-to-release/sources/email/enronsent09_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent09_01.xml.conllu
@@ -928,7 +928,7 @@
 11	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 12	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 13	no	no	DET	DT	_	14	det	14:det	_
-14	problem	problem	NOUN	NN	Number=Sing	2	ccomp	2:ccomp	SpaceAfter=No
+14	problem	problem	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent09_01-0070

--- a/not-to-release/sources/email/enronsent09_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent09_02.xml.conllu
@@ -86,7 +86,7 @@
 10	crazy	crazy	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
 12	so	so	ADV	RB	_	13	advmod	13:advmod	_
-13	now	now	ADV	RB	_	8	conj	2:ccomp|8:conj	_
+13	now	now	ADV	RB	_	8	parataxis	8:parataxis	_
 14	may	may	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 15	not	not	PART	RB	_	13	advmod	13:advmod	_
 16	be	be	AUX	VB	VerbForm=Inf	13	cop	13:cop	_
@@ -373,7 +373,7 @@
 8-9	I'll	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
 9	'll	will	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	try	try	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	_
+10	try	try	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	bump	bump	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_

--- a/not-to-release/sources/email/enronsent10_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent10_01.xml.conllu
@@ -101,7 +101,7 @@
 26	,	,	PUNCT	,	_	29	punct	29:punct	_
 27	so	so	ADV	RB	_	29	advmod	29:advmod	_
 28	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	29	nsubj	29:nsubj	_
-29	negotiated	negotiate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj	_
+29	negotiated	negotiate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 30	a	a	DET	DT	Definite=Ind|PronType=Art	33	det	33:det	_
 31	fall	fall	VERB	VB	VerbForm=Inf	32	compound	32:compound	_
 32	back	back	ADV	RB	_	33	amod	33:amod	_

--- a/not-to-release/sources/email/enronsent17_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent17_01.xml.conllu
@@ -744,7 +744,7 @@
 9-10	we'd	_	_	_	_	_	_	_	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	'd	would	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	do	do	VERB	VB	VerbForm=Inf	5	conj	5:conj	_
+11	do	do	VERB	VB	VerbForm=Inf	5	parataxis	5:parataxis	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	_
 13	over	over	ADP	IN	_	15	case	15:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_

--- a/not-to-release/sources/email/enronsent17_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent17_01.xml.conllu
@@ -123,7 +123,7 @@
 15-16	we've	_	_	_	_	_	_	_	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
-17	provided	provide	VERB	VBN	Tense=Past|VerbForm=Part	2	ccomp	2:ccomp	_
+17	provided	provide	VERB	VBN	Tense=Past|VerbForm=Part	2	parataxis	2:parataxis	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 19	sampling	sampling	NOUN	NN	Number=Sing	17	obj	17:obj	_
 20	of	of	ADP	IN	_	22	case	22:case	_

--- a/not-to-release/sources/email/enronsent19_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent19_01.xml.conllu
@@ -447,7 +447,7 @@
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
 14	would	would	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 15	really	really	ADV	RB	_	16	advmod	16:advmod	_
-16	need	need	VERB	VB	VerbForm=Inf	3	conj	3:conj	_
+16	need	need	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	know	know	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
 19	as	as	ADV	RB	_	20	advmod	20:advmod	_

--- a/not-to-release/sources/email/enronsent21_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent21_01.xml.conllu
@@ -146,7 +146,7 @@
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 15	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	not	not	PART	RB	_	17	advmod	17:advmod	_
-17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	2	conj	2:conj	SpaceAfter=No
+17	called	call	VERB	VBN	Tense=Past|VerbForm=Part	2	parataxis	2:parataxis	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent21_01-0010

--- a/not-to-release/sources/email/enronsent21_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent21_02.xml.conllu
@@ -937,7 +937,7 @@
 33	with	with	ADP	IN	_	32	obl	32:obl	_
 34	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	36	nsubj	36:nsubj	_
 35	would	would	AUX	MD	VerbForm=Fin	36	aux	36:aux	_
-36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	conj	8:conj	_
+36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	parataxis	8:parataxis	_
 37	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	obj	36:obj	SpaceAfter=No
 38	.	.	PUNCT	.	_	8	punct	8:punct	_
 

--- a/not-to-release/sources/email/enronsent21_02.xml.conllu
+++ b/not-to-release/sources/email/enronsent21_02.xml.conllu
@@ -341,7 +341,7 @@
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	not	not	PART	RB	_	12	advmod	12:advmod	_
-12	sure	sure	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
+12	sure	sure	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 13	why	why	SCONJ	WRB	PronType=Int	17	mark	17:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
 15-16	aren't	_	_	_	_	_	_	_	_

--- a/not-to-release/sources/email/enronsent25_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent25_01.xml.conllu
@@ -182,7 +182,7 @@
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	be	be	AUX	VB	VerbForm=Inf	14	aux	14:aux	_
-14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	conj	4:conj	_
+14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
 15	that	that	DET	DT	Number=Sing|PronType=Dem	16	det	16:det	_
 16	way	way	NOUN	NN	Number=Sing	14	obl:npmod	14:obl:npmod	_
 17	on	on	ADP	IN	_	18	case	18:case	_
@@ -455,7 +455,7 @@
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	be	be	AUX	VB	VerbForm=Inf	14	aux	14:aux	_
-14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	ccomp	4:ccomp	_
+14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
 15	that	that	DET	DT	Number=Sing|PronType=Dem	16	det	16:det	_
 16	way	way	NOUN	NN	Number=Sing	14	obj	14:obj	_
 17	on	on	ADP	IN	_	18	case	18:case	_
@@ -769,7 +769,7 @@
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	be	be	AUX	VB	VerbForm=Inf	14	aux	14:aux	_
-14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	conj	4:conj	_
+14	heading	head	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
 15	that	that	DET	DT	Number=Sing|PronType=Dem	16	det	16:det	_
 16	way	way	NOUN	NN	Number=Sing	14	obl:npmod	14:obl:npmod	_
 17	on	on	ADP	IN	_	18	case	18:case	_

--- a/not-to-release/sources/email/enronsent27_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent27_01.xml.conllu
@@ -686,7 +686,7 @@
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 24	may	may	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	26	aux	26:aux	_
-26	working	work	VERB	VBG	Tense=Pres|VerbForm=Part	3	conj	3:conj:and	_
+26	working	work	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 27	over	over	ADP	IN	_	28	case	28:case	_
 28	lunch	lunch	NOUN	NN	Number=Sing	26	obl	26:obl:over	SpaceAfter=No
 29	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -708,7 +708,7 @@
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 14	probably	probably	ADV	RB	_	16	advmod	16:advmod	_
 15	be	be	AUX	VB	VerbForm=Inf	16	aux	16:aux	_
-16	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	4	conj	4:conj:but	_
+16	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
 17	lunch	lunch	NOUN	NN	Number=Sing	16	obj	16:obj	_
 18	but	but	CCONJ	CC	_	24	cc	24:cc	_
 19	just	just	ADV	RB	_	24	advmod	24:advmod	_
@@ -934,7 +934,7 @@
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
 24	may	may	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	26	aux	26:aux	_
-26	working	work	VERB	VBG	Tense=Pres|VerbForm=Part	3	conj	3:conj:and	_
+26	working	work	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 27	over	over	ADP	IN	_	28	case	28:case	_
 28	lunch	lunch	NOUN	NN	Number=Sing	26	obl	26:obl:over	SpaceAfter=No
 29	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -956,7 +956,7 @@
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 14	probably	probably	ADV	RB	_	16	advmod	16:advmod	_
 15	be	be	AUX	VB	VerbForm=Inf	16	aux	16:aux	_
-16	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	4	conj	4:conj:but	_
+16	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
 17	lunch	lunch	NOUN	NN	Number=Sing	16	obj	16:obj	_
 18	but	but	CCONJ	CC	_	24	cc	24:cc	_
 19	just	just	ADV	RB	_	24	advmod	24:advmod	_

--- a/not-to-release/sources/email/enronsent29_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent29_01.xml.conllu
@@ -769,7 +769,7 @@
 14	,	,	PUNCT	,	_	17	punct	17:punct	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
-17	lacking	lack	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	_
+17	lacking	lack	VERB	VBG	Tense=Pres|VerbForm=Part	3	parataxis	3:parataxis	_
 18	Fax	fax	NOUN	NN	Number=Sing	22	compound	22:compound	_
 19	and	and	CCONJ	CC	_	21	cc	21:cc	_
 20	bank	bank	NOUN	NN	Number=Sing	21	compound	21:compound	_

--- a/not-to-release/sources/email/enronsent30_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent30_01.xml.conllu
@@ -365,7 +365,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	reality	reality	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
-12	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+12	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 15	lose	lose	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	35	advcl	35:advcl:if	_

--- a/not-to-release/sources/email/enronsent31_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent31_01.xml.conllu
@@ -146,7 +146,7 @@
 20	,	,	PUNCT	,	_	23	punct	23:punct	_
 21	so	so	ADV	RB	_	23	advmod	23:advmod	_
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj	_
-23	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+23	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 24	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	23	obj	23:obj|26:nsubj:xsubj	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	know	know	VERB	VB	VerbForm=Inf	23	xcomp	23:xcomp	_
@@ -469,7 +469,7 @@
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
 19	so	so	ADV	RB	_	21	advmod	21:advmod	_
 20	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+21	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 22	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	21	obj	21:obj|24:nsubj:xsubj	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	know	know	VERB	VB	VerbForm=Inf	21	xcomp	21:xcomp	_
@@ -812,7 +812,7 @@
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
 19	so	so	ADV	RB	_	21	advmod	21:advmod	_
 20	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	conj	4:conj	_
+21	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	parataxis	4:parataxis	_
 22	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	21	obj	21:obj|24:nsubj:xsubj	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	know	know	VERB	VB	VerbForm=Inf	21	xcomp	21:xcomp	_

--- a/not-to-release/sources/email/enronsent36_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent36_01.xml.conllu
@@ -301,7 +301,7 @@
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 11	should	should	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 12	be	be	AUX	VB	VerbForm=Inf	13	cop	13:cop	_
-13	fine	fine	ADJ	JJ	Degree=Pos	3	conj	3:conj	SpaceAfter=No
+13	fine	fine	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	SpaceAfter=No
 14	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent36_01-0023

--- a/not-to-release/sources/email/enronsent36_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent36_01.xml.conllu
@@ -437,7 +437,7 @@
 11	perhaps	perhaps	ADV	RB	_	14	advmod	14:advmod	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	can	can	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	leave	leave	VERB	VB	VerbForm=Inf	2	conj	2:conj	_
+14	leave	leave	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	appropriate	appropriate	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	sections	section	NOUN	NNS	Number=Plur	14	obj	14:obj|18:nsubj:xsubj	_

--- a/not-to-release/sources/email/enronsent37_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent37_01.xml.conllu
@@ -1338,7 +1338,7 @@
 17	)	)	PUNCT	-RRB-	_	12	punct	12:punct	_
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	conj	8:conj:and|20:nsubj	_
-20	waited	wait	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	4:conj	_
+20	waited	wait	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 21	for	for	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	bus	bus	NOUN	NN	Number=Sing	20	obl	20:obl:for	SpaceAfter=No

--- a/not-to-release/sources/email/enronsent40_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent40_01.xml.conllu
@@ -635,7 +635,7 @@
 29	so	so	ADV	RB	_	32	advmod	32:advmod	_
 30	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	32	nsubj	32:nsubj	_
 31	will	will	AUX	MD	VerbForm=Fin	32	aux	32:aux	_
-32	have	have	VERB	VB	VerbForm=Inf	20	conj	20:conj|23:nsubj	_
+32	have	have	VERB	VB	VerbForm=Inf	20	parataxis	20:parataxis|23:nsubj	_
 33	better	good	ADJ	JJR	Degree=Cmp	34	amod	34:amod	_
 34	ideas	idea	NOUN	NNS	Number=Plur	32	obj	32:obj	_
 35	for	for	ADP	IN	_	41	mark	41:mark	_

--- a/not-to-release/sources/newsgroup/groups.google.com_GayMarriage_0ccbb50b41a5830b_ENG_20050321_181500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GayMarriage_0ccbb50b41a5830b_ENG_20050321_181500.xml.conllu
@@ -216,7 +216,7 @@
 26	,	,	PUNCT	,	_	29	punct	29:punct	_
 27	so	so	ADV	RB	_	29	advmod	29:advmod	_
 28	there	there	PRON	EX	_	29	expl	29:expl	_
-29	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	conj	13:conj:but	_
+29	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	parataxis	13:parataxis	_
 30	a	a	DET	DT	Definite=Ind|PronType=Art	32	det	32:det	_
 31	real	real	ADJ	JJ	Degree=Pos	32	amod	32:amod	_
 32	need	need	NOUN	NN	Number=Sing	29	nsubj	29:nsubj	_

--- a/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
@@ -247,7 +247,7 @@
 20	Feb	February	PROPN	NNP	Abbr=Yes|Number=Sing	23	nsubj	23:nsubj	_
 21	2005	2005	NUM	CD	NumType=Card	20	nmod:tmod	20:nmod:tmod	_
 22	could	could	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
-23	mean	mean	VERB	VB	VerbForm=Inf	13	conj	7:advcl:although|13:conj	_
+23	mean	mean	VERB	VB	VerbForm=Inf	13	parataxis	7:advcl:although|13:parataxis	_
 24	August	August	PROPN	NNP	Number=Sing	23	obj	23:obj	_
 25	2006	2006	NUM	CD	NumType=Card	24	nummod	24:nummod	SpaceAfter=No
 26	...	...	PUNCT	,	_	7	punct	7:punct	_
@@ -923,7 +923,7 @@
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
-14	down	down	ADV	RB	_	4	conj	4:conj	_
+14	down	down	ADV	RB	_	4	parataxis	4:parataxis	_
 15	for	for	ADP	IN	_	17	case	17:case	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 17	while	while	NOUN	NN	Number=Sing	14	obl	14:obl:for	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_GuildWars_086f0f64ab633ab3_ENG_20041111_173500.xml.conllu
@@ -270,7 +270,7 @@
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	so	so	ADV	RB	_	17	advmod	17:advmod	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-17	missed	miss	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	conj	13:conj	_
+17	missed	miss	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	parataxis	13:parataxis	_
 18	out	out	ADP	RP	_	17	compound:prt	17:compound:prt	_
 19	on	on	ADP	IN	_	22	case	22:case	_
 20	2/3	2/3	NUM	CD	NumType=Card	22	nummod	22:nummod	_

--- a/not-to-release/sources/newsgroup/groups.google.com_INTPunderground_b2c62e87877e4a22_ENG_20050906_165900.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_INTPunderground_b2c62e87877e4a22_ENG_20050906_165900.xml.conllu
@@ -1574,7 +1574,7 @@
 22	credibility	credibility	NOUN	NN	Number=Sing	21	obj	21:obj	_
 23	so	so	ADV	RB	_	24	advmod	24:advmod	_
 24-25	what's	_	_	_	_	_	_	_	_
-24	what	what	PRON	WP	PronType=Int	21	conj	17:ccomp|21:conj	_
+24	what	what	PRON	WP	PronType=Int	21	parataxis	17:ccomp|21:parataxis	_
 25	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 26	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 27	point	point	NOUN	NN	Number=Sing	24	nsubj	24:nsubj	SpaceAfter=No
@@ -2056,7 +2056,7 @@
 9	puke	puke	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	so	so	ADV	RB	_	12	advmod	12:advmod	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	shut	shut	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	3:ccomp|5:conj	_
+12	shut	shut	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	parataxis	3:ccomp|5:parataxis	_
 13	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj	_
 14	off	off	ADP	RP	_	12	compound:prt	12:compound:prt	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_

--- a/not-to-release/sources/newsgroup/groups.google.com_INTPunderground_b2c62e87877e4a22_ENG_20050906_165900.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_INTPunderground_b2c62e87877e4a22_ENG_20050906_165900.xml.conllu
@@ -1541,7 +1541,7 @@
 18	view	view	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	point	point	NOUN	NN	Number=Sing	21	nsubj	21:nsubj	_
 20	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
-21	slanted	slanted	ADJ	JJ	Degree=Pos	5	ccomp	5:ccomp|13:ccomp	_
+21	slanted	slanted	ADJ	JJ	Degree=Pos	5	parataxis	5:parataxis	_
 22	and	and	CCONJ	CC	_	24	cc	24:cc	_
 23	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 24	admit	admit	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	conj	5:ccomp|21:conj:and	_
@@ -1613,7 +1613,7 @@
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	so	so	ADV	RB	_	11	advmod	11:advmod	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	spent	spend	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	conj	5:conj	_
+11	spent	spend	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	parataxis	5:parataxis	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	day	day	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	searching	search	VERB	VBG	VerbForm=Ger	11	advcl	11:advcl	_

--- a/not-to-release/sources/newsgroup/groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_RagnarokOnlineII_acbece2a311cfb3c_ENG_20051119_076100.xml.conllu
@@ -46,7 +46,7 @@
 35	time	time	NOUN	NN	Number=Sing	32	obl	32:obl:of	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
 37	there	there	PRON	EX	_	38	expl	38:expl	_
-38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	conj	32:conj	_
+38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	parataxis	32:parataxis	_
 39	no	no	DET	DT	_	41	det	41:det	_
 40	real	real	ADJ	JJ	Degree=Pos	41	amod	41:amod	_
 41	pictures	picture	NOUN	NNS	Number=Plur	38	nsubj	38:nsubj	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_003362349f033873_ENG_20040712_077100.xml.conllu
@@ -41,7 +41,7 @@
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	'm	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	stuck	stuck	ADJ	JJ	Degree=Pos	2	advcl	2:advcl	_
+10	stuck	stuck	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 11	at	at	ADP	IN	_	12	case	12:case	_
 12	home	home	NOUN	NN	Number=Sing	10	obl	10:obl:at	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_

--- a/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_alt.animals.cat_01ff709c4bf2c60c_ENG_20040418_040100.xml.conllu
@@ -713,7 +713,7 @@
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	so	so	ADV	RB	_	13	advmod	13:advmod	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj|15:nsubj:xsubj	_
-13	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
+13	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
 14	somewhat	somewhat	ADV	RB	_	15	advmod	15:advmod	_
 15	embarrassed	embarrassed	ADJ	JJ	Degree=Pos	13	xcomp	13:xcomp	_
 16	by	by	SCONJ	IN	_	18	mark	18:mark	_

--- a/not-to-release/sources/newsgroup/groups.google.com_eHolistic_2dd76f31ceb6bfe8_ENG_20050513_224200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_eHolistic_2dd76f31ceb6bfe8_ENG_20050513_224200.xml.conllu
@@ -415,7 +415,7 @@
 23	prize	prize	NOUN	NN	Number=Sing	24	compound	24:compound	_
 24	money	money	NOUN	NN	Number=Sing	26	nsubj	26:nsubj	_
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	cop	26:cop	_
-26	important	important	ADJ	JJ	Degree=Pos	5	conj	5:conj:and	_
+26	important	important	ADJ	JJ	Degree=Pos	5	parataxis	5:parataxis	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	help	help	VERB	VB	VerbForm=Inf	26	advcl	26:advcl:to	_
 29	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	28	obj	28:obj	_

--- a/not-to-release/sources/newsgroup/groups.google.com_eHolistic_e470976a8f836699_ENG_20050829_183800.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_eHolistic_e470976a8f836699_ENG_20050829_183800.xml.conllu
@@ -89,7 +89,7 @@
 19	,	,	PUNCT	,	_	22	punct	22:punct	_
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
-22	complained	complain	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	conj	11:conj	_
+22	complained	complain	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	parataxis	11:parataxis	_
 23	to	to	ADP	IN	_	25	case	25:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	corporation	corporation	NOUN	NN	Number=Sing	22	obl	22:obl:to	SpaceAfter=No
@@ -205,7 +205,7 @@
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	plant	plant	NOUN	NN	Number=Sing	21	nsubj:pass	21:nsubj:pass	_
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	conj	10:conj	_
+21	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	parataxis	10:parataxis	_
 22	down	down	ADP	RP	_	21	compound:prt	21:compound:prt	_
 23	last	last	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
 24	week	week	NOUN	NN	Number=Sing	21	obl:tmod	21:obl:tmod	SpaceAfter=No

--- a/not-to-release/sources/newsgroup/groups.google.com_emails_ec0a1064de05e74b_ENG_20040929_023800.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_emails_ec0a1064de05e74b_ENG_20040929_023800.xml.conllu
@@ -398,7 +398,7 @@
 24	chain	chain	NOUN	NN	Number=Sing	20	obl	20:obl:by	_
 25	so	so	ADV	RB	_	27	advmod	27:advmod	_
 26	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
-27	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	conj	20:conj	_
+27	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	parataxis	20:parataxis	_
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	settle	settle	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	_
 30	for	for	ADP	IN	_	32	case	32:case	_

--- a/not-to-release/sources/newsgroup/groups.google.com_herpesnation_c74170a0fcfdc880_ENG_20051125_075200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_herpesnation_c74170a0fcfdc880_ENG_20051125_075200.xml.conllu
@@ -152,7 +152,7 @@
 10	self	self	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	so	so	ADV	RB	_	13	advmod	13:advmod	_
 12	today	today	NOUN	NN	Number=Sing	13	obl:tmod	13:obl:tmod	_
-13	here	here	ADV	RB	PronType=Dem	3	conj	3:conj	_
+13	here	here	ADV	RB	PronType=Dem	3	parataxis	3:parataxis	_
 14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 16	few	few	ADJ	JJ	Degree=Pos	17	amod	17:amod	_

--- a/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0018a7697318f71f_ENG_20031006_163200.xml.conllu
@@ -1383,7 +1383,7 @@
 39	and	and	CCONJ	CC	_	40	cc	40:cc	_
 40	billiards	billiards	NOUN	NNS	Number=Plur	35	conj	33:nmod:of|35:conj:and	_
 41	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	42	aux:pass	42:aux:pass	_
-42	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	70	advcl	70:advcl	_
+42	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	70	parataxis	70:parataxis	_
 43	for	for	ADP	IN	_	45	case	45:case	_
 44	the	the	DET	DT	Definite=Def|PronType=Art	45	det	45:det	_
 45	diversion	diversion	NOUN	NN	Number=Sing	42	obl	42:obl:for	_
@@ -1762,7 +1762,7 @@
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 17	Parisian	Parisian	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	boulevard	boulevard	NOUN	NN	Number=Sing	14	nmod	14:nmod:of	SpaceAfter=No
-19	,	,	PUNCT	,	_	20	punct	20:punct	_
+19	,	,	PUNCnewsgroup-groups.google.com_APassionforRats_13b309ec29808aeb_ENG_20050523_143400-0003T	,	_	20	punct	20:punct	_
 20	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 21	up	up	ADV	RB	_	20	advmod	20:advmod	_
 22	and	and	CCONJ	CC	_	23	cc	23:cc	_

--- a/not-to-release/sources/reviews/008585.xml.conllu
+++ b/not-to-release/sources/reviews/008585.xml.conllu
@@ -107,7 +107,7 @@
 19	,	,	PUNCT	,	_	2	punct	2:punct	_
 20	then	then	ADV	RB	PronType=Dem	22	advmod	22:advmod	_
 21	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj|25:nsubj|50:nsubj	_
-22	came	come	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp|17:ccomp	_
+22	came	come	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 23	out	out	ADV	RB	_	22	advmod	22:advmod	SpaceAfter=No
 24	,	,	PUNCT	,	_	25	punct	25:punct	_
 25	took	take	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	22	conj	2:ccomp|22:conj:and	_

--- a/not-to-release/sources/reviews/015573.xml.conllu
+++ b/not-to-release/sources/reviews/015573.xml.conllu
@@ -40,7 +40,7 @@
 4	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	face	face	NOUN	NN	Number=Sing	1	obl	1:obl:to	_
 6	then	then	ADV	RB	PronType=Dem	7	advmod	7:advmod	_
-7	denied	deny	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj	_
+7	denied	deny	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
 

--- a/not-to-release/sources/reviews/024385.xml.conllu
+++ b/not-to-release/sources/reviews/024385.xml.conllu
@@ -30,7 +30,7 @@
 7-8	didn't	_	_	_	_	_	_	_	_
 7	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
 8	n't	not	PART	RB	_	9	advmod	9:advmod	_
-9	go	go	VERB	VB	VerbForm=Inf	2	advcl	2:advcl	_
+9	go	go	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 10	very	very	ADV	RB	_	11	advmod	11:advmod	_
 11	often	often	ADV	RB	_	9	advmod	9:advmod	SpaceAfter=No
 12	,	,	PUNCT	,	_	18	punct	18:punct	_

--- a/not-to-release/sources/reviews/034995.xml.conllu
+++ b/not-to-release/sources/reviews/034995.xml.conllu
@@ -7,7 +7,7 @@
 3	often	often	ADV	RB	_	4	advmod	4:advmod	_
 4	expired	expired	ADJ	JJ	Degree=Pos	0	root	0:root	_
 5	so	so	ADV	RB	_	6	advmod	6:advmod	_
-6	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	4	advcl	4:advcl	_
+6	check	check	VERB	VB	Mood=Imp|VerbForm=Fin	4	parataxis	4:parataxis	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	dates	date	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	every	every	DET	DT	_	10	det	10:det	_

--- a/not-to-release/sources/reviews/037794.xml.conllu
+++ b/not-to-release/sources/reviews/037794.xml.conllu
@@ -28,7 +28,7 @@
 24	so	so	ADV	RB	_	27	advmod	27:advmod	_
 25	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
 26	would	would	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
-27	say	say	VERB	VB	VerbForm=Inf	12	advcl	12:advcl	_
+27	say	say	VERB	VB	VerbForm=Inf	12	parataxis	12:parataxis	_
 28	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	27	ccomp	27:ccomp	_
 29	way	way	ADV	RB	_	32	advmod	32:advmod	_
 30	before	before	SCONJ	IN	_	32	mark	32:mark	_

--- a/not-to-release/sources/reviews/040616.xml.conllu
+++ b/not-to-release/sources/reviews/040616.xml.conllu
@@ -17,7 +17,7 @@
 13	house	house	NOUN	NN	Number=Sing	10	obj	10:obj	_
 14	so	so	ADV	RB	_	16	advmod	16:advmod	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	contacted	contact	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj:but	_
+16	contacted	contact	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 17	this	this	DET	DT	Number=Sing|PronType=Dem	20	det	20:det	_
 18	property	property	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	management	management	NOUN	NN	Number=Sing	20	compound	20:compound	_

--- a/not-to-release/sources/reviews/055207.xml.conllu
+++ b/not-to-release/sources/reviews/055207.xml.conllu
@@ -112,7 +112,7 @@
 20	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj|24:nsubj:xsubj	_
 21	would	would	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
 22	not	not	PART	RB	_	23	advmod	23:advmod	_
-23	recommend	recommend	VERB	VB	VerbForm=Inf	4	advcl	4:advcl	_
+23	recommend	recommend	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 24	getting	get	VERB	VBG	VerbForm=Ger	23	xcomp	23:xcomp	_
 25	that	that	DET	DT	Number=Sing|PronType=Dem	26	det	26:det	_
 26	program	program	NOUN	NN	Number=Sing	24	obj	24:obj	_

--- a/not-to-release/sources/reviews/083459.xml.conllu
+++ b/not-to-release/sources/reviews/083459.xml.conllu
@@ -35,7 +35,7 @@
 15	,	,	PUNCT	,	_	7	punct	7:punct	_
 16	so	so	ADV	RB	_	18	advmod	18:advmod	_
 17	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	18:nsubj|22:nsubj:xsubj	_
-18	wanted	want	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	7	advcl	7:advcl	_
+18	wanted	want	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	7	parataxis	7:parataxis	_
 19	to	to	PART	TO	_	22	mark	22:mark	_
 20	test	test	NOUN	NN	Number=Sing	22	obl:npmod	22:obl:npmod	SpaceAfter=No
 21	-	-	PUNCT	HYPH	_	22	punct	22:punct	SpaceAfter=No

--- a/not-to-release/sources/reviews/093655.xml.conllu
+++ b/not-to-release/sources/reviews/093655.xml.conllu
@@ -94,7 +94,7 @@
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	place	place	NOUN	NN	Number=Sing	15	nsubj	15:nsubj	_
 14	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	cop	15:cop	_
-15	empty	empty	ADJ	JJ	Degree=Pos	3	advcl	3:advcl	SpaceAfter=No
+15	empty	empty	ADJ	JJ	Degree=Pos	3	parataxis	3:parataxis	SpaceAfter=No
 16	)	)	PUNCT	-RRB-	_	15	punct	15:punct	_
 17	with	with	ADP	IN	_	21	case	21:case	_
 18	about	about	ADV	RB	_	19	advmod	19:advmod	_

--- a/not-to-release/sources/reviews/094621.xml.conllu
+++ b/not-to-release/sources/reviews/094621.xml.conllu
@@ -51,10 +51,10 @@
 10	cost	cost	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
 11	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
 12	very	very	ADV	RB	_	13	advmod	13:advmod	_
-13	high	high	ADJ	JJ	Degree=Pos	2	conj	2:conj	_
+13	high	high	ADJ	JJ	Degree=Pos	2	parataxis	2:parataxis	_
 14	so	so	ADV	RB	_	16	advmod	16:advmod	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|20:nsubj|24:nsubj	_
-16	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	advcl	13:advcl	_
+16	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	parataxis	13:parataxis	_
 17	never	never	ADV	RB	_	18	advmod	18:advmod	_
 18	mind	mind	VERB	VB	Mood=Imp|VerbForm=Fin	16	ccomp	16:ccomp	SpaceAfter=No
 19	,	,	PUNCT	,	_	20	punct	20:punct	_

--- a/not-to-release/sources/reviews/097548.xml.conllu
+++ b/not-to-release/sources/reviews/097548.xml.conllu
@@ -20,7 +20,7 @@
 16	,	,	PUNCT	,	_	15	punct	15:punct	_
 17	so	so	ADV	RB	_	19	advmod	19:advmod	_
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	19	nsubj	19:nsubj	_
-19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 20	in	in	ADV	RB	_	19	advmod	19:advmod	SpaceAfter=No
 21	,	,	PUNCT	,	_	22	punct	22:punct	_
 22	out	out	ADV	RB	_	20	conj	19:advmod|20:conj:and	SpaceAfter=No

--- a/not-to-release/sources/reviews/100592.xml.conllu
+++ b/not-to-release/sources/reviews/100592.xml.conllu
@@ -57,7 +57,7 @@
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	obj	9:obj	_
 11	so	so	ADV	RB	_	13	advmod	13:advmod	_
 12	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	advcl	4:advcl	_
+13	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	there	there	ADV	RB	PronType=Dem	13	advmod	13:advmod	_
 16	and	and	CCONJ	CC	_	18	cc	18:cc	_

--- a/not-to-release/sources/reviews/110441.xml.conllu
+++ b/not-to-release/sources/reviews/110441.xml.conllu
@@ -125,7 +125,7 @@
 17	so	so	ADV	RB	_	20	advmod	20:advmod	_
 18	off	off	ADV	RB	_	20	advmod	20:advmod	_
 19	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	went	go	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	ccomp	4:ccomp	SpaceAfter=No
+20	went	go	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	SpaceAfter=No
 21	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-110441-0008

--- a/not-to-release/sources/reviews/164805.xml.conllu
+++ b/not-to-release/sources/reviews/164805.xml.conllu
@@ -103,7 +103,7 @@
 4	car	car	NOUN	NN	Number=Sing	2	obj	2:obj	_
 5	so	so	ADV	RB	_	7	advmod	7:advmod	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj|8:nsubj:xsubj	_
-7	began	begin	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+7	began	begin	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 8	negotiating	negotiate	VERB	VBG	VerbForm=Ger	7	xcomp	7:xcomp	_
 9	my	my	PRON	PRP$	Number=Sing|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 10	trade	trade	NOUN	NN	Number=Sing	12	compound	12:compound	SpaceAfter=No

--- a/not-to-release/sources/reviews/209465.xml.conllu
+++ b/not-to-release/sources/reviews/209465.xml.conllu
@@ -82,7 +82,7 @@
 18	other	other	ADJ	JJ	Degree=Pos	14	obl	14:obl:from	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
-21	service	service	NOUN	NN	Number=Sing	6	advcl	6:advcl	_
+21	service	service	NOUN	NN	Number=Sing	6	parataxis	6:parataxis	_
 22	and	and	CCONJ	CC	_	24	cc	24:cc	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	price	price	NOUN	NN	Number=Sing	21	conj	6:advcl|21:conj:and	SpaceAfter=No

--- a/not-to-release/sources/reviews/243799.xml.conllu
+++ b/not-to-release/sources/reviews/243799.xml.conllu
@@ -24,7 +24,7 @@
 13	uneven	uneven	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	dog	dog	NOUN	NN	Number=Sing	9	obl	9:obl:to	_
 15	then	then	ADV	RB	PronType=Dem	16	advmod	16:advmod	_
-16	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
+16	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	1:parataxis	_
 17	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	obj	16:obj	_
 18	back	back	ADV	RB	_	16	advmod	16:advmod	_
 19	to	to	PART	TO	_	21	mark	21:mark	_

--- a/not-to-release/sources/reviews/319816.xml.conllu
+++ b/not-to-release/sources/reviews/319816.xml.conllu
@@ -111,7 +111,7 @@
 58-59	don't	_	_	_	_	_	_	_	_
 58	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	60	aux	60:aux	_
 59	n't	not	PART	RB	_	60	advmod	60:advmod	_
-60	see	see	VERB	VB	VerbForm=Inf	51	conj	51:conj	_
+60	see	see	VERB	VB	VerbForm=Inf	51	parataxis	51:parataxis	_
 61	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	60	obj	60:obj	_
 62	drving	drive	VERB	VBG	Typo=Yes|VerbForm=Ger	60	advcl	60:advcl	CorrectForm=driving
 63	up	up	ADV	RB	_	62	advmod	62:advmod	SpaceAfter=No

--- a/not-to-release/sources/reviews/338429.xml.conllu
+++ b/not-to-release/sources/reviews/338429.xml.conllu
@@ -187,7 +187,7 @@
 12	nice	nice	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	car	car	NOUN	NN	Number=Sing	9	nmod	9:nmod:in	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	show	show	VERB	VB	VerbForm=Inf	4	conj	4:conj	_
+15	show	show	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
 16	up	up	ADP	RP	_	15	compound:prt	15:compound:prt	SpaceAfter=No
 17	.	.	PUNCT	.	_	4	punct	4:punct	_
 

--- a/not-to-release/sources/reviews/345182.xml.conllu
+++ b/not-to-release/sources/reviews/345182.xml.conllu
@@ -197,7 +197,7 @@
 24	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
 25	could	could	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 26	not	not	PART	RB	_	27	advmod	27:advmod	_
-27	return	return	VERB	VB	VerbForm=Inf	7	conj	2:ccomp|7:conj:and	_
+27	return	return	VERB	VB	VerbForm=Inf	7	parataxis	7:parataxis	_
 28	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	27	obj	27:obj	SpaceAfter=No
 29	.	.	PUNCT	.	_	2	punct	2:punct	_
 

--- a/not-to-release/sources/reviews/345455.xml.conllu
+++ b/not-to-release/sources/reviews/345455.xml.conllu
@@ -35,7 +35,7 @@
 8-9	wasn't	_	_	_	_	_	_	_	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	cop	10:cop	_
 9	n't	not	PART	RB	_	10	advmod	10:advmod	_
-10	sure	sure	ADJ	JJ	Degree=Pos	5	conj	5:conj	_
+10	sure	sure	ADJ	JJ	Degree=Pos	5	parataxis	5:parataxis	_
 11	what	what	PRON	WP	PronType=Int	14	obl	14:obl:for	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	14:aux	_

--- a/not-to-release/sources/reviews/376503.xml.conllu
+++ b/not-to-release/sources/reviews/376503.xml.conllu
@@ -49,7 +49,7 @@
 30	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	33	nsubj	33:nsubj	_
 31	must	must	AUX	MD	VerbForm=Fin	33	aux	33:aux	_
 32	be	be	AUX	VB	VerbForm=Inf	33	aux	33:aux	_
-33	doing	do	VERB	VBG	VerbForm=Ger	23	advcl	23:advcl	_
+33	doing	do	VERB	VBG	VerbForm=Ger	23	parataxis	23:parataxis	_
 34	something	something	PRON	NN	Number=Sing	33	obj	33:obj	_
 35	right	right	ADV	RB	_	33	advmod	33:advmod	SpaceAfter=No
 36	...	...	PUNCT	,	_	23	punct	23:punct	SpaceAfter=No

--- a/not-to-release/sources/reviews/384229.xml.conllu
+++ b/not-to-release/sources/reviews/384229.xml.conllu
@@ -26,7 +26,7 @@
 15	great	great	ADJ	JJ	Degree=Pos	4	conj	4:conj:and	_
 16	so	so	ADV	RB	_	18	advmod	18:advmod	_
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	conj	4:conj:and	_
+18	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	parataxis	4:parataxis	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	would	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 21	try	try	VERB	VB	VerbForm=Inf	18	ccomp	18:ccomp	_

--- a/not-to-release/sources/reviews/396880.xml.conllu
+++ b/not-to-release/sources/reviews/396880.xml.conllu
@@ -29,7 +29,7 @@
 13	,	,	PUNCT	,	_	16	punct	16:punct	_
 14	so	so	ADV	RB	_	16	advmod	16:advmod	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	asked	ask	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	conj	2:conj	_
+16	asked	ask	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	2	parataxis	2:parataxis	_
 17	for	for	ADP	IN	_	21	case	21:case	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 19	single	single	ADJ	JJ	Degree=Pos	21	amod	21:amod	_

--- a/not-to-release/sources/reviews/398243.xml.conllu
+++ b/not-to-release/sources/reviews/398243.xml.conllu
@@ -81,7 +81,7 @@
 10	Automotive	Automotive	PROPN	NNP	Number=Sing	7	conj	5:nmod:about|7:conj:and	_
 11	so	so	ADV	RB	_	13	advmod	13:advmod	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj|15:nsubj:xsubj	_
-13	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	3:conj	_
+13	decided	decide	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	give	give	VERB	VB	VerbForm=Inf	13	xcomp	13:xcomp	_
 16	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	iobj	15:iobj	_

--- a/not-to-release/sources/weblog/blogspot.com_dakbangla_20041028153019_ENG_20041028_153019.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_dakbangla_20041028153019_ENG_20041028_153019.xml.conllu
@@ -1334,7 +1334,7 @@
 47	Council	Council	PROPN	NNP	Number=Sing	42	nmod	42:nmod:of	_
 48	--	--	PUNCT	,	_	37	punct	37:punct	_
 49	thus	thus	ADV	RB	_	50	advmod	50:advmod	_
-50	leaving	leave	VERB	VBG	VerbForm=Ger	37	advcl	37:advcl	_
+50	leaving	leave	VERB	VBG	VerbForm=Ger	37	parataxis	37:parataxis	_
 51	Washington	Washington	PROPN	NNP	Number=Sing	50	obj	50:obj	_
 52	as	as	ADP	IN	_	55	case	55:case	_
 53	the	the	DET	DT	Definite=Def|PronType=Art	55	det	55:det	_

--- a/not-to-release/sources/weblog/blogspot.com_healingiraq_20050121235804_ENG_20050121_235804.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_healingiraq_20050121235804_ENG_20050121_235804.xml.conllu
@@ -1225,7 +1225,7 @@
 15	even	even	ADV	RB	_	16	advmod	16:advmod	_
 16	Sistani	Sistani	PROPN	NNP	Number=Sing	18	nsubj	18:nsubj|20:nsubj:xsubj	_
 17	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
-18	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	4	advcl	4:advcl	_
+18	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	10	parataxis	10:parataxis	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	call	call	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_

--- a/not-to-release/sources/weblog/blogspot.com_marketview_20060625150800_ENG_20060625_150800.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_marketview_20060625150800_ENG_20060625_150800.xml.conllu
@@ -68,7 +68,7 @@
 39	gifts	gift	NOUN	NNS	Number=Plur	42	nsubj	42:nsubj	_
 40	now	now	ADV	RB	_	39	advmod	39:advmod	_
 41	would	would	AUX	MD	VerbForm=Fin	42	aux	42:aux	_
-42	mean	mean	VERB	VB	VerbForm=Inf	25	advcl	25:advcl	_
+42	mean	mean	VERB	VB	VerbForm=Inf	20	parataxis	20:parataxis	_
 43	significantly	significantly	ADV	RB	_	44	advmod	44:advmod	_
 44	less	less	ADJ	JJR	Degree=Cmp	45	amod	45:amod	_
 45	money	money	NOUN	NN	Number=Sing	42	obj	42:obj	_
@@ -402,7 +402,7 @@
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	28:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	good	good	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
-28	idea	idea	NOUN	NN	Number=Sing	13	advcl	13:advcl	SpaceAfter=No
+28	idea	idea	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	SpaceAfter=No
 29	,	,	PUNCT	,	_	34	punct	34:punct	_
 30	but	but	CCONJ	CC	_	34	cc	34:cc	_
 31	Buffet	Buffet	PROPN	NNP	Number=Sing	34	nsubj	34:nsubj	_

--- a/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_rigorousintuition_20060511134300_ENG_20060511_134300.xml.conllu
@@ -5155,7 +5155,7 @@
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	therefore	therefore	ADV	RB	_	7	advmod	7:advmod	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	SpaceAfter=No
+7	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	SpaceAfter=No
 8	"	"	PUNCT	''	_	3	punct	3:punct	_
 9	:)	:)	SYM	NFP	_	3	discourse	3:discourse	_
 

--- a/not-to-release/sources/weblog/juancole.com_juancole_20041109060653_ENG_20041109_060653.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20041109060653_ENG_20041109_060653.xml.conllu
@@ -121,7 +121,7 @@
 30	,	,	PUNCT	,	_	29	punct	29:punct	_
 31	thus	thus	ADV	RB	_	33	advmod	33:advmod	_
 32	fatally	fatally	ADV	RB	_	33	advmod	33:advmod	_
-33	weakening	weaken	VERB	VBG	VerbForm=Ger	29	advcl	29:advcl	_
+33	weakening	weaken	VERB	VBG	VerbForm=Ger	13	parataxis	13:parataxis	_
 34	the	the	DET	DT	Definite=Def|PronType=Art	35	det	35:det	_
 35	legitimacy	legitimacy	NOUN	NN	Number=Sing	33	obj	33:obj	_
 36	of	of	ADP	IN	_	39	case	39:case	_


### PR DESCRIPTION
Corrections to the corpus relating to this git issue: https://github.com/UniversalDependencies/UD_English-EWT/issues/236

Deprel of "x so y" set so that "x" is the head of "y" and the relation is "parataxis". 