### PR TITLE
Num years

### DIFF
--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -647,7 +647,7 @@
 9	territories	territory	PROPN	NNPS	Number=Plur	4	nmod	4:nmod:of	_
 10	during	during	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
-12	1990s	1990	NOUN	NNS	Number=Plur	4	nmod	4:nmod:during	_
+12	1990s	1990	NOUN	NNS	Number=Plur|NumForm=Digit|NumType=Card	4	nmod	4:nmod:during	_
 13	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 14	,	,	PUNCT	,	_	13	punct	13:punct	_
 15	along	along	ADP	IN	_	18	case	18:case	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -9452,7 +9452,7 @@
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	September	September	PROPN	NNP	Number=Sing	4	obl	4:obl:in	_
 12	of	of	ADP	IN	_	13	case	13:case	_
-13	'67	'67	NUM	CD	NumType=Card	11	nmod	11:nmod:of	SpaceAfter=No
+13	'67	'67	NUM	CD	NumForm=Digit|NumType=Card	11	nmod	11:nmod:of	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent28_01-0010
@@ -9460,7 +9460,7 @@
 1	By	by	ADP	IN	_	2	case	2:case	_
 2	March	March	PROPN	NNP	Number=Sing	8	obl	8:obl:by	_
 3	of	of	ADP	IN	_	4	case	4:case	_
-4	'68	'68	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
+4	'68	'68	NUM	CD	NumForm=Digit|NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
@@ -9481,7 +9481,7 @@
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	December	December	PROPN	NNP	Number=Sing	14	obl	14:obl:in	_
 24	of	of	ADP	IN	_	25	case	25:case	_
-25	'68	'68	NUM	CD	NumType=Card	23	nmod	23:nmod:of	SpaceAfter=No
+25	'68	'68	NUM	CD	NumForm=Digit|NumType=Card	23	nmod	23:nmod:of	SpaceAfter=No
 26	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = email-enronsent28_01-0011
@@ -9495,7 +9495,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	December	December	PROPN	NNP	Number=Sing	4	obl	4:obl:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
-10	'70	'70	NUM	CD	NumType=Card	8	nmod	8:nmod:of	SpaceAfter=No
+10	'70	'70	NUM	CD	NumForm=Digit|NumType=Card	8	nmod	8:nmod:of	SpaceAfter=No
 11	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent28_01-0012
@@ -9503,7 +9503,7 @@
 1	By	by	ADP	IN	_	2	case	2:case	_
 2	April	April	PROPN	NNP	Number=Sing	8	obl	8:obl:by	_
 3	of	of	ADP	IN	_	4	case	4:case	_
-4	'71	'71	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
+4	'71	'71	NUM	CD	NumForm=Digit|NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
@@ -9520,7 +9520,7 @@
 18	in	in	ADP	IN	_	19	case	19:case	_
 19	February	February	PROPN	NNP	Number=Sing	15	obl	15:obl:in	_
 20	of	of	ADP	IN	_	21	case	21:case	_
-21	'72	'72	NUM	CD	NumType=Card	19	nmod	19:nmod:of	SpaceAfter=No
+21	'72	'72	NUM	CD	NumForm=Digit|NumType=Card	19	nmod	19:nmod:of	SpaceAfter=No
 22	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = email-enronsent28_01-0013
@@ -9544,7 +9544,7 @@
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	January	January	PROPN	NNP	Number=Sing	5	obl	5:obl:in	_
 19	of	of	ADP	IN	_	20	case	20:case	_
-20	'73	'73	NUM	CD	NumType=Card	18	nmod	18:nmod:of	SpaceAfter=No
+20	'73	'73	NUM	CD	NumForm=Digit|NumType=Card	18	nmod	18:nmod:of	SpaceAfter=No
 21	,	,	PUNCT	,	_	5	punct	5:punct	_
 22	turning	turn	VERB	VBG	VerbForm=Ger	5	advcl	5:advcl	_
 23	everyone	everyone	PRON	NN	Number=Sing	22	obj	22:obj|24:nsubj:xsubj	_
@@ -9557,7 +9557,7 @@
 2	by	by	ADP	IN	_	3	case	3:case	_
 3	December	December	PROPN	NNP	Number=Sing	9	obl	9:obl:by	_
 4	of	of	ADP	IN	_	5	case	5:case	_
-5	'73	'73	NUM	CD	NumType=Card	3	nmod	3:nmod:of	_
+5	'73	'73	NUM	CD	NumForm=Digit|NumType=Card	3	nmod	3:nmod:of	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	Dow	Dow	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
@@ -9576,7 +9576,7 @@
 6	by	by	ADP	IN	_	7	case	7:case	_
 7	December	December	PROPN	NNP	Number=Sing	13	obl	13:obl:by	_
 8	of	of	ADP	IN	_	9	case	9:case	_
-9	'74	'74	NUM	CD	NumType=Card	7	nmod	7:nmod:of	_
+9	'74	'74	NUM	CD	NumForm=Digit|NumType=Card	7	nmod	7:nmod:of	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	Dow	Dow	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
 12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_

--- a/not-to-release/sources/email/enronsent07_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent07_01.xml.conllu
@@ -29,7 +29,7 @@
 25	sometime	sometime	ADV	RB	_	27	advmod	27:advmod	_
 26	in	in	ADP	IN	_	27	case	27:case	_
 27	Q1	Q1	NOUN	NN	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
-28	'02	'02	NUM	CD	NumType=Card	27	nummod	27:nummod	SpaceAfter=No
+28	'02	'02	NUM	CD	NumForm=Digit|NumType=Card	27	nummod	27:nummod	SpaceAfter=No
 29	.	.	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = email-enronsent07_01-0002

--- a/not-to-release/sources/email/enronsent28_01.xml.conllu
+++ b/not-to-release/sources/email/enronsent28_01.xml.conllu
@@ -97,7 +97,7 @@
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	September	September	PROPN	NNP	Number=Sing	4	obl	4:obl:in	_
 12	of	of	ADP	IN	_	13	case	13:case	_
-13	'67	'67	NUM	CD	NumType=Card	11	nmod	11:nmod:of	SpaceAfter=No
+13	'67	'67	NUM	CD	NumForm=Digit|NumType=Card	11	nmod	11:nmod:of	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent28_01-0010
@@ -105,7 +105,7 @@
 1	By	by	ADP	IN	_	2	case	2:case	_
 2	March	March	PROPN	NNP	Number=Sing	8	obl	8:obl:by	_
 3	of	of	ADP	IN	_	4	case	4:case	_
-4	'68	'68	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
+4	'68	'68	NUM	CD	NumForm=Digit|NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
@@ -126,7 +126,7 @@
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	December	December	PROPN	NNP	Number=Sing	14	obl	14:obl:in	_
 24	of	of	ADP	IN	_	25	case	25:case	_
-25	'68	'68	NUM	CD	NumType=Card	23	nmod	23:nmod:of	SpaceAfter=No
+25	'68	'68	NUM	CD	NumForm=Digit|NumType=Card	23	nmod	23:nmod:of	SpaceAfter=No
 26	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = email-enronsent28_01-0011
@@ -140,7 +140,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	December	December	PROPN	NNP	Number=Sing	4	obl	4:obl:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
-10	'70	'70	NUM	CD	NumType=Card	8	nmod	8:nmod:of	SpaceAfter=No
+10	'70	'70	NUM	CD	NumForm=Digit|NumType=Card	8	nmod	8:nmod:of	SpaceAfter=No
 11	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent28_01-0012
@@ -148,7 +148,7 @@
 1	By	by	ADP	IN	_	2	case	2:case	_
 2	April	April	PROPN	NNP	Number=Sing	8	obl	8:obl:by	_
 3	of	of	ADP	IN	_	4	case	4:case	_
-4	'71	'71	NUM	CD	NumType=Card	2	nmod	2:nmod:of	_
+4	'71	'71	NUM	CD	NumForm=Digit|NumType=Card	2	nmod	2:nmod:of	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	Dow	Dow	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj	_
 7	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
@@ -165,7 +165,7 @@
 18	in	in	ADP	IN	_	19	case	19:case	_
 19	February	February	PROPN	NNP	Number=Sing	15	obl	15:obl:in	_
 20	of	of	ADP	IN	_	21	case	21:case	_
-21	'72	'72	NUM	CD	NumType=Card	19	nmod	19:nmod:of	SpaceAfter=No
+21	'72	'72	NUM	CD	NumForm=Digit|NumType=Card	19	nmod	19:nmod:of	SpaceAfter=No
 22	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = email-enronsent28_01-0013
@@ -189,7 +189,7 @@
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	January	January	PROPN	NNP	Number=Sing	5	obl	5:obl:in	_
 19	of	of	ADP	IN	_	20	case	20:case	_
-20	'73	'73	NUM	CD	NumType=Card	18	nmod	18:nmod:of	SpaceAfter=No
+20	'73	'73	NUM	CD	NumForm=Digit|NumType=Card	18	nmod	18:nmod:of	SpaceAfter=No
 21	,	,	PUNCT	,	_	5	punct	5:punct	_
 22	turning	turn	VERB	VBG	VerbForm=Ger	5	advcl	5:advcl	_
 23	everyone	everyone	PRON	NN	Number=Sing	22	obj	22:obj|24:nsubj:xsubj	_
@@ -202,7 +202,7 @@
 2	by	by	ADP	IN	_	3	case	3:case	_
 3	December	December	PROPN	NNP	Number=Sing	9	obl	9:obl:by	_
 4	of	of	ADP	IN	_	5	case	5:case	_
-5	'73	'73	NUM	CD	NumType=Card	3	nmod	3:nmod:of	_
+5	'73	'73	NUM	CD	NumForm=Digit|NumType=Card	3	nmod	3:nmod:of	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	Dow	Dow	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
@@ -221,7 +221,7 @@
 6	by	by	ADP	IN	_	7	case	7:case	_
 7	December	December	PROPN	NNP	Number=Sing	13	obl	13:obl:by	_
 8	of	of	ADP	IN	_	9	case	9:case	_
-9	'74	'74	NUM	CD	NumType=Card	7	nmod	7:nmod:of	_
+9	'74	'74	NUM	CD	NumForm=Digit|NumType=Card	7	nmod	7:nmod:of	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	Dow	Dow	PROPN	NNP	Number=Sing	13	nsubj	13:nsubj	_
 12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_

--- a/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200.xml.conllu
+++ b/not-to-release/sources/newsgroup/groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200.xml.conllu
@@ -437,7 +437,7 @@
 18	and	and	CCONJ	CC	_	21	cc	21:cc	_
 19	catch	catch	NOUN	NN	Number=Sing	21	compound	21:compound	SpaceAfter=No
 20	-	-	PUNCT	HYPH	_	21	punct	21:punct	SpaceAfter=No
-21	22s	22	NOUN	NNS	Number=Plur	15	conj	11:obl:in|15:conj:and	SpaceAfter=No
+21	22s	22	NOUN	NNS	Number=Plur|NumForm=Digit|NumType=Card	15	conj	11:obl:in|15:conj:and	SpaceAfter=No
 22	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = newsgroup-groups.google.com_humanities.lit.authors.shakespeare_0c155162a7dfaf28_ENG_20031127_172200-0025

--- a/not-to-release/sources/reviews/018548.xml.conllu
+++ b/not-to-release/sources/reviews/018548.xml.conllu
@@ -235,9 +235,9 @@
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	5:cop	_
 3	back	back	ADV	RB	_	5	advmod	5:advmod	_
 4	between	between	ADP	IN	_	5	case	5:case	_
-5	'05	'05	NUM	CD	NumType=Card	0	root	0:root	_
+5	'05	'05	NUM	CD	NumForm=Digit|NumType=Card	0	root	0:root	_
 6	and	and	CCONJ	CC	_	7	cc	7:cc	_
-7	'09	'09	NUM	CD	NumType=Card	5	conj	5:conj:and	_
+7	'09	'09	NUM	CD	NumForm=Digit|NumType=Card	5	conj	5:conj:and	_
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10-11	don't	_	_	_	_	_	_	_	_

--- a/not-to-release/sources/reviews/091704.xml.conllu
+++ b/not-to-release/sources/reviews/091704.xml.conllu
@@ -14,7 +14,7 @@
 3	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 4	taken	take	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	her	she	PRON	PRP$	Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
-6	'07	'07	NUM	CD	NumType=Card	8	nummod	8:nummod	_
+6	'07	'07	NUM	CD	NumForm=Digit|NumType=Card	8	nummod	8:nummod	_
 7	Ford	Ford	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 8	Fusion	Fusion	PROPN	NNP	Number=Sing	4	obj	4:obj	_
 9	in	in	ADV	RB	_	4	advmod	4:advmod	_

--- a/not-to-release/sources/weblog/blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700.xml.conllu
+++ b/not-to-release/sources/weblog/blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700.xml.conllu
@@ -978,9 +978,9 @@
 # sent_id = weblog-blogspot.com_alaindewitt_20040929103700_ENG_20040929_103700-0053
 # text = In ’72 or ’73, if you were a pilot, active or Guard, and you had an obligation and wanted to get out, no problem.
 1	In	in	ADP	IN	_	2	case	2:case	_
-2	’72	'72	NUM	CD	NumType=Card	10	obl	10:obl:in	_
+2	’72	'72	NUM	CD	NumForm=Digit|NumType=Card	10	obl	10:obl:in	_
 3	or	or	CCONJ	CC	_	4	cc	4:cc	_
-4	’73	'73	NUM	CD	NumType=Card	2	conj	2:conj:or|10:obl:in	SpaceAfter=No
+4	’73	'73	NUM	CD	NumForm=Digit|NumType=Card	2	conj	2:conj:or|10:obl:in	SpaceAfter=No
 5	,	,	PUNCT	,	_	10	punct	10:punct	_
 6	if	if	SCONJ	IN	_	10	mark	10:mark	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20040604210986_ENG_20040604_210986.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20040604210986_ENG_20040604_210986.xml.conllu
@@ -419,7 +419,7 @@
 6	in	in	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	late	late	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
-9	1980s	1980	NOUN	NNS	Number=Plur	13	obl	13:obl:in	SpaceAfter=No
+9	1980s	1980	NOUN	NNS	Number=Plur|NumForm=Digit|NumType=Card	13	obl	13:obl:in	SpaceAfter=No
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 12	reportedly	reportedly	ADV	RB	_	13	advmod	13:advmod	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20040823064025_ENG_20040823_064025.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20040823064025_ENG_20040823_064025.xml.conllu
@@ -1478,7 +1478,7 @@
 12	in	in	ADP	IN	_	13	case	13:case	_
 13	September	September	PROPN	NNP	Number=Sing	22	obl	22:obl:in	_
 14	of	of	ADP	IN	_	15	case	15:case	_
-15	'72	'72	NUM	CD	NumType=Card	13	nmod	13:nmod:of	SpaceAfter=No
+15	'72	'72	NUM	CD	NumForm=Digit|NumType=Card	13	nmod	13:nmod:of	SpaceAfter=No
 16	,	,	PUNCT	,	_	22	punct	22:punct	_
 17	Red	Red	PROPN	NNP	Number=Sing	21	nmod:poss	21:nmod:poss	_
 18-19	Blount's	_	_	_	_	_	_	_	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20041120060600_ENG_20041120_060600.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20041120060600_ENG_20041120_060600.xml.conllu
@@ -76,7 +76,7 @@
 9	territories	territory	PROPN	NNPS	Number=Plur	4	nmod	4:nmod:of	_
 10	during	during	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
-12	1990s	1990	NOUN	NNS	Number=Plur	4	nmod	4:nmod:during	_
+12	1990s	1990	NOUN	NNS	Number=Plur|NumForm=Digit|NumType=Card	4	nmod	4:nmod:during	_
 13	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	SpaceAfter=No
 14	,	,	PUNCT	,	_	13	punct	13:punct	_
 15	along	along	ADP	IN	_	18	case	18:case	_

--- a/not-to-release/sources/weblog/juancole.com_juancole_20051126063000_ENG_20051126_063000.xml.conllu
+++ b/not-to-release/sources/weblog/juancole.com_juancole_20051126063000_ENG_20051126_063000.xml.conllu
@@ -128,7 +128,7 @@
 32	back	back	ADV	RB	_	35	advmod	35:advmod	_
 33	in	in	ADP	IN	_	35	case	35:case	_
 34	the	the	DET	DT	Definite=Def|PronType=Art	35	det	35:det	_
-35	1960s	1960	NOUN	NNS	Number=Plur	22	obl	22:obl:in	SpaceAfter=No
+35	1960s	1960	NOUN	NNS	Number=Plur|NumForm=Digit|NumType=Card	22	obl	22:obl:in	SpaceAfter=No
 36	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20051126063000_ENG_20051126_063000-0006


### PR DESCRIPTION
I forget... what did we decide for things like 1960s, 1990s, etc?  Leave them as NOUN/NNS?  Do anything with NumForm and NumType?  (Currently they are `Number=Plur` and no other features)

How about  `M5J 1S9`?  Ignore for now?

`Catch - 22s` with `22s` as its own token?  