### PR TITLE
added UCxn annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ almost all respects, but there remain the following deviations:
 
 # Changelog
 
+**2024-11-15 v2.15**
+
+Highlights:
+
+  - **Construction annotations in the [UCxn](https://github.com/LeonieWeissweiler/UCxn) framework** added to MISC ([#551](https://github.com/UniversalDependencies/UD_English-EWT/pull/551))
+     * This release adds rule-based annotations of Interrogatives, Conditionals, Existentials, and NPN (noun-preposition-noun) constructions on the head of the respective phrase, plus construction elements.
+     * The UCxn v1 notation and categories are documented [here](https://github.com/LeonieWeissweiler/UCxn/blob/main/docs/UCxn-v1.pdf).
+     * Special thanks: [@LeonieWeissweiler](https://github.com/LeonieWeissweiler), [@WesScivetti](https://github.com/WesScivetti/), [@s-herrera](https://github.com/s-herrera)
+
+(TODO)
+
 **2024-05-15 v2.14**
 
 Highlights:

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -15567,7 +15567,7 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-0001
 # newpar id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-p0001
 # text = are there any sadists out there who share the same tastes as i do ?
-1	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+1	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
 4	sadists	sadist	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|8:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot
@@ -22403,7 +22403,7 @@
 3	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	5	cop	5:cop	CorrectForm='s
 4	not	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
 5	available	available	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
-6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Existential-CopPred-ThereExpl|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
+6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,6:Interrogative-Polar-Direct.Clause
 7	there	there	PRON	EX	_	6	expl	6:expl	_
 8	nearby	nearby	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	alternative	alternative	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
@@ -23017,7 +23017,7 @@
 # sent_id = answers-20111108093942AAYF9Dn_ans-0001
 # newpar id = answers-20111108093942AAYF9Dn_ans-p0001
 # text = Is there any kind of public transport available between noida and greater noida?
-1	Is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+1	Is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
 4	kind	kind	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -193,9 +193,9 @@
 8	suppose	suppose	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
 9	there	there	PRON	EX	_	11	expl	11:expl	_
 10	will	will	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	be	be	VERB	VB	VerbForm=Inf	8	ccomp	8:ccomp	_
+11	be	be	VERB	VB	VerbForm=Inf	8	ccomp	8:ccomp	Cxn=Existential-CopPred-ThereExpl
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
-13	wave	wave	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
+13	wave	wave	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	CxnElt=11:Existential-CopPred-ThereExpl.Pivot
 14	of	of	ADP	IN	_	17	case	17:case	_
 15	succesfull	succesfull	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 16	arab	Arab	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -368,7 +368,7 @@
 26	ways	way	NOUN	NNS	Number=Plur	20	conj	19:xcomp|20:conj:or|29:nsubj	_
 27	that	that	PRON	WDT	PronType=Rel	29	nsubj	26:ref	_
 28	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	bad	bad	ADJ	JJ	Degree=Pos	26	acl:relcl	26:acl:relcl	Cxn=rc-that-nsubj
+29	bad	bad	ADJ	JJ	Degree=Pos	26	acl:relcl	26:acl:relcl	_
 30	for	for	ADP	IN	_	32	case	32:case	_
 31	US	US	PROPN	NNP	Number=Sing	32	compound	32:compound	_
 32	standing	standing	NOUN	NN	Number=Sing	29	obl	29:obl:for	_
@@ -410,7 +410,7 @@
 26-27	haven't	_	_	_	_	_	_	_	_
 26	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
 27	n't	not	PART	RB	Polarity=Neg	28	advmod	28:advmod	_
-28	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	24	acl:relcl	24:acl:relcl	Cxn=rc-wh-nsubj
+28	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	24	acl:relcl	24:acl:relcl	_
 29	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	obj	28:obj	SpaceAfter=No
 30	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -465,7 +465,7 @@
 16	who's	whose	PRON	WP$	Poss=Yes|PronType=Rel|Typo=Yes	18	nmod:poss	15:ref	CorrectForm=whose
 17	stated	state	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	18	amod	18:amod	_
 18	goals	goal	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-19	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nmod:poss_nsubj
+19	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 20	"	"	PUNCT	``	_	24	punct	24:punct	SpaceAfter=No
 21-22	Don't	_	_	_	_	_	_	_	_
 21	Do	do	AUX	VB	Mood=Imp|VerbForm=Fin	24	aux	24:aux	_
@@ -488,7 +488,7 @@
 37	Do	do	AUX	VB	Mood=Imp|VerbForm=Fin	40	aux	40:aux	_
 38	n't	not	PART	RB	Polarity=Neg	40	advmod	40:advmod	_
 39	be	be	AUX	VB	VerbForm=Inf	40	cop	40:cop	_
-40	profitable	profitable	ADJ	JJ	Degree=Pos	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-nmod:poss_nsubj:outer|SpaceAfter=No
+40	profitable	profitable	ADJ	JJ	Degree=Pos	30	acl:relcl	30:acl:relcl	SpaceAfter=No
 41	.	.	PUNCT	.	_	40	punct	40:punct	SpaceAfter=No
 42	"	"	PUNCT	''	_	40	punct	40:punct	_
 
@@ -531,7 +531,7 @@
 32	strategy	strategy	NOUN	NN	Number=Sing	54	nsubj	35:nsubj|54:nsubj	SpaceAfter=No
 33	,	,	PUNCT	,	_	35	punct	35:punct	_
 34	which	which	PRON	WDT	PronType=Rel	35	nsubj	32:ref	_
-35	gives	give	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	Cxn=rc-wh-nsubj
+35	gives	give	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
 36	employees	employee	NOUN	NNS	Number=Plur	35	iobj	35:iobj	_
 37	one	one	NUM	CD	NumForm=Word|NumType=Card	38	nummod	38:nummod	_
 38	day	day	NOUN	NN	Number=Sing	35	obj	35:obj	_
@@ -562,9 +562,9 @@
 5	;	;	PUNCT	,	_	7	punct	7:punct	_
 6-7	there's	_	_	_	_	_	_	_	_
 6	there	there	PRON	EX	_	7	expl	7:expl	_
-7	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	_
+7	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	parataxis	1:parataxis	Cxn=Existential-CopPred-ThereExpl
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
-9	punchline	punchline	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	SpaceAfter=No
+9	punchline	punchline	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	CxnElt=7:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 10	,	,	PUNCT	,	_	11	punct	11:punct	_
 11	too	too	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -617,7 +617,7 @@
 12	Israel	Israel	PROPN	NNP	Number=Sing	10	obl	10:obl:with	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
-15	imagine	imagine	VERB	VB	VerbForm=Inf	10	conj	7:advcl:to|10:conj:and	_
+15	imagine	imagine	VERB	VB	VerbForm=Inf	10	conj	7:advcl:to|10:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 17	two	two	NUM	CD	NumForm=Word|NumType=Card	19	nummod	19:nummod	SpaceAfter=No
 18	-	-	PUNCT	HYPH	_	17	punct	17:punct	SpaceAfter=No
@@ -630,7 +630,7 @@
 25	road	road	NOUN	NN	Number=Sing	28	nsubj	28:nsubj|29:nsubj:xsubj	_
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	negotiations	negotiation	NOUN	NNS	Number=Plur	25	nmod	25:nmod:of	_
-28	remained	remain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:if	_
+28	remained	remain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 29	rocky	rocky	ADJ	JJ	Degree=Pos	28	xcomp	28:xcomp	SpaceAfter=No
 30	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -671,7 +671,7 @@
 33	Sharon	Sharon	PROPN	NNP	Number=Sing	36	nsubj	36:nsubj	_
 34	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	aux	36:aux	_
 35	always	always	ADV	RB	PronType=Tot	36	advmod	36:advmod	_
-36	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
+36	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part	30	acl:relcl	30:acl:relcl	SpaceAfter=No
 37	.	.	PUNCT	.	_	13	punct	13:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041120060600_ENG_20041120_060600-0005
@@ -691,7 +691,7 @@
 12	not	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
 13	soon	soon	ADV	RB	Degree=Pos	15	advmod	15:advmod	_
 14	be	be	AUX	VB	VerbForm=Inf	15	aux:pass	15:aux:pass	_
-15	filled	fill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj:pass|SpaceAfter=No
+15	filled	fill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041120060600_ENG_20041120_060600-0006
@@ -726,7 +726,7 @@
 8-9	cannot	_	_	_	_	_	_	_	_
 8	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 9	not	not	PART	RB	Polarity=Neg	10	advmod	10:advmod	_
-10	find	find	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:if	_
+10	find	find	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:if	CxnElt=25:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	way	way	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -741,10 +741,10 @@
 22	young	young	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	19	nmod	19:nmod:of|28:nsubj	_
 24	may	may	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
-25	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	_
+25	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=25:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 26	up	up	ADP	RP	_	25	compound:prt	25:compound:prt	_
 27	that	that	PRON	WDT	PronType=Rel	28	nsubj	23:ref	_
-28	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	Cxn=rc-that-nsubj
+28	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	_
 29	to	to	ADP	IN	_	30	case	30:case	_
 30	bin	bin	PROPN	NNP	Number=Sing	28	obl	28:obl:to	_
 31	Laden	Laden	PROPN	NNP	Number=Sing	30	flat	30:flat	_
@@ -760,7 +760,7 @@
 3	local	local	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 4	Palestinian	Palestinian	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	leaders	leader	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|7:nsubj:xsubj	_
-6	remain	remain	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+6	remain	remain	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	strong	strong	ADJ	JJ	Degree=Pos	6	xcomp	6:xcomp	_
 8	enough	enough	ADV	RB	_	7	advmod	7:advmod	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -776,7 +776,7 @@
 19	-	-	PUNCT	HYPH	_	18	punct	18:punct	SpaceAfter=No
 20	Palestinian	Palestinian	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	struggle	struggle	NOUN	NN	Number=Sing	22	nsubj	22:nsubj	_
-22	remains	remain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+22	remains	remain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 23	among	among	ADP	IN	_	27	case	27:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
 25	best	good	ADJ	JJS	Degree=Sup	27	amod	27:amod	_
@@ -807,7 +807,7 @@
 11	United	United	ADJ	NNP	Degree=Pos	12	amod	12:amod	_
 12	States	State	PROPN	NNPS	Number=Plur	14	nsubj	14:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	deploy	deploy	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
+14	deploy	deploy	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
 15	in	in	ADP	IN	_	17	case	17:case	_
 16	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
 17	war	war	NOUN	NN	Number=Sing	14	obl	14:obl:in	_
@@ -918,7 +918,7 @@
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	fight	fight	NOUN	NN	Number=Sing	4	obl	4:obl:in|11:nsubj	_
 10	that	that	PRON	WDT	PronType=Rel	11	nsubj	9:ref	_
-11	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-nsubj
+11	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	one	one	NUM	CD	NumForm=Word|NumType=Card	13	nummod	13:nummod	_
 13	Iraqi	Iraqi	PROPN	NNP	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	dead	dead	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -930,10 +930,10 @@
 2	Ramadi	Ramadi	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	big	big	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
-8	demonstration	demonstration	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	SpaceAfter=No
+8	demonstration	demonstration	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 9	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040324065800_ENG_20040324_065800-0006
@@ -1051,7 +1051,7 @@
 8	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	5	nmod	5:nmod:of|11:nsubj	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
-11	suffer	suffer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
+11	suffer	suffer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	American	American	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	occupation	occupation	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -1200,7 +1200,7 @@
 6	Google	Google	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
 7	can	can	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 8	even	even	ADV	RB	_	9	advmod	9:advmod	_
-9	survive	survive	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+9	survive	survive	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=9:Interrogative-Polar-Indirect.Clause
 10	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_marketview_20040611132900_ENG_20040611_132900-0005
@@ -1219,7 +1219,7 @@
 # text = What they wonder is whether Google can be anything more than what it's always been -- a great search engine with some real grass-roots support, successful by the grace of simplicity.
 1	What	what	PRON	WP	PronType=Rel	9	nsubj:outer	3:obj|9:nsubj:outer	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-free-obj
+3	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 5	whether	whether	SCONJ	IN	_	9	mark	9:mark	_
 6	Google	Google	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
@@ -1233,7 +1233,7 @@
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 14	's	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 15	always	always	ADV	RB	PronType=Tot	16	advmod	16:advmod	_
-16	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
+16	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Promoted=Yes
 17	--	--	PUNCT	:	_	21	punct	21:punct	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 19	great	great	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
@@ -1309,7 +1309,7 @@
 15	loyal	loyal	ADJ	JJ	Degree=Pos	0	root	0:root|18:obj	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	find	find	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj
+18	find	find	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	_
 19	--	--	PUNCT	,	_	20	punct	20:punct	_
 20	witness	witness	VERB	VB	Mood=Imp|VerbForm=Fin	15	parataxis	15:parataxis	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -1398,7 +1398,7 @@
 # text = If they continue to add features so they can justify their likely sky-high valuation, Google risks losing a huge chunk of their customer base to the next keep-it-simple search engine.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	advcl	19:advcl:if	_
+3	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	advcl	19:advcl:if	CxnElt=19:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	add	add	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	features	feature	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -1414,7 +1414,7 @@
 16	valuation	valuation	NOUN	NN	Number=Sing	10	obj	10:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	3	punct	3:punct	_
 18	Google	Google	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj|20:nsubj:xsubj	_
-19	risks	risk	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+19	risks	risk	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=19:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 20	losing	lose	VERB	VBG	VerbForm=Ger	19	xcomp	19:xcomp	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 22	huge	huge	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
@@ -1502,7 +1502,7 @@
 13	what	what	PRON	WP	PronType=Rel	11	obl	11:obl:to|16:obj	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	expect	expect	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-free-obj
+16	expect	expect	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	_
 17	in	in	ADP	IN	_	21	case	21:case	_
 18	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
 19	new	new	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
@@ -1563,7 +1563,7 @@
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	freedom	freedom	NOUN	NN	Number=Sing	9	nmod	9:nmod:of|13:obl	_
 12	Westerners	Westerner	PROPN	NNPS	Number=Plur	13	nsubj	13:nsubj	_
-13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl-pstrand
+13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	in	in	ADP	IN	_	13	obl	13:obl	Promoted=Yes|SpaceAfter=No
 15	,	,	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
 16	"	"	PUNCT	''	_	3	punct	3:punct	_
@@ -1598,8 +1598,8 @@
 5	write	write	VERB	VB	VerbForm=Inf	32	ccomp	32:ccomp	_
 6	anything	anything	PRON	NN	Number=Sing|PronType=Ind	5	obj	5:obj|8.1:obj	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|8.1:nsubj:xsubj	_
-8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj_xcomp
-8.1	write	write	VERB	VB	VerbForm=Inf	_	_	8:xcomp	CopyOf=5
+8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8.1	write	write	VERB	VB	VerbForm=Inf	_	_	8:xcomp	CopyOf=5|wordform=__EMPTY__
 9	about	about	ADP	IN	_	11	case	11:case	_
 10	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	prophet	prophet	NOUN	NN	Number=Sing	6	nmod	6:nmod:about	SpaceAfter=No
@@ -1607,7 +1607,7 @@
 13	but	but	CCONJ	CC	_	24	cc	24:cc	_
 14	if	if	SCONJ	IN	_	16	mark	16:mark	_
 15	one	one	PRON	PRP	Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	raises	raise	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
+16	raises	raise	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 17	doubts	doubt	NOUN	NNS	Number=Plur	16	obj	16:obj	_
 18	about	about	ADP	IN	_	20	case	20:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
@@ -1615,7 +1615,7 @@
 21	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	nsubj:pass	24:nsubj:pass|26:nsubj:pass	_
 22	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux:pass	24:aux:pass	_
 23	either	either	CCONJ	CC	_	24	cc:preconj	24:cc:preconj	_
-24	fined	fine	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	conj	5:conj:but|32:ccomp	_
+24	fined	fine	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	conj	5:conj:but|32:ccomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 25	or	or	CCONJ	CC	_	26	cc	26:cc	_
 26	sent	send	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	conj	24:conj:or	_
 27	to	to	ADP	IN	_	28	case	28:case	_
@@ -1648,11 +1648,11 @@
 18	)	)	PUNCT	-RRB-	_	17	punct	17:punct	_
 19	war	War	PROPN	NNP	Number=Sing	12	obl	12:obl:in	SpaceAfter=No
 20	,	,	PUNCT	,	_	6	punct	6:punct	_
-21	why	why	ADV	WRB	PronType=Int	25	advmod	25:advmod	_
+21	why	why	ADV	WRB	PronType=Int	25	advmod	25:advmod	CxnElt=25:Interrogative-WHInfo-Direct.WHWord
 22	should	should	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	25	nsubj	25:nsubj	_
-25	pay	pay	VERB	VB	VerbForm=Inf	0	root	0:root	_
+25	pay	pay	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=25:Interrogative-WHInfo-Direct.Clause
 26	for	for	ADP	IN	_	27	case	27:case	_
 27	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	25	obl	25:obl:for	SpaceAfter=No
 28	?	?	PUNCT	.	_	25	punct	25:punct	SpaceAfter=No
@@ -1751,8 +1751,8 @@
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	prove	prove	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	just	just	ADV	RB	_	12	advmod	12:advmod	_
-11	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
-12	fanatic	fanatic	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	_
+11	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	CxnElt=12:Interrogative-WHInfo-Indirect.WHWord
+12	fanatic	fanatic	ADJ	JJ	Degree=Pos	9	ccomp	9:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=12:Interrogative-WHInfo-Indirect.Clause
 13	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 14	extremist	extremist	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	Muslims	Muslim	PROPN	NNPS	Number=Plur	12	nsubj	12:nsubj	_
@@ -1969,7 +1969,7 @@
 19	guerrillas	guerrilla	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj|22:nsubj:xsubj	_
 20	threaten	threaten	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	conj	17:conj:and	_
 21	to	to	PART	TO	_	22	mark	22:mark	_
-22	behead	behead	VERB	VB	VerbForm=Inf	20	xcomp	20:xcomp	_
+22	behead	behead	VERB	VB	VerbForm=Inf	20	xcomp	20:xcomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 23	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	22	obj	22:obj	_
 24	if	if	SCONJ	IN	_	30	mark	30:mark	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
@@ -1977,7 +1977,7 @@
 27	compaign	compaign	NOUN	NN	Number=Sing	30	nsubj:pass	30:nsubj:pass	_
 28	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	aux:pass	30:aux:pass	_
 29	not	not	PART	RB	Polarity=Neg	30	advmod	30:advmod	_
-30	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	22	advcl	22:advcl:if	SpaceAfter=No
+30	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 31	.	.	PUNCT	.	_	17	punct	17:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041111060900_ENG_20041111_060900-0008
@@ -2044,14 +2044,14 @@
 5	cities	city	NOUN	NNS	Number=Plur	2	conj	2:conj:and|8:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	any	any	DET	DT	PronType=Ind	8	det	8:det	_
-8	guide	guide	NOUN	NN	Number=Sing	15	advcl	15:advcl:if	SpaceAfter=No
+8	guide	guide	NOUN	NN	Number=Sing	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 9	,	,	PUNCT	,	_	8	punct	8:punct	_
 10	those	that	DET	DT	Number=Plur|PronType=Dem	11	det	11:det	_
 11	pockets	pocket	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj|17:nsubj:xsubj	_
 12	of	of	ADP	IN	_	13	case	13:case	_
 13	resistance	resistance	NOUN	NN	Number=Sing	11	nmod	11:nmod:of	_
 14	could	could	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
+15	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	on	on	ADP	RP	_	15	compound:prt	15:compound:prt	_
 17	bedeviling	bedevil	VERB	VBG	VerbForm=Ger	15	xcomp	15:xcomp	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
@@ -2098,7 +2098,7 @@
 11	earlier	early	ADV	RBR	Degree=Cmp	14	advmod	14:advmod	_
 12	been	be	AUX	VBN	Tense=Past|VerbForm=Part	14	aux:pass	14:aux:pass	_
 13	absolutely	absolutely	ADV	RB	_	14	advmod	14:advmod	_
-14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass
+14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
 15	to	to	SCONJ	IN	_	16	mark	16:mark	_
 16	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:to	_
 17	out	out	ADP	RP	_	16	compound:prt	16:compound:prt	_
@@ -2184,7 +2184,7 @@
 9	Unconfirmed	Unconfirmed	ADJ	NNP	Degree=Pos	10	amod	10:amod	_
 10	Sources	Source	PROPN	NNPS	Number=Plur	8	obj	8:obj|12:nsubj	_
 11	which	which	PRON	WDT	PronType=Rel	12	nsubj	10:ref	_
-12	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nsubj
+12	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 13	some	some	DET	DT	PronType=Ind	14	det	14:det	_
 14	fun	fun	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	with	with	ADP	IN	_	17	case	17:case	_
@@ -2261,7 +2261,7 @@
 18	all	all	DET	DT	PronType=Tot	24	nsubj:outer	21:obj|24:nsubj:outer	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	US	US	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
-21	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj
+21	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 22	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	give	give	VERB	VB	VerbForm=Inf	4	conj	4:conj:and	_
@@ -2282,8 +2282,8 @@
 5	years	year	NOUN	NNS	Number=Plur	8	obl	8:obl:for	_
 6	there	there	PRON	EX	_	8	expl	8:expl	_
 7	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
-8	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
-9	tensions	tension	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
+8	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+9	tensions	tension	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	CxnElt=8:Existential-CopPred-ThereExpl.Pivot
 10	with	with	ADP	IN	_	14	case	14:case	_
 11-12	Iran’s	_	_	_	_	_	_	_	_
 11	Iran	Iran	PROPN	NNP	Number=Sing	14	nmod:poss	14:nmod:poss	_
@@ -2305,7 +2305,7 @@
 27	European	European	ADJ	NNP	Degree=Pos	28	amod	28:amod	_
 28	Union	Union	PROPN	NNP	Number=Sing	24	obl	24:obl:through	_
 29	that	that	PRON	WDT	PronType=Rel	30	nsubj	22:ref	_
-30	meets	meet	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	acl:relcl	22:acl:relcl	Cxn=rc-that-nsubj
+30	meets	meet	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	acl:relcl	22:acl:relcl	_
 31	with	with	ADP	IN	_	33	case	33:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	approval	approval	NOUN	NN	Number=Sing	30	obl	30:obl:with	_
@@ -2329,9 +2329,9 @@
 8	Opposition	opposition	NOUN	NN	Number=Sing	9	compound	9:compound	_
 9	Group	group	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
 10	released	release	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
-11	what	what	PRON	WP	PronType=Int	13	obj	13:obj|14:nsubj:xsubj	_
+11	what	what	PRON	WP	PronType=Int	13	obj	13:obj|14:nsubj:xsubj	CxnElt=13:Interrogative-WHInfo-Indirect.WHWord
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
-13	call	call	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+13	call	call	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=13:Interrogative-WHInfo-Indirect.Clause
 14	proof	proof	NOUN	NN	Number=Sing	13	xcomp	13:xcomp	_
 15	of	of	ADP	IN	_	20	case	20:case	_
 16	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
@@ -2360,7 +2360,7 @@
 15	that	that	PRON	WDT	PronType=Rel	18	obj	14:ref	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	group	group	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
-18	presented	present	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+18	presented	present	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 19	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0006
@@ -2382,7 +2382,7 @@
 14	world	world	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
 15	’s	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	ever	ever	ADV	RB	PronType=Ind	17	advmod	17:advmod	_
-17	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+17	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
 18	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0007
@@ -2406,7 +2406,7 @@
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	will	will	AUX	MD	VerbForm=Fin	15	conj	15:conj:and	_
 19	not	not	PART	RB	Polarity=Neg	18	advmod	18:advmod	_
-20	have	have	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+20	have	have	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0008
@@ -2498,7 +2498,7 @@
 20	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 21	never	never	ADV	RB	PronType=Neg	23	advmod	23:advmod	_
 22	officially	officially	ADV	RB	_	23	advmod	23:advmod	_
-23	said	say	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
+23	said	say	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
 24	that	that	SCONJ	IN	_	26	mark	26:mark	_
 25	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	26	nsubj	26:nsubj	_
 26	posses	possess	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	23	ccomp	23:ccomp	CorrectForm=possess
@@ -2600,8 +2600,8 @@
 7	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	6	obj	6:obj	SpaceAfter=No
 8	,	,	PUNCT	,	_	2	punct	2:punct	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
-10	who	who	PRON	WP	PronType=Int	11	nsubj	11:nsubj	_
-11	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+10	who	who	PRON	WP	PronType=Int	11	nsubj	11:nsubj	CxnElt=11:Interrogative-WHInfo-Direct.WHWord
+11	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=11:Interrogative-WHInfo-Direct.Clause
 12	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	,	,	PUNCT	,	_	18	punct	18:punct	_
 14	and	and	CCONJ	CC	_	18	cc	18:cc	_
@@ -2636,7 +2636,7 @@
 7	uranium	uranium	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	being	be	AUX	VBG	Tense=Pres|VerbForm=Part	10	aux:pass	10:aux:pass	_
-10	enriched	enrich	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
+10	enriched	enrich	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 11	,	,	PUNCT	,	_	14	punct	14:punct	_
 12	somewhat	somewhat	ADV	RB	_	14	advmod	14:advmod	_
 13	like	like	ADP	IN	_	14	case	14:case	_
@@ -2721,7 +2721,7 @@
 21	"	"	PUNCT	``	_	24	punct	24:punct	SpaceAfter=No
 22	dual	dual	ADJ	JJ	Degree=Pos	24	amod	24:amod	SpaceAfter=No
 23	-	-	PUNCT	HYPH	_	22	punct	22:punct	SpaceAfter=No
-24	citizens	citizen	NOUN	NNS	Number=Plur	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
+24	citizens	citizen	NOUN	NNS	Number=Plur	15	acl:relcl	15:acl:relcl	SpaceAfter=No
 25	"	"	PUNCT	''	_	24	punct	24:punct	SpaceAfter=No
 26	)	)	PUNCT	-RRB-	_	24	punct	24:punct	SpaceAfter=No
 27	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -2743,7 +2743,7 @@
 13	fees	fee	NOUN	NNS	Number=Plur	11	obj	11:obj|16:obj	_
 14	that	that	PRON	WDT	PronType=Rel	16	obj	13:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-that-obj
+16	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	for	for	SCONJ	IN	_	18	mark	18:mark	_
 18	evacuating	evacuate	VERB	VBG	Tense=Pres|VerbForm=Part	16	advcl	16:advcl:for	_
 19	U.S.	U.S.	PROPN	NNP	Number=Sing	20	compound	20:compound	_
@@ -2752,7 +2752,7 @@
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0005
 # text = Why?
-1	Why	why	ADV	WRB	PronType=Int	0	root	0:root	SpaceAfter=No
+1	Why	why	ADV	WRB	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 2	?	?	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0006
@@ -2840,7 +2840,7 @@
 18	that	that	PRON	WDT	PronType=Rel	21	nsubj	17:ref	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	cop	21:cop	_
 20	totally	totally	ADV	RB	_	21	advmod	21:advmod	_
-21	predictable	predictable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+21	predictable	predictable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 22	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0009
@@ -2870,14 +2870,14 @@
 9	Asia	Asia	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
 10	when	when	ADV	WRB	PronType=Rel	12	advmod	5:ref	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl
+12	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 13	U.S.	U.S.	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	citizens	citizen	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	from	from	ADP	IN	_	16	case	16:case	_
 16	areas	area	NOUN	NNS	Number=Plur	12	obl	12:obl:from|19:nsubj:pass	_
 17	that	that	PRON	WDT	PronType=Rel	19	nsubj:pass	16:ref	_
 18	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux:pass	19:aux:pass	_
-19	hit	hit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	Cxn=rc-that-nsubj:pass
+19	hit	hit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	_
 20	by	by	ADP	IN	_	22	case	22:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	tsunami	tsunami	NOUN	NN	Number=Sing	19	obl:agent	19:obl:agent	_
@@ -2888,7 +2888,7 @@
 27	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	cop	30:cop	_
 28	much	much	ADV	RB	_	29	advmod	29:advmod	_
 29	less	less	ADV	RBR	Degree=Cmp	30	advmod	30:advmod	_
-30	predictable	predictable	ADJ	JJ	Degree=Pos	25	acl:relcl	25:acl:relcl	Cxn=rc-that-nsubj
+30	predictable	predictable	ADJ	JJ	Degree=Pos	25	acl:relcl	25:acl:relcl	_
 31	than	than	ADP	IN	_	36	case	36:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	36	det	36:det	_
 33	Hezbollah	Hezbollah	PROPN	NNP	Number=Sing	35	compound	35:compound	SpaceAfter=No
@@ -2896,7 +2896,7 @@
 35	provoked	provoke	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	36	amod	36:amod	_
 36	destruction	destruction	NOUN	NN	Number=Sing	30	obl	30:obl:than|38:nsubj	_
 37	that	that	PRON	WDT	PronType=Rel	38	nsubj	36:ref	_
-38	rained	rain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	Cxn=rc-that-nsubj
+38	rained	rain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
 39	down	down	ADV	RB	_	38	advmod	38:advmod	_
 40	on	on	ADP	IN	_	41	case	41:case	_
 41	Lebanon	Lebanon	PROPN	NNP	Number=Sing	38	obl	38:obl:on	SpaceAfter=No
@@ -2905,10 +2905,10 @@
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0011
 # text = And what do we get for this effort?
 1	And	and	CCONJ	CC	_	5	cc	5:cc	_
-2	what	what	PRON	WP	PronType=Int	5	obj	5:obj	_
+2	what	what	PRON	WP	PronType=Int	5	obj	5:obj	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 3	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	for	for	ADP	IN	_	8	case	8:case	_
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	effort	effort	NOUN	NN	Number=Sing	5	obl	5:obl:for	SpaceAfter=No
@@ -2984,7 +2984,7 @@
 11	among	among	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	amod	14:amod	_
-14	plaintiffs	plaintiff	NOUN	NNS	Number=Plur	1	acl:relcl	1:acl:relcl	Cxn=rc-wh-nsubj
+14	plaintiffs	plaintiff	NOUN	NNS	Number=Plur	1	acl:relcl	1:acl:relcl	_
 15	in	in	ADP	IN	_	17	case	17:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	lawsuit	lawsuit	NOUN	NN	Number=Sing	14	nmod	14:nmod:in	SpaceAfter=No
@@ -3054,10 +3054,10 @@
 23	bombed	bomb	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	15	conj	15:conj:and	_
 24	and	and	CCONJ	CC	_	26	cc	26:cc	_
 25	there	there	PRON	EX	_	26	expl	26:expl	_
-26	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
+26	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	Cxn=Existential-CopPred-ThereExpl
 27	absolutely	absolutely	ADV	RB	_	29	advmod	29:advmod	_
 28	no	no	DET	DT	PronType=Neg	29	det	29:det	_
-29	way	way	NOUN	NN	Number=Sing	26	nsubj	26:nsubj	_
+29	way	way	NOUN	NN	Number=Sing	26	nsubj	26:nsubj	CxnElt=26:Existential-CopPred-ThereExpl.Pivot
 30	for	for	SCONJ	IN	_	33	mark	33:mark	_
 31	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	33	nsubj	33:nsubj	_
 32	to	to	PART	TO	_	33	mark	33:mark	_
@@ -3085,12 +3085,12 @@
 6	citizens	citizen	NOUN	NNS	Number=Plur	0	root	0:root	_
 7	and	and	CCONJ	CC	_	9	cc	9:cc	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	_
+9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	6:conj:and	Cxn=Existential-CopPred-ThereExpl
 10	no	no	DET	DT	PronType=Neg	11	det	11:det	_
-11	way	way	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|14:obl:unmarked	_
+11	way	way	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|14:obl:unmarked	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 12	that	that	PRON	WDT	PronType=Rel	14	obl:unmarked	11:ref	_
 13	anybody	anybody	PRON	NN	Number=Sing|PronType=Ind	14	nsubj	14:nsubj	_
-14	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obl:unmarked
+14	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 15	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -3162,11 +3162,11 @@
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	countries	country	NOUN	NNS	Number=Plur	9	obl	9:obl:in|13:nsubj|23:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	house	house	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
+13	house	house	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	illegal	illegal	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	militias	militia	NOUN	NNS	Number=Plur	13	obj	13:obj|17:nsubj	_
 16	that	that	PRON	WDT	PronType=Rel	17	nsubj	15:ref	_
-17	attack	attack	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
+17	attack	attack	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	other	other	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	countries	country	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
@@ -3290,7 +3290,7 @@
 4	example	example	NOUN	NN	Number=Sing	0	root	0:root	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	what	what	PRON	WP	PronType=Rel	4	nmod	4:nmod:of|7:nsubj	_
-7	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-free-nsubj
+7	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 8	when	when	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
 9	Bush	Bush	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
 10	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
@@ -3301,7 +3301,7 @@
 15-16	hasn't	_	_	_	_	_	_	_	_
 15	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	n't	not	PART	RB	Polarity=Neg	17	advmod	17:advmod	_
-17	anticipated	anticipate	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+17	anticipated	anticipate	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
 18	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0004
@@ -3317,9 +3317,9 @@
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10-11	there's	_	_	_	_	_	_	_	_
 10	there	there	PRON	EX	_	11	expl	11:expl	_
-11	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
+11	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	Cxn=Existential-CopPred-ThereExpl
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
-13	lot	lot	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
+13	lot	lot	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	CxnElt=11:Existential-CopPred-ThereExpl.Pivot
 14	of	of	ADP	IN	_	15	case	15:case	_
 15	talk	talk	NOUN	NN	Number=Sing	13	nmod	13:nmod:of	_
 16	right	right	ADV	RB	_	17	advmod	17:advmod	_
@@ -3343,15 +3343,15 @@
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	2004	2004	NUM	CD	NumForm=Digit|NumType=Card	4	obl	4:obl:in	SpaceAfter=No
 7	,	,	PUNCT	,	_	4	punct	4:punct	_
-8	what	what	PRON	WP	PronType=Int	12	obj	12:obj	_
+8	what	what	PRON	WP	PronType=Int	12	obj	12:obj	CxnElt=12:Interrogative-WHInfo-Direct.WHWord
 9	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 10	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	memoirs	memoirs	NOUN	NNS	Number=Ptan	12	nsubj	12:nsubj	_
-12	say	say	VERB	VB	VerbForm=Inf	0	root	0:root	_
+12	say	say	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct,Interrogative-WHInfo-Direct#2|CxnElt=12:Interrogative-WHInfo-Direct.Clause,12:Interrogative-WHInfo-Direct#2.Clause
 13	about	about	ADP	IN	_	14	case	14:case	_
 14	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	12	obl	12:obl:about	SpaceAfter=No
 15	,	,	PUNCT	,	_	16	punct	16:punct	_
-16	what	what	PRON	WP	PronType=Int	12	conj	12:conj:and	_
+16	what	what	PRON	WP	PronType=Int	12	conj	12:conj:and	CxnElt=12:Interrogative-WHInfo-Direct#2.WHWord
 17	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 18	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 19	title	title	NOUN	NN	Number=Sing	16	nsubj	16:nsubj	_
@@ -3387,9 +3387,9 @@
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0008
 # text = There is a painting on my wall in the Oval -- first of all, I don't know.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
-4	painting	painting	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
+4	painting	painting	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	on	on	ADP	IN	_	7	case	7:case	_
 6	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	7	nmod:poss	7:nmod:poss	_
 7	wall	wall	NOUN	NN	Number=Sing	2	obl	2:obl:on	_
@@ -3462,9 +3462,9 @@
 3	--	--	PUNCT	,	_	2	punct	2:punct	_
 4-5	there's	_	_	_	_	_	_	_	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
-7	painting	painting	NOUN	NN	Number=Sing	5	nsubj	5:nsubj|16:nsubj	_
+7	painting	painting	NOUN	NN	Number=Sing	5	nsubj	5:nsubj|16:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 8	on	on	ADP	IN	_	10	case	10:case	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	wall	wall	NOUN	NN	Number=Sing	7	nmod	7:nmod:on	_
@@ -3473,7 +3473,7 @@
 13	Oval	Oval	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	Office	Office	PROPN	NNP	Number=Sing	10	nmod	10:nmod:in	_
 15	that	that	PRON	WDT	PronType=Rel	16	nsubj	7:ref	_
-16	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
+16	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	horseman	horseman	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	charging	charge	VERB	VBG	VerbForm=Ger	18	acl	18:acl	_
@@ -3484,12 +3484,12 @@
 24	,	,	PUNCT	,	_	27	punct	27:punct	_
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	there	there	PRON	EX	_	27	expl	27:expl	_
-27	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+27	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	Cxn=Existential-CopPred-ThereExpl
 28	at	at	ADP	IN	_	29	case	29:case	_
 29	least	least	ADJ	JJS	Degree=Sup	30	nmod	30:nmod:at	_
 30	two	two	NUM	CD	NumForm=Word|NumType=Card	32	nummod	32:nummod	_
 31	other	other	ADJ	JJ	Degree=Pos	32	amod	32:amod	_
-32	horsemen	horseman	NOUN	NNS	Number=Plur	27	nsubj	27:nsubj	_
+32	horsemen	horseman	NOUN	NNS	Number=Plur	27	nsubj	27:nsubj	CxnElt=27:Existential-CopPred-ThereExpl.Pivot
 33	following	follow	VERB	VBG	VerbForm=Ger	32	acl	32:acl	SpaceAfter=No
 34	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -3836,7 +3836,7 @@
 16	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
 17	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
 18	not	not	PART	RB	Polarity=Neg	19	advmod	19:advmod	_
-19	change	change	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
+19	change	change	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	_
 20	once	once	SCONJ	IN	_	22	mark	22:mark	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 22	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	19	advcl	19:advcl:once	_
@@ -3922,9 +3922,9 @@
 # text = There has been random speculation about Google developiong a new browser and/or acquiring Firefox.
 1	There	there	PRON	EX	_	3	expl	3:expl	_
 2	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	random	random	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
-5	speculation	speculation	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+5	speculation	speculation	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 6	about	about	SCONJ	IN	_	8	mark	8:mark	_
 7	Google	Google	PROPN	NNP	Number=Sing	8	nsubj	8:nsubj|13:nsubj|15:nsubj	_
 8	developiong	develop	VERB	VBG	Typo=Yes|VerbForm=Ger	5	acl	5:acl:about	CorrectForm=developing
@@ -3997,7 +3997,7 @@
 13	today	today	NOUN	NN	Number=Sing	11	obl:unmarked	11:obl:unmarked	TemporalNPAdjunct=Yes
 14	that	that	PRON	WDT	PronType=Rel	16	nsubj	12:ref	_
 15	strongly	strongly	ADV	RB	_	16	advmod	16:advmod	_
-16	indicate	indicate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj
+16	indicate	indicate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 17	that	that	SCONJ	IN	_	21	mark	21:mark	_
 18	Google	Google	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
@@ -4170,7 +4170,7 @@
 14	Darin	Darin	PROPN	NNP	Number=Sing	5	obl	5:obl:to|17:nsubj	_
 15	Fisher	Fisher	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	who	who	PRON	WP	PronType=Rel	17	nsubj	14:ref	_
-17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	obj	17:obj	_
 19	at	at	ADP	IN	_	20	case	20:case	_
 20	Google	Google	PROPN	NNP	Number=Sing	17	obl	17:obl:at	_
@@ -4364,10 +4364,10 @@
 26	money	money	NOUN	NN	Number=Sing	24	obj	24:obj	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	see	see	VERB	VB	VerbForm=Inf	24	advcl	24:advcl:to	_
-29	who	who	PRON	WP	PronType=Int	32	nsubj	32:nsubj	_
+29	who	who	PRON	WP	PronType=Int	32	nsubj	32:nsubj	CxnElt=32:Interrogative-WHInfo-Indirect.WHWord
 30	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	cop	32:cop	_
 31	behind	behind	ADP	IN	_	32	case	32:case	_
-32	something	something	PRON	NN	Number=Sing|PronType=Ind	28	ccomp	28:ccomp	SpaceAfter=No
+32	something	something	PRON	NN	Number=Sing|PronType=Ind	28	ccomp	28:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=32:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 33	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0024
@@ -4393,7 +4393,7 @@
 19	this	this	DET	DT	Number=Sing|PronType=Dem	20	det	20:det	_
 20	year	year	NOUN	NN	Number=Sing	16	obl:unmarked	16:obl:unmarked	TemporalNPAdjunct=Yes
 21	that	that	PRON	WDT	PronType=Rel	22	nsubj	18:ref	_
-22	formalizes	formalize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-that-nsubj
+22	formalizes	formalize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	29	det	29:det	_
 24	Google	Google	PROPN	NNP	Number=Sing	29	compound	29:compound	SpaceAfter=No
 25	-	-	SYM	SYM	_	26	cc	26:cc	SpaceAfter=No
@@ -4410,7 +4410,7 @@
 3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 4	not	not	PART	RB	Polarity=Neg	6	advmod	6:advmod	_
 5	already	already	ADV	RB	_	6	advmod	6:advmod	_
-6	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	14	advcl	14:advcl:if	_
+6	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	Flash	Flash	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	movie	movie	NOUN	NN	Number=Sing	6	obj	6:obj	_
@@ -4418,7 +4418,7 @@
 11	,	,	PUNCT	,	_	6	punct	6:punct	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj|19:nsubj	_
 13	should	should	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	_
+14	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 15	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 16	few	few	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
 17	minutes	minute	NOUN	NNS	Number=Plur	14	obj	14:obj	_
@@ -4483,7 +4483,7 @@
 1	Every	every	DET	DT	PronType=Tot	2	det	2:det	_
 2	move	move	NOUN	NN	Number=Sing	5	nsubj	4:obj|5:nsubj	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+4	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	brings	bring	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 7	particular	particular	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -4549,7 +4549,7 @@
 26	source	source	NOUN	NN	Number=Sing	27	compound	27:compound	_
 27	thing	thing	NOUN	NN	Number=Sing	29	nsubj	29:nsubj	_
 28	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	about	about	ADP	IN	_	22	acl:relcl	22:acl:relcl	Cxn=rc-free-pred-pstrand|Promoted=Yes|SpaceAfter=No
+29	about	about	ADP	IN	_	22	acl:relcl	22:acl:relcl	Promoted=Yes|SpaceAfter=No
 30	.	.	PUNCT	.	_	22	punct	22:punct	_
 
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0031
@@ -4566,7 +4566,7 @@
 9	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	5	ccomp	5:ccomp	_
 10	what	what	PRON	WP	PronType=Rel	9	obj	9:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	can	can	AUX	MD	VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
+12	can	can	AUX	MD	VerbForm=Fin	10	acl:relcl	10:acl:relcl	Promoted=Yes
 13	to	to	PART	TO	_	15	mark	15:mark	_
 14	both	both	CCONJ	CC	_	15	cc:preconj	15:cc:preconj	_
 15	shape	shape	VERB	VB	VerbForm=Inf	9	advcl	9:advcl:to	_
@@ -4644,7 +4644,7 @@
 7	self	self	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	interest	interest	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	4:ref	_
-10	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-cleft.that-nsubj
+10	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
 11	large	large	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 12	open	open	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	source	source	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -4678,7 +4678,7 @@
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
 3	What	what	PRON	WP	PronType=Rel	6	nsubj	5:obj|6:nsubj	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obj
+5	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	sense	sense	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -4706,7 +4706,7 @@
 19	source	source	NOUN	NN	Number=Sing	20	compound	20:compound	_
 20	project	project	NOUN	NN	Number=Sing	22	nsubj	22:nsubj	_
 21	will	will	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	go	go	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
+22	go	go	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	SpaceAfter=No
 23	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0037
@@ -4784,18 +4784,18 @@
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0002
 # text = How did the CPA get to the point where it has turned even Iraqi Shiites, who were initially grateful for the removal of Saddam Hussein, against the United States?
-1	How	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+1	How	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	CPA	CPA	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
-5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	to	to	ADP	IN	_	8	case	8:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	point	point	NOUN	NN	Number=Sing	5	obl	5:obl:to|12:obl	_
 9	where	where	ADV	WRB	PronType=Rel	12	advmod	8:ref	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obl
+12	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 13	even	even	ADV	RB	_	15	advmod	15:advmod	_
 14	Iraqi	Iraqi	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	Shiites	Shiite	PROPN	NNPS	Number=Plur	12	obj	12:obj|20:nsubj	SpaceAfter=No
@@ -4803,7 +4803,7 @@
 17	who	who	PRON	WP	PronType=Rel	20	nsubj	15:ref	_
 18	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	cop	20:cop	_
 19	initially	initially	ADV	RB	_	20	advmod	20:advmod	_
-20	grateful	grateful	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nsubj
+20	grateful	grateful	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	_
 21	for	for	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	removal	removal	NOUN	NN	Number=Sing	20	obl	20:obl:for	_
@@ -4819,9 +4819,9 @@
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0003
 # text = Where it risks fighting dual Sunni Arab and Shiite insurgencies simultaneously, at a time when US troops are rotating on a massive scale and hoping to downsize their forces in country?
-1	Where	where	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	Where	where	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj|4:nsubj:xsubj	_
-3	risks	risk	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	risks	risk	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	fighting	fight	VERB	VBG	VerbForm=Ger	3	xcomp	3:xcomp	_
 5	dual	dual	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 6	Sunni	Sunni	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -4838,7 +4838,7 @@
 17	US	US	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	troops	troops	NOUN	NNS	Number=Ptan	20	nsubj	20:nsubj|26:nsubj|28:nsubj:xsubj	_
 19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
-20	rotating	rotate	VERB	VBG	Tense=Pres|VerbForm=Part	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-obl:unmarked
+20	rotating	rotate	VERB	VBG	Tense=Pres|VerbForm=Part	15	acl:relcl	15:acl:relcl	_
 21	on	on	ADP	IN	_	24	case	24:case	_
 22	a	a	DET	DT	Definite=Ind|PronType=Art	24	det	24:det	_
 23	massive	massive	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
@@ -4868,7 +4868,7 @@
 11	contingents	contingent	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
 12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	already	already	ADV	RB	_	14	advmod	14:advmod	_
-14	committed	committed	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-obl:unmarked
+14	committed	committed	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	_
 15	to	to	SCONJ	IN	_	16	mark	16:mark	_
 16	leaving	leave	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:to	SpaceAfter=No
 17	,	,	PUNCT	,	_	22	punct	22:punct	_
@@ -4926,9 +4926,9 @@
 7	Defense	Defense	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	_
 8	only	only	ADV	RB	_	9	advmod	9:advmod	_
 9	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-10	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
+10	how	how	ADV	WRB	PronType=Int	12	advmod	12:advmod	CxnElt=12:Interrogative-WHInfo-Indirect.WHWord
 11	to	to	PART	TO	_	12	mark	12:mark	_
-12	blow	blow	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
+12	blow	blow	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=12:Interrogative-WHInfo-Indirect.Clause
 13	things	thing	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 14	up	up	ADP	RP	_	12	compound:prt	12:compound:prt	SpaceAfter=No
 15	.	.	PUNCT	.	_	9	punct	9:punct	_
@@ -4949,7 +4949,7 @@
 12	most	most	ADJ	JJS	Degree=Sup	15	nsubj	15:nsubj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
 14	whom	whom	PRON	WP	PronType=Rel	12	nmod	10:ref	_
-15	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
+15	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 16	no	no	DET	DT	PronType=Neg	18	det	18:det	_
 17	administrative	administrative	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	experience	experience	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
@@ -5028,7 +5028,7 @@
 13	social	social	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	experiments	experiment	NOUN	NNS	Number=Plur	11	conj	8:nmod:of|11:conj:and|18:obj	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obj_xcomp
+16	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	impose	impose	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
 19	on	on	ADP	IN	_	22	case	22:case	_
@@ -5074,12 +5074,12 @@
 5-6	Who's	_	_	_	_	_	_	_	_
 5	Who	who	PRON	WP	PronType=Int	7	nsubj	7:nsubj	_
 6	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
-7	Who	who	PRON	WP	PronType=Int	12	csubj	12:csubj|13:csubj:xsubj	_
+7	Who	who	PRON	WP	PronType=Int	12	csubj	12:csubj|13:csubj:xsubj	CxnElt=12:Interrogative-WHInfo-Direct.WHWord
 8	of	of	ADP	IN	_	9	case	9:case	_
 9	Neocons	Neocon	PROPN	NNPS	Number=Plur	7	nmod	7:nmod:of	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Iraq	Iraq	PROPN	NNP	Number=Sing	9	nmod	9:nmod:in	_
-12	helps	help	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+12	helps	help	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=12:Interrogative-WHInfo-Direct.Clause
 13	explain	explain	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	extreme	extreme	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -5107,7 +5107,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj	5:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	close	close	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+10	close	close	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	_
 11	to	to	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	Bush	Bush	PROPN	NNP	Number=Sing	14	compound	14:compound	_
@@ -5234,18 +5234,18 @@
 14	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 15	scarcely	scarcely	ADV	RB	_	17	advmod	17:advmod	_
 16	be	be	AUX	VB	VerbForm=Inf	17	aux:pass	17:aux:pass	_
-17	guessed	guess	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass-pstrand
+17	guessed	guess	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
 18	at	at	ADP	IN	_	17	obl	17:obl	Promoted=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0018
 # text = There is a classical logical fallacy, post hoc ergo propter hoc (Z happens after X, therefore Z is caused by X), and I keep revising this posting this evening because I don't want to fall into it.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	classical	classical	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	logical	logical	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
-6	fallacy	fallacy	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
+6	fallacy	fallacy	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
 8	post	post	X	FW	Foreign=Yes	6	appos	6:appos	_
 9	hoc	hoc	X	FW	Foreign=Yes	8	flat	8:flat	_
@@ -5402,7 +5402,7 @@
 12	which	which	PRON	WDT	PronType=Rel	15	obl	11:ref	_
 13	Hassan	Hassan	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj	_
 14	Nasrallah	Nasrallah	PROPN	NNP	Number=Sing	13	flat	13:flat	_
-15	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pstrand
+15	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 16	for	for	ADP	IN	_	12	case	12:case	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	stand	stand	VERB	VB	VerbForm=Inf	9	acl	9:acl:to	_
@@ -5550,7 +5550,7 @@
 33	organization	organization	NOUN	NN	Number=Sing	30	nmod	30:nmod:with	SpaceAfter=No
 34	,	,	PUNCT	,	_	36	punct	36:punct	_
 35	which	which	PRON	WDT	PronType=Rel	36	nsubj	30:ref	_
-36	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-nsubj
+36	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
 37	7	7	NUM	CD	NumForm=Digit|NumType=Card	39	nummod	39:nummod	_
 38	US	US	PROPN	NNP	Number=Sing	39	compound	39:compound	_
 39	soldiers	soldier	NOUN	NNS	Number=Plur	36	obj	36:obj|40:nsubj:xsubj	_
@@ -5601,7 +5601,7 @@
 20	CPA	CPA	PROPN	NNP	Number=Sing	23	nsubj	23:nsubj	_
 21	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	been	be	AUX	VBN	Tense=Past|VerbForm=Part	23	aux	23:aux	_
-23	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	18	acl:relcl	18:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+23	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	18	acl:relcl	18:acl:relcl	SpaceAfter=No
 24	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0029
@@ -5629,11 +5629,11 @@
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0030
 # text = Why were they suddenly acted on Saturday?
-1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	5	nsubj:pass	5:nsubj:pass	_
 4	suddenly	suddenly	ADV	RB	_	5	advmod	5:advmod	_
-5	acted	act	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+5	acted	act	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	on	on	ADP	IN	_	5	obl	5:obl	Promoted=Yes
 7	Saturday	Saturday	PROPN	NNP	Number=Sing	5	obl:unmarked	5:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 8	?	?	PUNCT	.	_	5	punct	5:punct	_
@@ -5728,17 +5728,17 @@
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
+5	what	what	PRON	WP	PronType=Int	7	obj	7:obj	CxnElt=7:Interrogative-WHInfo-Indirect.WHWord
 6	that	that	PRON	DT	Number=Sing|PronType=Dem	7	nsubj	7:nsubj	_
-7	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	SpaceAfter=No
+7	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=7:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 8	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent23_13-0008
 # text = where did you grow up?
-1	where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	up	up	ADP	RP	_	4	compound:prt	4:compound:prt	SpaceAfter=No
 6	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -5759,7 +5759,7 @@
 1	should	should	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	embarrassed	embarrassed	ADJ	JJ	Degree=Pos	0	root	0:root	_
+4	embarrassed	embarrassed	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	that	that	SCONJ	IN	_	7	mark	7:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 7-8	haven't	_	_	_	_	_	_	_	_
@@ -5770,7 +5770,7 @@
 11	idea	idea	NOUN	NN	Number=Sing	7	obj	7:obj|14:obj	_
 12	what	what	PRON	WP	PronType=Rel	14	obj	11:ref	_
 13	that	that	PRON	DT	Number=Sing|PronType=Dem	14	nsubj	14:nsubj	_
-14	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
+14	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # newdoc id = email-enronsent23_08
@@ -5779,7 +5779,7 @@
 # text = i am going out tonight to get wasted if anyone is interested.
 1	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	out	out	ADV	RB	_	3	advmod	3:advmod	_
 5	tonight	tonight	NOUN	NN	Number=Sing	3	obl:unmarked	3:obl:unmarked	TemporalNPAdjunct=Yes
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -5788,7 +5788,7 @@
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	12	nsubj	12:nsubj	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
-12	interested	interested	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	SpaceAfter=No
+12	interested	interested	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 13	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_08-0002
@@ -5990,7 +5990,7 @@
 7	pinchers	pinscher	NOUN	NNS	Number=Plur|Typo=Yes	2	advcl	2:advcl:like|10:nsubj:pass	CorrectForm=pinschers
 8	who	who	PRON	WP	PronType=Rel	10	nsubj:pass	7:ref	_
 9	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	shrunk	shrink	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass|SpaceAfter=No
+10	shrunk	shrink	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_11-0007
@@ -6050,7 +6050,7 @@
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	college	college	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	3:ref	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 8	one	one	NUM	CD	NumForm=Word|NumType=Card	7	obj	7:obj	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
@@ -6060,10 +6060,10 @@
 
 # sent_id = email-enronsent23_11-0011
 # text = why do you think they are mean?
-1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	mean	mean	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	SpaceAfter=No
@@ -6074,15 +6074,15 @@
 # text = are you kidding?
 1	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	kidding	kid	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
+3	kidding	kid	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_11-0013
 # text = why would you want a chihuahua?
-1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	chihuahua	chihuahua	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -6102,7 +6102,7 @@
 # text = do you think they are cool b/c of the taco bell dog?
 1	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
 5	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	cool	cool	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	_
@@ -6187,13 +6187,13 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	administartion	administration	NOUN	NN	Number=Sing|Typo=Yes	8	nsubj	8:nsubj	CorrectForm=administration
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
-8	acting	act	VERB	VBG	Tense=Pres|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-obl-pfront
+8	acting	act	VERB	VBG	Tense=Pres|VerbForm=Part	2	acl:relcl	2:acl:relcl	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 10	that	that	SCONJ	IN	_	24	mark	24:mark	_
 11	if	if	SCONJ	IN	_	14	mark	14:mark	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
 13	expeditiously	expeditiously	ADV	RB	_	14	advmod	14:advmod	_
-14	suspend	suspend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
+14	suspend	suspend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 15-16	everyone's	_	_	_	_	_	_	_	_
 15	everyone	everyone	PRON	NN	Number=Sing|PronType=Tot	17	nmod:poss	17:nmod:poss	_
 16	's	's	PART	POS	_	15	case	15:case	_
@@ -6204,7 +6204,7 @@
 21	quickly	quickly	ADV	RB	_	14	advmod	14:advmod	SpaceAfter=No
 22	,	,	PUNCT	,	_	14	punct	14:punct	_
 23	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	nsubj	24:nsubj	_
-24	sets	set	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+24	sets	set	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 25	up	up	ADP	RP	_	24	compound:prt	24:compound:prt	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	27	det	27:det	_
 27	barrier	barrier	NOUN	NN	Number=Sing	24	obj	24:obj|34:obl	_
@@ -6214,7 +6214,7 @@
 31	access	access	NOUN	NN	Number=Sing	32	compound	32:compound	_
 32	coalition	coalition	NOUN	NN	Number=Sing	34	nsubj	34:nsubj	_
 33	must	must	AUX	MD	VerbForm=Fin	34	aux	34:aux	_
-34	break	break	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	Cxn=rc-wh-obl-pstrand
+34	break	break	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	_
 35	through	through	ADP	IN	_	28	case	28:case	SpaceAfter=No
 36	.	.	PUNCT	.	_	24	punct	24:punct	_
 
@@ -6239,7 +6239,7 @@
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	dishes	dish	NOUN	NNS	Number=Plur	9	nsubj:pass	9:nsubj:pass	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl:relcl	5:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
+9	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl:relcl	5:advcl:relcl	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent05_01-0008
@@ -6262,7 +6262,7 @@
 16	having	have	VERB	VBG	VerbForm=Ger	14	acl	14:acl:of	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	justify	justify	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
-19	why	why	ADV	WRB	PronType=Int	27	advmod	27:advmod	_
+19	why	why	ADV	WRB	PronType=Int	27	advmod	27:advmod	CxnElt=27:Interrogative-WHInfo-Indirect.WHWord
 20	each	each	DET	DT	PronType=Tot	23	det	23:det	_
 21	and	and	CCONJ	CC	_	22	cc	22:cc	_
 22	every	every	DET	DT	PronType=Tot	20	conj	20:conj:and|23:det	_
@@ -6270,7 +6270,7 @@
 24	should	should	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	27	cop	27:cop	_
 26	the	the	DET	DT	Definite=Def|PronType=Art	27	det	27:det	_
-27	exception	exception	NOUN	NN	Number=Sing	18	ccomp	18:ccomp	_
+27	exception	exception	NOUN	NN	Number=Sing	18	ccomp	18:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=27:Interrogative-WHInfo-Indirect.Clause
 28	to	to	ADP	IN	_	30	case	30:case	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	30	det	30:det	_
 30	suspension	suspension	NOUN	NN	Number=Sing	27	nmod	27:nmod:to	_
@@ -6330,7 +6330,7 @@
 2	be	be	AUX	VB	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	where	where	ADV	WRB	PronType=Rel	0	root	0:root|5:advmod	_
 4	power	power	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
-5	lies	lie	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
+5	lies	lie	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = email-enronsent23_14
@@ -6432,9 +6432,9 @@
 # text = there will be some girls there and then we can get them to meet up with us at that garden in the heights party later that night.
 1	there	there	PRON	EX	_	3	expl	3:expl	_
 2	will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	some	some	DET	DT	PronType=Ind	5	det	5:det	_
-5	girls	girl	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
+5	girls	girl	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 6	there	there	ADV	RB	PronType=Dem	3	advmod	3:advmod	_
 7	and	and	CCONJ	CC	_	11	cc	11:cc	_
 8	then	then	ADV	RB	PronType=Dem	11	advmod	11:advmod	_
@@ -6494,13 +6494,13 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	_
+4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	error	error	NOUN	NN	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 8	,	,	PUNCT	,	_	4	punct	4:punct	_
 9	please	please	INTJ	UH	_	10	discourse	10:discourse	_
-10	notify	notify	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+10	notify	notify	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	sender	sender	NOUN	NN	Number=Sing	10	iobj	10:iobj	_
 13	immediately	immediately	ADV	RB	_	10	advmod	10:advmod	_
@@ -6554,10 +6554,10 @@
 # sent_id = email-enronsent23_14-0015
 # newpar id = email-enronsent23_14-p0006
 # text = what do you mean i am perverted?
-1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	perverted	perverted	ADJ	JJ	Degree=Pos	4	parataxis	4:parataxis	SpaceAfter=No
@@ -6719,14 +6719,14 @@
 14	but	but	CCONJ	CC	_	24	cc	24:cc	_
 15	if	if	SCONJ	IN	_	17	mark	17:mark	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj|19:nsubj:xsubj	_
-17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	_
+17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	advcl	24:advcl:if	CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 18	to	to	PART	TO	_	19	mark	19:mark	_
 19	reach	reach	VERB	VB	VerbForm=Inf	17	xcomp	17:xcomp	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	19	obj	19:obj	SpaceAfter=No
 21	,	,	PUNCT	,	_	17	punct	17:punct	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj	_
 23	can	can	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	do	do	VERB	VB	VerbForm=Inf	4	conj	4:conj:but	_
+24	do	do	VERB	VB	VerbForm=Inf	4	conj	4:conj:but	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=24:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 25	so	so	ADV	RB	_	24	advmod	24:advmod	_
 26	at	at	ADP	IN	_	27	case	27:case	_
 27	RobBrnglsn@aol.com	RobBrnglsn@aol.com	PROPN	ADD	_	24	obl	24:obl:at	_
@@ -6782,10 +6782,10 @@
 1	PS	ps	NOUN	NN	Number=Sing	4	discourse	4:discourse	_
 2	--	--	PUNCT	:	_	1	punct	1:punct	_
 3	There	there	PRON	EX	_	4	expl	4:expl	_
-4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	happy	happy	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
-7	hour	hour	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
+7	hour	hour	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 8	tonight	tonight	NOUN	NN	Number=Sing	4	obl:unmarked	4:obl:unmarked	TemporalNPAdjunct=Yes
 9	at	at	ADP	IN	_	10	case	10:case	_
 10	Scudeiros	Scudeiros	PROPN	NNP	Number=Sing	4	obl	4:obl:at	_
@@ -6810,11 +6810,11 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	make	make	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	_
+4	make	make	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	obj	4:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	4	punct	4:punct	_
 7	please	please	INTJ	UH	_	8	discourse	8:discourse	_
-8	come	come	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+8	come	come	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 9	!	!	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = email-enronsent20_02-0012
@@ -6937,7 +6937,7 @@
 1	Will	will	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	aux	4:aux	_
-4	providing	provide	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	providing	provide	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	an	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	execution	execution	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	version	version	NOUN	NN	Number=Sing	4	obj	4:obj	_
@@ -7052,12 +7052,12 @@
 # text = If you have any questions, please contact us at noc@paulhastings.com.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 5	questions	question	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
 7	please	please	INTJ	UH	_	8	discourse	8:discourse	_
-8	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+8	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 9	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	8	obj	8:obj	_
 10	at	at	ADP	IN	_	11	case	11:case	_
 11	noc@paulhastings.com	noc@paulhastings.com	PROPN	ADD	_	8	obl	8:obl:at	SpaceAfter=No
@@ -7086,7 +7086,7 @@
 14	which	which	PRON	WDT	PronType=Rel	17	obl	10:ref	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	17:nsubj:pass	_
 16	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	17:aux:pass	_
-17	addressed	address	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-obl-pfront
+17	addressed	address	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	_
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	may	may	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 20	contain	contain	VERB	VB	VerbForm=Inf	6	conj	6:conj:and	_
@@ -7139,13 +7139,13 @@
 # text = If you received this in error, please contact the sender and delete the material from all computers."
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	3	obj	3:obj	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	error	error	NOUN	NN	Number=Sing	3	obl	3:obl:in	SpaceAfter=No
 7	,	,	PUNCT	,	_	3	punct	3:punct	_
 8	please	please	INTJ	UH	_	9	discourse	9:discourse	_
-9	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+9	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	sender	sender	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -7294,7 +7294,7 @@
 7	companies	company	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj	7:ref	_
 9	all	all	DET	DT	PronType=Tot	10	advmod	10:advmod	_
-10	bid	bid	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+10	bid	bid	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 11	higher	high	ADV	RBR	Degree=Cmp	10	advmod	10:advmod	_
 12	than	than	ADP	IN	_	13	case	13:case	_
 13	ENA	ENA	PROPN	NNP	Number=Sing	11	obl	11:obl:than	SpaceAfter=No
@@ -7424,13 +7424,13 @@
 # text = If you have any other questions, please let me know.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	any	any	DET	DT	PronType=Ind	6	det	6:det	_
 5	other	other	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	questions	question	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 7	,	,	PUNCT	,	_	3	punct	3:punct	_
 8	please	please	INTJ	UH	_	9	discourse	9:discourse	_
-9	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+9	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj|11:nsubj:xsubj	_
 11	know	know	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	SpaceAfter=No
 12	.	.	PUNCT	.	_	9	punct	9:punct	_
@@ -7477,7 +7477,7 @@
 8	sources	source	NOUN	NNS	Number=Plur	6	obl	6:obl:on|11:obj|14:nsubj:xsubj	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	8:ref	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-obj
+11	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 12	to	to	PART	TO	_	14	mark	14:mark	_
 13	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 14	reliable	reliable	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -7834,7 +7834,7 @@
 11	agreement	agreement	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	SpaceAfter=No
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	which	which	PRON	WDT	PronType=Rel	14	nsubj	7:ref	_
-14	reads	read	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+14	reads	read	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	part	part	NOUN	NN	Number=Sing	14	obl	14:obl:in	SpaceAfter=No
 17	:	:	PUNCT	:	_	20	punct	20:punct	_
@@ -7861,7 +7861,7 @@
 38	counterparty	counterparty	NOUN	NN	Number=Sing	41	nsubj	41:nsubj	_
 39	will	will	AUX	MD	VerbForm=Fin	41	aux	41:aux	_
 40	be	be	AUX	VB	VerbForm=Inf	41	aux	41:aux	_
-41	transporting	transport	VERB	VBG	Tense=Pres|VerbForm=Part	35	acl:relcl	35:acl:relcl	Cxn=rc-that-obj
+41	transporting	transport	VERB	VBG	Tense=Pres|VerbForm=Part	35	acl:relcl	35:acl:relcl	_
 42	on	on	ADP	IN	_	43	case	43:case	_
 43	HPL	hpl	NOUN	NN	Number=Sing	41	obl	41:obl:on	_
 44	may	may	AUX	MD	VerbForm=Fin	32	advcl	32:advcl:because	_
@@ -7990,7 +7990,7 @@
 17	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
 18	both	both	ADV	RB	_	20	advmod	20:advmod	_
 19	previously	previously	ADV	RB	_	20	advmod	20:advmod	_
-20	approved	approve	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
+20	approved	approve	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent28_03-0017
@@ -8010,7 +8010,7 @@
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj|3:nsubj:xsubj	_
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	5	mark	5:mark	_
-5	acceptable	acceptable	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	_
+5	acceptable	acceptable	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=5:Interrogative-Polar-Indirect.Clause
 6	and	and	CCONJ	CC	_	9	cc	9:cc	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj|12:nsubj	_
 8	will	will	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -8052,9 +8052,9 @@
 # newpar id = email-enronsent28_03-p0005
 # text = What's going on dude?
 1-2	What's	_	_	_	_	_	_	_	_
-1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	_
+1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	on	on	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	dude	dude	NOUN	NN	Number=Sing	3	vocative	3:vocative	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -8095,14 +8095,14 @@
 2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	realize	realize	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=12:Interrogative-WHInfo-Indirect.WHWord
 6	much	much	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
 8	stuff	stuff	NOUN	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No
 9	"	"	PUNCT	''	_	8	punct	8:punct	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 11	could	could	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
-12	pack	pack	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+12	pack	pack	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=12:Interrogative-WHInfo-Indirect.Clause
 13	into	into	ADP	IN	_	17	case	17:case	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
 15	one	one	NUM	CD	NumForm=Word|NumType=Card	16	nummod	16:nummod	_
@@ -8136,7 +8136,7 @@
 1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
-4	chasing	chase	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	chasing	chase	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	that	that	PRON	DT	Number=Sing|PronType=Dem	4	obj	4:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -8195,17 +8195,17 @@
 # sent_id = email-enronsent28_03-0037
 # newpar id = email-enronsent28_03-p0007
 # text = How is it going?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
+4	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent28_03-0038
 # text = Did you survive the honeymoon?
 1	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	survive	survive	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	survive	survive	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	honeymoon	honeymoon	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -8225,13 +8225,13 @@
 1	Go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	ahead	ahead	ADV	RB	_	1	advmod	1:advmod	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
-4	forward	forward	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	_
+4	forward	forward	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	to	to	ADP	IN	_	6	case	6:case	_
 6	Brant	Brant	PROPN	NNP	Number=Sing	4	obl	4:obl:to	_
 7	if	if	SCONJ	IN	_	10	mark	10:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	SpaceAfter=No
+10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # newdoc id = email-enronsent01_01
@@ -8303,7 +8303,7 @@
 2	to	to	ADP	IN	_	3	case	3:case	_
 3	all	all	DET	DT	PronType=Tot	1	nmod	1:nmod:to|5:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	5	nsubj	3:ref	_
-5	volunteered	volunteer	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
+5	volunteered	volunteer	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent01_01-0009
@@ -8462,8 +8462,8 @@
 
 # sent_id = email-enronsent01_01-0020
 # text = WHO WANTS TO HELP MILLIONS FOR UNITED WAY?
-1	WHO	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj|4:nsubj:xsubj	_
-2	WANTS	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	WHO	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj|4:nsubj:xsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	WANTS	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	TO	to	PART	TO	_	4	mark	4:mark	_
 4	HELP	help	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	MILLIONS	million	NOUN	NNS	Number=Plur	4	obj	4:obj	_
@@ -8483,9 +8483,9 @@
 # sent_id = email-enronsent01_01-0022
 # newpar id = email-enronsent01_01-p0009
 # text = How to Pledge:
-1	How	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	How	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	to	to	PART	TO	_	3	mark	3:mark	_
-3	Pledge	pledge	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+3	Pledge	pledge	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 4	:	:	PUNCT	:	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent01_01-0023
@@ -8584,7 +8584,7 @@
 2	:	:	PUNCT	:	_	14	punct	14:punct	_
 3	If	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	any	any	DET	DT	PronType=Ind	7	det	7:det	_
 7	questions	question	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 8	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	11	case	11:case	_
@@ -8593,7 +8593,7 @@
 11	process	process	NOUN	NN	Number=Sing	7	nmod	7:nmod:regarding	SpaceAfter=No
 12	,	,	PUNCT	,	_	5	punct	5:punct	_
 13	please	please	INTJ	UH	_	14	discourse	14:discourse	_
-14	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
+14	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 15	Joan	Joan	PROPN	NNP	Number=Sing	14	obj	14:obj	_
 16	Woodson	Woodson	PROPN	NNP	Number=Sing	15	flat	15:flat	_
 17	(	(	PUNCT	-LRB-	_	18	punct	18:punct	SpaceAfter=No
@@ -8700,7 +8700,7 @@
 # text = have you heard from anyone?
 1	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	from	from	ADP	IN	_	5	case	5:case	_
 5	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	obl	3:obl:from	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -8710,7 +8710,7 @@
 1	also	also	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
 3-4	what's	_	_	_	_	_	_	_	_
-3	what	what	PRON	WP	PronType=Int	0	root	0:root	_
+3	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	deal	deal	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
@@ -8783,7 +8783,7 @@
 
 # sent_id = email-enronsent01_01-0041
 # text = How are you?
-1	How	how	ADV	WRB	PronType=Int	0	root	0:root	_
+1	How	how	ADV	WRB	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	1	nsubj	1:nsubj	SpaceAfter=No
 4	?	?	PUNCT	.	_	1	punct	1:punct	_
@@ -8912,7 +8912,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	little	little	ADJ	JJ	Degree=Pos	13	obl:unmarked	13:obl:unmarked	_
-13	sooner	soon	ADJ	JJR	Degree=Cmp	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
+13	sooner	soon	ADJ	JJR	Degree=Cmp	8	acl:relcl	8:acl:relcl	_
 14	than	than	SCONJ	IN	_	16	mark	16:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 16	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:than	_
@@ -9003,15 +9003,15 @@
 # sent_id = email-enronsent08_01-0015
 # text = There are a few life theories like that which working through.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 4	few	few	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 5	life	life	NOUN	NN	Number=Sing	6	compound	6:compound	_
-6	theories	theory	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|10:nsubj	_
+6	theories	theory	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|10:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 7	like	like	ADP	IN	_	8	case	8:case	_
 8	that	that	PRON	DT	Number=Sing|PronType=Dem	6	nmod	6:nmod:like	_
 9	which	which	PRON	WDT	PronType=Rel	10	nsubj	6:ref	MissingWordAfter=Yes
-10	working	work	VERB	VBG	VerbForm=Ger	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj
+10	working	work	VERB	VBG	VerbForm=Ger	6	acl:relcl	6:acl:relcl	_
 11	through	through	ADV	RB	_	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -9028,10 +9028,10 @@
 # sent_id = email-enronsent08_01-0017
 # newpar id = email-enronsent08_01-p0002
 # text = How are things going with you?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	things	thing	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	with	with	ADP	IN	_	6	case	6:case	_
 6	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	4	obl	4:obl:with	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -9040,7 +9040,7 @@
 # text = Are you enjoying Houston?
 1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	enjoying	enjoy	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+3	enjoying	enjoy	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	Houston	Houston	PROPN	NNP	Number=Sing	3	obj	3:obj	SpaceAfter=No
 5	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -9241,7 +9241,7 @@
 4	next	next	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	time	time	NOUN	NN	Number=Sing	3	obl:unmarked	3:obl:unmarked|7:obl	TemporalNPAdjunct=Yes
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
+7	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	amstel	Amstel	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	lights	Light	PROPN	NNPS	Number=Plur	7	obj	7:obj	_
 10	together	together	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
@@ -9316,12 +9316,12 @@
 4	not	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	intended	intend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	amod	7:amod	_
-7	recipient	recipient	NOUN	NN	Number=Sing	12	advcl	12:advcl:if	SpaceAfter=No
+7	recipient	recipient	NOUN	NN	Number=Sing	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 8	,	,	PUNCT	,	_	7	punct	7:punct	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj:pass	12:nsubj:pass	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
 11	hereby	hereby	ADV	RB	_	12	advmod	12:advmod	_
-12	notified	notify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+12	notified	notify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	that	that	SCONJ	IN	_	16	mark	16:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
 15	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
@@ -9352,7 +9352,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	_
+4	received	receive	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	this	this	DET	DT	Number=Sing|PronType=Dem	6	det	6:det	_
 6	transmittal	transmittal	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	and	and	CCONJ	CC	_	10	cc	10:cc	SpaceAfter=No
@@ -9363,7 +9363,7 @@
 12	error	error	NOUN	NN	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 13	,	,	PUNCT	,	_	4	punct	4:punct	_
 14	please	please	INTJ	UH	_	15	discourse	15:discourse	_
-15	notify	notify	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+15	notify	notify	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	15	iobj	15:iobj	_
 17	immediately	immediately	ADV	RB	_	15	advmod	15:advmod	_
 18	by	by	ADP	IN	_	19	case	19:case	_
@@ -9527,7 +9527,7 @@
 14	there	there	PRON	EX	_	17	expl	17:expl	_
 15	could	could	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 16	be	be	AUX	VB	VerbForm=Inf	17	cop	17:cop	_
-17	love	love	NOUN	NN	Number=Sing	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+17	love	love	NOUN	NN	Number=Sing	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
 19	self	self	NOUN	NN	Number=Sing	21	compound	21:compound	SpaceAfter=No
 20	-	-	PUNCT	HYPH	_	19	punct	19:punct	SpaceAfter=No
@@ -9563,7 +9563,7 @@
 22-23	haven't	_	_	_	_	_	_	_	_
 22	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	n't	not	PART	RB	Polarity=Neg	24	advmod	24:advmod	_
-24	found	find	VERB	VBN	Tense=Past|VerbForm=Part	32	advcl	32:advcl:if	_
+24	found	find	VERB	VBN	Tense=Past|VerbForm=Part	32	advcl	32:advcl:if	CxnElt=32:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 25	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	obj	24:obj	_
 26	as	as	ADP	IN	_	27	case	27:case	_
 27	yet	yet	ADV	RB	_	24	obl	24:obl:as	_
@@ -9571,7 +9571,7 @@
 29	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	32	nsubj	32:nsubj	_
 30	possibly	possibly	ADV	RB	_	32	advmod	32:advmod	_
 31	soon	soon	ADV	RB	Degree=Pos	32	advmod	32:advmod	_
-32	will	will	AUX	MD	VerbForm=Fin	5	conj	5:conj:and	SpaceAfter=No
+32	will	will	AUX	MD	VerbForm=Fin	5	conj	5:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=32:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 33	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent30_02-0004
@@ -9581,7 +9581,7 @@
 3	past	past	NOUN	NN	Number=Sing	6	obl	6:obl:in	_
 4	there	there	PRON	EX	_	6	expl	6:expl	_
 5	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+6	been	be	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 7	..	..	PUNCT	,	_	12	punct	12:punct	_
 8	and	and	CCONJ	CC	_	12	cc	12:cc	_
 9	maybe	maybe	ADV	RB	_	12	advmod	12:advmod	_
@@ -9589,11 +9589,11 @@
 11	still	still	ADV	RB	_	12	advmod	12:advmod	_
 12	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	_
 13	many	many	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
-14	things	thing	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|20:obl:without	_
+14	things	thing	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj|20:obl:without	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
 15	that	that	PRON	WDT	PronType=Rel	20	obl	14:ref	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|20:nsubj:xsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
-18	had	have	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	Cxn=rc-that-obl_xcomp-pstrand
+18	had	have	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	do	do	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 21	without	without	ADP	IN	_	15	case	15:case	SpaceAfter=No
@@ -9616,7 +9616,7 @@
 13	situation	situation	NOUN	NN	Number=Sing	11	conj	6:obl:on|11:conj:or|16:nsubj|23:nsubj	_
 14	that	that	PRON	WDT	PronType=Rel	16	nsubj	11:ref	_
 15	could	could	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	give	give	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
+16	give	give	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
 17	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	16	iobj	16:iobj	_
 18	greater	great	ADJ	JJR	Degree=Cmp	19	amod	19:amod	_
 19	prestige	prestige	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -9663,7 +9663,7 @@
 29	all	all	DET	PDT	PronType=Tot	30	det:predet	30:det:predet	_
 30	those	that	PRON	DT	Number=Plur|PronType=Dem	20	obl	20:obl:to|32:nsubj	_
 31	that	that	PRON	WDT	PronType=Rel	32	nsubj	30:ref	_
-32	show	show	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	Cxn=rc-that-nsubj
+32	show	show	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
 33	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	32	iobj	32:iobj	_
 34	a	a	DET	DT	Definite=Ind|PronType=Art	36	det	36:det	_
 35	little	little	ADJ	JJ	Degree=Pos	36	amod	36:amod	_
@@ -9718,9 +9718,9 @@
 # sent_id = email-enronsent30_02-0008
 # text = There is no subterfuge in you.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	no	no	DET	DT	PronType=Neg	4	det	4:det	_
-4	subterfuge	subterfuge	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
+4	subterfuge	subterfuge	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obl	2:obl:in	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -9735,7 +9735,7 @@
 6	and	and	CCONJ	CC	_	19	cc	19:cc	_
 7	all	all	DET	DT	PronType=Tot	19	nsubj	9:obj|19:nsubj	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj
+9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	from	from	ADP	IN	_	11	case	11:case	_
 11	life	life	NOUN	NN	Number=Sing	9	obl	9:obl:from	SpaceAfter=No
 12	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -9749,7 +9749,7 @@
 20	whom	whom	PRON	WP	PronType=Rel	23	iobj	19:ref	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	23	nsubj	23:nsubj	_
 22	can	can	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
-23	trust	trust	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-wh-iobj
+23	trust	trust	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	_
 24	and	and	CCONJ	CC	_	32	cc	32:cc	_
 25	with	with	ADP	IN	_	26	case	26:case	_
 26	whom	whom	PRON	WP	PronType=Rel	32	obl	19:ref	_
@@ -9805,7 +9805,7 @@
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	all	all	DET	DT	PronType=Tot	16	nsubj	14:obj|16:nsubj|21:nsubj	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	seek	seek	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
+14	seek	seek	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	sincerity	sincerity	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
 17	and	and	CCONJ	CC	_	21	cc	21:cc	_
@@ -9864,7 +9864,7 @@
 # text = All you want is for "them" to get on with it - and to leave you alone..
 1	All	all	DET	DT	PronType=Tot	10	nsubj:outer	3:obj|10:nsubj:outer|17:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 5	for	for	SCONJ	IN	_	10	mark	10:mark	_
 6	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
@@ -9935,7 +9935,7 @@
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=6:Interrogative-Polar-Indirect.Clause
 7	any	any	DET	DT	PronType=Ind	8	det	8:det	_
 8	questions	question	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -9958,7 +9958,7 @@
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
-4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 6	historical	historical	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 7	nymex	nymex	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -9966,7 +9966,7 @@
 9	file	file	NOUN	NN	Number=Sing	4	obj	4:obj|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	created	create	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-obj
+12	created	create	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 13	for	for	ADP	IN	_	17	case	17:case	_
 14-15	Lavo's	_	_	_	_	_	_	_	_
 14	Lavo	Lavo	PROPN	NNP	Number=Sing	17	nmod:poss	17:nmod:poss	_
@@ -9979,10 +9979,10 @@
 # text = If you do would you send me a copy?
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	send	send	VERB	VB	VerbForm=Inf	0	root	0:root	_
+6	send	send	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,6:Interrogative-Polar-Direct.Clause
 7	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	iobj	6:iobj	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	copy	copy	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
@@ -10038,7 +10038,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
-4	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	26	advcl	26:advcl:if	_
+4	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	26	advcl	26:advcl:if	CxnElt=26:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	London	London	PROPN	NNP	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
@@ -10060,7 +10060,7 @@
 23	,	,	PUNCT	,	_	4	punct	4:punct	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
 25	can	can	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
-26	access	access	VERB	VB	VerbForm=Inf	0	root	0:root	_
+26	access	access	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=26:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 27	the	the	DET	DT	Definite=Def|PronType=Art	29	det	29:det	_
 28	live	live	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
 29	event	event	NOUN	NN	Number=Sing	26	obj	26:obj	_
@@ -10265,16 +10265,16 @@
 29	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
 30	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	31	nsubj	31:nsubj	_
 31	know	know	VERB	VB	VerbForm=Inf	5	parataxis	5:parataxis	_
-32	who	who	PRON	WP	PronType=Int	34	nsubj	34:nsubj|41:obl:to	_
+32	who	who	PRON	WP	PronType=Int	34	nsubj	34:nsubj|41:obl:to	CxnElt=34:Interrogative-WHInfo-Indirect.WHWord
 33	would	would	AUX	MD	VerbForm=Fin	34	aux	34:aux	_
-34	handle	handle	VERB	VB	VerbForm=Inf	31	ccomp	31:ccomp|41:obl	_
+34	handle	handle	VERB	VB	VerbForm=Inf	31	ccomp	31:ccomp|41:obl	Cxn=Interrogative-WHInfo-Indirect|CxnElt=34:Interrogative-WHInfo-Indirect.Clause
 35	this	this	PRON	DT	Number=Sing|PronType=Dem	34	obj	34:obj	_
 36	at	at	ADP	IN	_	37	case	37:case	_
 37	Enron	Enron	PROPN	NNP	Number=Sing	34	obl	34:obl:at	_
 38	that	that	PRON	WDT	PronType=Rel	41	obl	32:ref	_
 39	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	41	nsubj	41:nsubj	_
 40	can	can	AUX	MD	VerbForm=Fin	41	aux	41:aux	_
-41	speak	speak	VERB	VB	VerbForm=Inf	32	acl:relcl	32:acl:relcl	Cxn=rc-that-obl-pstrand
+41	speak	speak	VERB	VB	VerbForm=Inf	32	acl:relcl	32:acl:relcl	_
 42	to	to	ADP	IN	_	38	case	32:case	SpaceAfter=No
 43	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -10345,7 +10345,7 @@
 2	-	-	PUNCT	,	_	1	punct	1:punct	_
 3	Were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	having	have	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+5	having	have	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	phone	phone	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	system	system	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	problems	problem	NOUN	NNS	Number=Plur	5	obj	5:obj	_
@@ -10408,7 +10408,7 @@
 15	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:or	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	may	may	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
+18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	_
 19	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
 20	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
 21	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
@@ -10587,7 +10587,7 @@
 3	agreement	agreement	NOUN	NN	Number=Sing	11	nsubj	6:obj|11:nsubj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
-6	find	find	VERB	VB	VerbForm=Inf	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obj
+6	find	find	VERB	VB	VerbForm=Inf	3	acl:relcl	3:acl:relcl	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 9	Master	master	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -10608,7 +10608,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
 8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	7	obj	7:obj	_
 9	else	else	ADJ	JJ	Degree=Pos	8	amod	8:amod	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -10663,10 +10663,10 @@
 2	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj|4:nsubj:xsubj	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	CxnElt=8:Interrogative-WHInfo-Indirect.WHWord
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj|10:nsubj:xsubj	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	like	like	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+8	like	like	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=8:Interrogative-WHInfo-Indirect.Clause
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	proceed	proceed	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -10735,11 +10735,11 @@
 1	Could	could	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	this	this	PRON	DT	Number=Sing|PronType=Dem	4	nsubj	4:nsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:obj	_
+4	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:obj	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause,4:Interrogative-WHInfo-Direct.Clause,4:Interrogative-WHInfo-Direct.WHWord
 5-6	your	_	_	_	_	_	_	_	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|Typo=Yes|VerbForm=Fin	7	aux	7:aux	CorrectForm='re
-7	referencing	reference	VERB	VBG	Tense=Pres|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+7	referencing	reference	VERB	VBG	Tense=Pres|VerbForm=Part	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 8	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent29_01-0047
@@ -10795,13 +10795,13 @@
 1	Go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	ahead	ahead	ADV	RB	_	1	advmod	1:advmod	_
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
-4	forward	forward	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	_
+4	forward	forward	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	to	to	ADP	IN	_	6	case	6:case	_
 6	Brant	Brant	PROPN	NNP	Number=Sing	4	obl	4:obl:to	_
 7	if	if	SCONJ	IN	_	10	mark	10:mark	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 9	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	SpaceAfter=No
+10	ready	ready	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent29_01-0055
@@ -10905,9 +10905,9 @@
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 4	see	see	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:as	_
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 7	several	several	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
-8	blanks	blank	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	_
+8	blanks	blank	NOUN	NNS	Number=Plur	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
 9	concerning	concern	VERB	VBG	Tense=Pres|VerbForm=Part	11	case	11:case	_
 10	administrative	administrative	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	information	information	NOUN	NN	Number=Sing	8	nmod	8:nmod:concerning	_
@@ -10946,7 +10946,7 @@
 # text = Do you have this information?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	information	information	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -11130,7 +11130,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	data	data	NOUN	NN	Number=Sing	3	obj	3:obj|8:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+8	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 9	:	:	PUNCT	:	_	3	punct	3:punct	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	shall	shall	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -11366,11 +11366,11 @@
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj:pass	4:nsubj:pass	_
 2	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	be	be	AUX	VB	VerbForm=Inf	4	aux:pass	4:aux:pass	_
-4	appreciated	appreciate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+4	appreciated	appreciate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	could	could	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	advice	advice	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	_
+8	advice	advice	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 9	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	8	obj	8:obj	_
 10	on	on	ADP	IN	_	12	case	12:case	_
 11	this	this	DET	DT	Number=Sing|PronType=Dem	12	det	12:det	_
@@ -11458,7 +11458,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	uncertainties	uncertainty	NOUN	NNS	Number=Plur	5	obl	5:obl:given|11:obj	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+11	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 12	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent19_02-0027
@@ -11565,7 +11565,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	who	who	PRON	WP	PronType=Rel	20	nsubj	15:ref	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	cop	20:cop	_
-20	responsible	responsible	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nsubj
+20	responsible	responsible	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	_
 21	for	for	ADP	IN	_	23	case	23:case	_
 22	Georgia	Georgia	PROPN	NNP	Number=Sing	23	compound	23:compound	_
 23	Tech	Tech	PROPN	NNP	Number=Sing	20	obl	20:obl:for	_
@@ -11625,7 +11625,7 @@
 # text = Is this okay with you?
 1	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	this	this	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
-3	okay	okay	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	okay	okay	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	with	with	ADP	IN	_	5	case	5:case	_
 5	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	3	obl	3:obl:with	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -11732,10 +11732,10 @@
 
 # sent_id = email-enronsent19_02-0046
 # text = How are you doing?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
+4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent19_02-0047
@@ -11823,7 +11823,7 @@
 4	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:obl	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj:pass	7:nsubj:pass	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-free-obl|SpaceAfter=No
+7	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 8	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent19_02-0053
@@ -11841,10 +11841,10 @@
 11	get	get	VERB	VB	VerbForm=Inf	7	acl	7:acl:to	_
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	know	know	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
-14	what	what	PRON	WP	PronType=Int	17	obj	17:obj	_
+14	what	what	PRON	WP	PronType=Int	17	obj	17:obj	CxnElt=17:Interrogative-WHInfo-Indirect.WHWord
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	do	do	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	_
+17	do	do	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=17:Interrogative-WHInfo-Indirect.Clause
 18	in	in	ADP	IN	_	20	case	20:case	_
 19	this	this	DET	DT	Number=Sing|PronType=Dem	20	det	20:det	_
 20	field	field	NOUN	NN	Number=Sing	17	obl	17:obl:in	_
@@ -12033,11 +12033,11 @@
 2	let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 3	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	2	obj	2:obj|4:nsubj:xsubj	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	what	what	DET	WDT	PronType=Int	6	det	6:det	_
+5	what	what	DET	WDT	PronType=Int	6	det	6:det	CxnElt=9:Interrogative-WHInfo-Indirect.WHWord
 6	time	time	NOUN	NN	Number=Sing	9	obj	9:obj	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	meet	meet	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	SpaceAfter=No
+9	meet	meet	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=9:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent00_02-0006
@@ -12069,7 +12069,7 @@
 6	employees	employee	NOUN	NNS	Number=Plur	3	obl	3:obl:to|9:nsubj:pass	_
 7	who	who	PRON	WP	PronType=Rel	9	nsubj:pass	6:ref	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj:pass
+9	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	_
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
@@ -12087,7 +12087,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	tax	tax	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	law	law	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
-6	works	work	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
+6	works	work	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	SpaceAfter=No
 7	,	,	PUNCT	,	_	2	punct	2:punct	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	tax	tax	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -12171,7 +12171,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 3	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	prefer	prefer	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:if	_
+4	prefer	prefer	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	settle	settle	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
@@ -12183,7 +12183,7 @@
 13	,	,	PUNCT	,	_	4	punct	4:punct	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	distribute	distribute	VERB	VB	VerbForm=Inf	0	root	0:root	_
+16	distribute	distribute	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 17	gross	gross	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	shares	share	NOUN	NNS	Number=Plur	16	obj	16:obj	SpaceAfter=No
 19	.	.	PUNCT	.	_	16	punct	16:punct	_
@@ -12277,11 +12277,11 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	like	like	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	SpaceAfter=No
+4	like	like	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	can	can	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	set	set	VERB	VB	VerbForm=Inf	0	root	0:root	_
+8	set	set	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 11	conference	conference	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -12313,7 +12313,7 @@
 8	time	time	NOUN	NN	Number=Sing	6	conj	4:obj|6:conj:and	_
 9	that	that	PRON	WDT	PronType=Rel	11	nsubj	6:ref	_
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
-11	convenient	convenient	ADJ	JJ	Degree=Pos	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
+11	convenient	convenient	ADJ	JJ	Degree=Pos	6	acl:relcl	6:acl:relcl	_
 12	for	for	ADP	IN	_	13	case	13:case	_
 13	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	11	obl	11:obl:for	SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -12378,11 +12378,11 @@
 5	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
 7	understand	understand	VERB	VB	VerbForm=Inf	0	root	0:root	_
-8	which	which	DET	WDT	PronType=Int	9	det	9:det	ManuallyChecked=PronType
+8	which	which	DET	WDT	PronType=Int	9	det	9:det	CxnElt=12:Interrogative-WHInfo-Indirect.WHWord|ManuallyChecked=PronType
 9	date	date	NOUN	NN	Number=Sing	12	nsubj:pass	12:nsubj:pass	_
 10	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 11	be	be	AUX	VB	VerbForm=Inf	12	aux:pass	12:aux:pass	_
-12	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	ccomp	7:ccomp	_
+12	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	ccomp	7:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=12:Interrogative-WHInfo-Indirect.Clause
 13	to	to	PART	TO	_	14	mark	14:mark	_
 14	determine	determine	VERB	VB	VerbForm=Inf	12	advcl	12:advcl:to	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
@@ -12567,7 +12567,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:if	_
+4	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	quotes	quote	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	put	put	VERB	VB	VerbForm=Inf	5	acl	5:acl:to	_
@@ -12577,7 +12577,7 @@
 11	then	then	ADV	RB	PronType=Dem	14	advmod	14:advmod	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	14:nsubj|16:nsubj:xsubj	_
 13	will	will	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	_
+14	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 15	to	to	PART	TO	_	16	mark	16:mark	_
 16	clarify	clarify	VERB	VB	VerbForm=Inf	14	xcomp	14:xcomp	SpaceAfter=No
 17	.	.	PUNCT	.	_	14	punct	14:punct	_
@@ -12603,10 +12603,10 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	negotiations	negotiation	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	stall	stall	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	SpaceAfter=No
+4	stall	stall	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 5	,	,	PUNCT	,	_	4	punct	4:punct	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	7:expl	_
-7	seems	seem	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+7	seems	seem	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 8	like	like	SCONJ	IN	_	10	mark	10:mark	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj|15:nsubj:xsubj	_
 10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:like	_
@@ -12732,9 +12732,9 @@
 1	Let	let	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj|3:nsubj:xsubj	_
 3	know	know	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
-4	what	what	PRON	WP	PronType=Int	6	obj	6:obj	_
+4	what	what	PRON	WP	PronType=Int	6	obj	6:obj	CxnElt=6:Interrogative-WHInfo-Indirect.WHWord
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	think	think	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=6:Interrogative-WHInfo-Indirect.Clause
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
 9	property	property	NOUN	NN	Number=Sing	6	obl	6:obl:of	SpaceAfter=No
@@ -12800,11 +12800,11 @@
 # text = Is this how your clients usually evaluate these properties?
 1	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	this	this	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
-3	how	how	ADV	WRB	PronType=Rel	0	root	0:root|7:advmod	_
+3	how	how	ADV	WRB	PronType=Rel	0	root	0:root|7:advmod	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause,3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	clients	client	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 6	usually	usually	ADV	RB	_	7	advmod	7:advmod	_
-7	evaluate	evaluate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod
+7	evaluate	evaluate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	_
 8	these	this	DET	DT	Number=Plur|PronType=Dem	9	det	9:det	_
 9	properties	property	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -12840,7 +12840,7 @@
 6	limitations	limitation	NOUN	NNS	Number=Plur	3	obl	3:obl:than|9:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
-9	describing	describe	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+9	describing	describe	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	meeting	meeting	NOUN	NN	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
@@ -12904,7 +12904,7 @@
 # text = All you have to do is sign up for one free offer (such as efax) and then cancel within the offer time frame.
 1	All	all	DET	DT	PronType=Tot	7	nsubj:outer	5:obj|7:nsubj:outer|20:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj_xcomp
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -13053,9 +13053,9 @@
 1	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 2	...	...	PUNCT	,	_	4	punct	4:punct	SpaceAfter=No
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	no	no	DET	DT	PronType=Neg	6	det	6:det	_
-6	companion	companion	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
+6	companion	companion	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 7	quite	quite	ADV	RB	_	9	advmod	9:advmod	_
 8	so	so	ADV	RB	_	9	advmod	9:advmod	_
 9	devoted	devoted	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
@@ -13086,7 +13086,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13143,7 +13143,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13252,7 +13252,7 @@
 2	a	a	DET	DT	Definite=Ind|PronType=Art	3	det	3:det	_
 3	moment	moment	NOUN	NN	Number=Sing	0	root	0:root|5:nsubj	_
 4	that	that	PRON	WDT	PronType=Rel	5	nsubj	3:ref	_
-5	speaks	speak	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-that-nsubj
+5	speaks	speak	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	for	for	ADP	IN	_	7	case	7:case	_
 7	itself	itself	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obl	5:obl:for	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -13336,7 +13336,7 @@
 4	program	program	NOUN	NN	Number=Sing	1	obj	1:obj|7:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	7	nsubj	4:ref	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
-7	generate	generate	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+7	generate	generate	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	blast	blast	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	16	case	16:case	_
@@ -13358,7 +13358,7 @@
 # text = All you have to do is become a member and watch your earnings grow!
 1	All	all	DET	DT	PronType=Tot	7	nsubj:outer	3:obj|7:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -13533,11 +13533,11 @@
 14	woul	would	AUX	GW	Typo=Yes|VerbForm=Fin	17	aux	17:aux	_
 15	d	_	X	MD	_	14	goeswith	14:goeswith	_
 16	be	be	AUX	VB	VerbForm=Inf	17	cop	17:cop	_
-17	grateful	grateful	ADJ	JJ	Degree=Pos	4	parataxis	4:parataxis	_
+17	grateful	grateful	ADJ	JJ	Degree=Pos	4	parataxis	4:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 18	if	if	SCONJ	IN	_	21	mark	21:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	21	nsubj	21:nsubj	_
 20	could	could	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
-21	get	get	VERB	VB	VerbForm=Inf	17	advcl	17:advcl:if	_
+21	get	get	VERB	VB	VerbForm=Inf	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	cash	cash	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	to	to	ADP	IN	_	25	case	25:case	_
@@ -13609,7 +13609,7 @@
 3	update	update	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 4	whatever	whatever	PRON	WP	PronType=Rel	3	obj	3:obj|6:xcomp	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-free-xcomp-auxstrand
+6	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	to	to	PART	TO	_	6	xcomp	4:mark	Promoted=Yes
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	_
@@ -13674,7 +13674,7 @@
 23	text	text	NOUN	NN	Number=Sing	21	obj	21:obj|26:obj	_
 24	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj:pass	26:nsubj:pass|28:nsubj:xsubj	CorrectSpaceAfter=Yes|SpaceAfter=No
 25	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	26	aux:pass	26:aux:pass	_
-26	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obj
+26	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	23	acl:relcl	23:acl:relcl	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	put	put	VERB	VB	VerbForm=Inf	26	xcomp	26:xcomp	_
 29	up	up	ADV	RB	_	28	advmod	28:advmod	_
@@ -13686,10 +13686,10 @@
 35	time	time	NOUN	NN	Number=Sing	32	obl	32:obl:of	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
 37	there	there	PRON	EX	_	38	expl	38:expl	_
-38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	parataxis	32:parataxis	_
+38	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	parataxis	32:parataxis	Cxn=Existential-CopPred-ThereExpl
 39	no	no	DET	DT	PronType=Neg	41	det	41:det	_
 40	real	real	ADJ	JJ	Degree=Pos	41	amod	41:amod	_
-41	pictures	picture	NOUN	NNS	Number=Plur	38	nsubj	38:nsubj	_
+41	pictures	picture	NOUN	NNS	Number=Plur	38	nsubj	38:nsubj	CxnElt=38:Existential-CopPred-ThereExpl.Pivot
 42	yet	yet	ADV	RB	_	38	advmod	38:advmod	SpaceAfter=No
 43	...	...	PUNCT	,	_	47	punct	47:punct	_
 44	but	but	CCONJ	CC	_	47	cc	47:cc	_
@@ -13752,8 +13752,8 @@
 20	so	so	ADV	RB	_	22	advmod	22:advmod	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 22	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	conj	18:conj	_
-23	how	how	ADV	WRB	PronType=Int	24	advmod	24:advmod	_
-24	hard	hard	ADJ	JJ	Degree=Pos	22	ccomp	22:ccomp	_
+23	how	how	ADV	WRB	PronType=Int	24	advmod	24:advmod	CxnElt=24:Interrogative-WHInfo-Indirect.WHWord
+24	hard	hard	ADJ	JJ	Degree=Pos	22	ccomp	22:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=24:Interrogative-WHInfo-Indirect.Clause
 25	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	expl	24:expl	_
 26	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
@@ -13821,14 +13821,14 @@
 12	where	where	ADV	WRB	PronType=Rel	15	advmod	11:ref	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
 14	can	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	hear	hear	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
+15	hear	hear	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
 16	talking	talk	VERB	VBG	VerbForm=Ger	17	amod	17:amod	_
 17	parakeets	parakeet	NOUN	NNS	Number=Plur	15	obj	15:obj|22:nsubj|26:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	22	nsubj	17:ref	_
 19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
 20	not	not	PART	RB	Polarity=Neg	22	advmod	22:advmod	_
 21	just	just	ADV	RB	_	22	advmod	22:advmod	_
-22	mimicking	mimic	VERB	VBG	Tense=Pres|VerbForm=Part	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+22	mimicking	mimic	VERB	VBG	Tense=Pres|VerbForm=Part	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 23	,	,	PUNCT	,	_	26	punct	26:punct	_
 24	but	but	CCONJ	CC	_	26	cc	26:cc	_
 25	actually	actually	ADV	RB	_	26	advmod	26:advmod	_
@@ -13891,14 +13891,14 @@
 5	from	from	ADP	IN	_	6	case	6:case	_
 6	tgs	tgs	PROPN	NNP	Number=Sing	2	obl	2:obl:from	SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
-8	look	look	VERB	VB	Mood=Imp|VerbForm=Fin	2	parataxis	2:parataxis	_
+8	look	look	VERB	VB	Mood=Imp|VerbForm=Fin	2	parataxis	2:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 9	at	at	ADP	IN	_	10	case	10:case	_
 10	all	all	DET	DT	PronType=Tot	8	obl	8:obl:at	_
 11	of	of	ADP	IN	_	12	case	12:case	_
 12	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	10	nmod	10:nmod:of	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	_
+15	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 16	time	time	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	21	punct	21:punct	_
 18-19	they're	_	_	_	_	_	_	_	_
@@ -13998,7 +13998,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	friend	friend	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj|8:nsubj:xsubj|9:nsubj:xsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+6	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	get	get	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	rid	rid	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
@@ -14158,7 +14158,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	treatment	treatment	NOUN	NN	Number=Sing	2	obl	2:obl:to|7:obj	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	receive	receive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+7	receive	receive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 8	,	,	PUNCT	,	_	12	punct	12:punct	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
@@ -14194,7 +14194,7 @@
 5	people	people	NOUN	NNS	Number=Plur	3	obl	3:obl:for|8:nsubj|10:nsubj:xsubj|16:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	like	like	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+8	like	like	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	play	play	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	D	D	PROPN	NNP	Number=Sing	10	obj	10:obj	SpaceAfter=No
@@ -14261,18 +14261,18 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	this	this	PRON	DT	Number=Sing|PronType=Dem	7	nsubj	7:nsubj|8:nsubj:xsubj	_
-7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
 8	good	good	ADJ	JJ	Degree=Pos	7	xcomp	7:xcomp	SpaceAfter=No
 9	,	,	PUNCT	,	_	18	punct	18:punct	_
 10	and	and	CCONJ	CC	_	18	cc	18:cc	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	advcl	18:advcl:if	CxnElt=18:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 14	any	any	DET	DT	PronType=Ind	15	det	15:det	_
 15	question	question	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	13	punct	13:punct	_
 17	please	please	INTJ	UH	_	18	discourse	18:discourse	_
-18	ask	ask	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj:and	SpaceAfter=No
+18	ask	ask	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=18:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = newsgroup-groups.google.com_DungeonsDragonsChillicotheOH45601_022e6f4a0cd6fb61_ENG_20050829_233300-0005
@@ -14386,12 +14386,12 @@
 2	unsubscribe	unsubscribe	VERB	VB	VerbForm=Inf	14	advcl	14:advcl:to	_
 3	(	(	PUNCT	-LRB-	_	5	punct	5:punct	SpaceAfter=No
 4	or	or	CCONJ	CC	_	5	cc	5:cc	_
-5	subscribe	subscribe	VERB	VB	VerbForm=Inf	2	conj	2:conj:or|14:advcl:to	_
+5	subscribe	subscribe	VERB	VB	VerbForm=Inf	2	conj	2:conj:or|14:advcl:to	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 6	if	if	SCONJ	IN	_	10	mark	10:mark	_
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	message	message	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 9	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	forwarded	forward	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl	5:advcl:if	_
+10	forwarded	forward	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl	5:advcl:if	CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 11	to	to	ADP	IN	_	12	case	12:case	_
 12	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	10	obl	10:obl:to	SpaceAfter=No
 13	)	)	PUNCT	-RRB-	_	5	punct	5:punct	_
@@ -14414,8 +14414,8 @@
 1	While	while	SCONJ	IN	_	4	mark	4:mark	_
 2	there	there	PRON	EX	_	4	expl	4:expl	_
 3	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	been	be	VERB	VBN	Tense=Past|VerbForm=Part	22	advcl	22:advcl:while	_
-5	spasms	spasm	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
+4	been	be	VERB	VBN	Tense=Past|VerbForm=Part	22	advcl	22:advcl:while	Cxn=Existential-CopPred-ThereExpl
+5	spasms	spasm	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	speculation	speculation	NOUN	NN	Number=Sing	5	nmod	5:nmod:of	_
 8	about	about	SCONJ	IN	_	12	mark	12:mark	_
@@ -14652,7 +14652,7 @@
 28	Rahu	Rahu	PROPN	NNP	Number=Sing	26	nmod	26:nmod:of	_
 29	which	which	PRON	WDT	PronType=Rel	31	nsubj	26:ref	_
 30	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
-31	resulted	result	VERB	VBN	Tense=Past|VerbForm=Part	26	acl:relcl	26:acl:relcl	Cxn=rc-wh-nsubj
+31	resulted	result	VERB	VBN	Tense=Past|VerbForm=Part	26	acl:relcl	26:acl:relcl	_
 32	into	into	ADP	IN	_	33	case	33:case	_
 33	floods	flood	NOUN	NNS	Number=Plur	31	obl	31:obl:into	_
 34	in	in	ADP	IN	_	36	case	36:case	_
@@ -14766,7 +14766,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
-4	new	new	ADJ	JJ	Degree=Pos	13	advcl	13:advcl:if	_
+4	new	new	ADJ	JJ	Degree=Pos	13	advcl	13:advcl:if	CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	to	to	ADP	IN	_	9	case	9:case	_
 6	"	"	PUNCT	``	_	9	punct	9:punct	SpaceAfter=No
 7	The	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -14775,7 +14775,7 @@
 10	"	"	PUNCT	''	_	9	punct	9:punct	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 12	can	can	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	_
+13	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 14	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	13	iobj	13:iobj	_
 15	that	that	SCONJ	IN	_	18	mark	18:mark	_
 16-17	you'll	_	_	_	_	_	_	_	_
@@ -14867,7 +14867,7 @@
 1	And	and	CCONJ	CC	_	12	cc	12:cc	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+4	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	iobj	4:iobj	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	story	story	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
@@ -14875,7 +14875,7 @@
 9	that	that	PRON	DT	Number=Sing|PronType=Dem	12	nsubj	12:nsubj	_
 10	would	would	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 11	be	be	AUX	VB	VerbForm=Inf	12	cop	12:cop	_
-12	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	_
+12	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	to	too	ADV	RB	Typo=Yes	12	advmod	12:advmod	CorrectForm=too|SpaceAfter=No
 14	!	!	PUNCT	.	_	12	punct	12:punct	_
 
@@ -14952,7 +14952,7 @@
 1	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	12	obl:unmarked	4:obl|12:obl:unmarked	TemporalNPAdjunct=Yes
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|5:nsubj:xsubj	_
-4	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
+4	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	wearing	wear	VERB	VBG	VerbForm=Ger	4	xcomp	4:xcomp	_
 6-7	woman's	_	_	_	_	_	_	_	_
 6	woman	woman	NOUN	NN	Number=Sing	8	nmod:poss	8:nmod:poss	_
@@ -15108,7 +15108,7 @@
 17	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	18	amod	18:amod	_
 18	thing	thing	NOUN	NN	Number=Sing	22	nsubj:outer	20:obj|22:nsubj:outer	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj
+20	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 21	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 22	change	change	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 23	into	into	ADP	IN	_	27	case	27:case	_
@@ -15155,7 +15155,7 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	masses	mass	NOUN	NNS	Number=Plur	0	root	0:root|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
+10	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
@@ -15223,7 +15223,7 @@
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
 28	services	service	NOUN	NNS	Number=Plur	26	conj	12:obl:on|26:conj:and	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	Cxn=rc-red-obj
+30	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	_
 31	from	from	ADP	IN	_	33	case	33:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	airlines	airline	NOUN	NNS	Number=Plur	30	obl	30:obl:from	SpaceAfter=No
@@ -15303,7 +15303,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	check	check	VERB	VB	VerbForm=Inf	15	advcl	15:advcl:if	_
+4	check	check	VERB	VB	VerbForm=Inf	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	with	with	ADP	IN	_	8	case	8:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	other	other	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -15314,7 +15314,7 @@
 12	,	,	PUNCT	,	_	4	punct	4:punct	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
 14	may	may	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+15	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	excellent	excellent	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 17	discount	discount	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	airfare	airfare	NOUN	NN	Number=Sing	15	obj	15:obj|23:nsubj	SpaceAfter=No
@@ -15322,7 +15322,7 @@
 20	which	which	PRON	WDT	PronType=Rel	23	nsubj	18:ref	_
 21	may	may	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
 22	even	even	ADV	RB	_	23	advmod	23:advmod	_
-23	surprise	surprise	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-nsubj
+23	surprise	surprise	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	_
 24	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	23	obj	23:obj	SpaceAfter=No
 25	.	.	PUNCT	.	_	15	punct	15:punct	_
 
@@ -15358,7 +15358,7 @@
 18	pilot	pilot	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	study	study	NOUN	NN	Number=Sing	21	obl	21:obl:in	SpaceAfter=No
 20	,	,	PUNCT	,	_	19	punct	19:punct	_
-21	discriminated	discriminate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
+21	discriminated	discriminate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 22	between	between	ADP	IN	_	23	case	23:case	_
 23	ADHD	adhd	NOUN	NN	Number=Sing	21	obl	21:obl:between	SpaceAfter=No
 24	,	,	PUNCT	,	_	25	punct	25:punct	_
@@ -15401,7 +15401,7 @@
 28	any	anyone	PRON	GW	Number=Sing|PronType=Ind|Typo=Yes	26	obl	26:obl:to|31:nsubj	_
 29	one	_	X	NN	_	28	goeswith	28:goeswith	_
 30	who	who	PRON	WP	PronType=Rel	31	nsubj	28:ref	_
-31	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-wh-nsubj
+31	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
 32	access	access	NOUN	NN	Number=Sing	31	obj	31:obj	_
 33	to	to	ADP	IN	_	35	case	35:case	_
 34	a	a	DET	DT	Definite=Ind|PronType=Art	35	det	35:det	_
@@ -15419,7 +15419,7 @@
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:nsubj:pass|10:nsubj:xsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	Cxn=rc-free-nsubj:pass
+7	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	substitution	substitution	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	test	test	NOUN	NN	Number=Sing	7	xcomp	7:xcomp	SpaceAfter=No
@@ -15436,7 +15436,7 @@
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	which	which	PRON	WDT	PronType=Rel	6	nmod	4:ref	_
 9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	timed	time	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nmod_nsubj:pass-pfront
+10	timed	time	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	_
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	90	90	NUM	CD	NumForm=Digit|NumType=Card	13	nummod	13:nummod	_
 13	seconds	second	NOUN	NNS	Number=Plur	10	obl	10:obl:for	_
@@ -15551,11 +15551,11 @@
 10	,	,	PUNCT	,	_	9	punct	9:punct	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	website	website	NOUN	NN	Number=Sing	13	obj	13:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	13	punct	13:punct	_
-17	place	place	VERB	VB	VerbForm=Inf	6	conj	4:xcomp|6:conj:and	_
+17	place	place	VERB	VB	VerbForm=Inf	6	conj	4:xcomp|6:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 18	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 19	link	link	NOUN	NN	Number=Sing	17	obj	17:obj	_
 20	on	on	ADP	IN	_	22	case	22:case	_
@@ -15567,14 +15567,14 @@
 # sent_id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-0001
 # newpar id = newsgroup-groups.google.com_alt.animals.badgers_2044a3376e5a87a5_ENG_20040529_135300-p0001
 # text = are there any sadists out there who share the same tastes as i do ?
-1	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
-4	sadists	sadist	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|8:nsubj	_
+4	sadists	sadist	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|8:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot
 5	out	out	ADV	RB	_	6	advmod	6:advmod	_
 6	there	there	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 7	who	who	PRON	WP	PronType=Rel	8	nsubj	4:ref	_
-8	share	share	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
+8	share	share	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	same	same	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	tastes	taste	NOUN	NNS	Number=Plur	8	obj	8:obj	_
@@ -15590,7 +15590,7 @@
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	nt	not	PART	RB	Polarity=Neg|Typo=Yes	4	advmod	4:advmod	CorrectForm=n't
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	what	what	PRON	WP	PronType=Int	4	ccomp	4:ccomp	_
+5	what	what	PRON	WP	PronType=Int	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=5:Interrogative-WHInfo-Indirect.Clause,5:Interrogative-WHInfo-Indirect.WHWord
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 8	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -15694,7 +15694,7 @@
 4	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	2	nmod	2:nmod:to|7:nsubj:pass	_
 5	who	who	PRON	WP	PronType=Rel	7	nsubj:pass	4:ref	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	offended	offend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj:pass
+7	offended	offend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	_
 8	by	by	ADP	IN	_	10	case	10:case	_
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	request	request	NOUN	NN	Number=Sing	7	obl:agent	7:obl:agent	_
@@ -15959,7 +15959,7 @@
 13	dieters	dieter	NOUN	NNS	Number=Plur	3	obl	3:obl:from|16:nsubj	_
 14	who	who	PRON	WP	PronType=Rel	16	nsubj	13:ref	_
 15	successfully	successfully	ADV	RB	_	16	advmod	16:advmod	_
-16	used	use	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj
+16	used	use	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	natural	natural	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	supplement	supplement	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -16016,7 +16016,7 @@
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 3	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	successfully	successfully	ADV	RB	_	5	advmod	5:advmod	_
-5	used	use	VERB	VBN	Tense=Past|VerbForm=Part	16	advcl	16:advcl:if	_
+5	used	use	VERB	VBN	Tense=Past|VerbForm=Part	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	any	any	DET	DT	PronType=Ind	5	obj	5:obj	_
 7	of	of	ADP	IN	_	9	case	9:case	_
 8	these	this	DET	DT	Number=Plur|PronType=Dem	9	det	9:det	_
@@ -16027,7 +16027,7 @@
 13	loss	loss	NOUN	NN	Number=Sing	11	obj	11:obj	SpaceAfter=No
 14	,	,	PUNCT	,	_	5	punct	5:punct	_
 15	please	please	INTJ	UH	_	16	discourse	16:discourse	_
-16	write	write	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+16	write	write	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 17	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	16	iobj	16:iobj	_
 18	at	at	ADP	IN	_	19	case	19:case	_
 19	gottlie...@yahoo.com	gottlie...@yahoo.com	PROPN	ADD	_	16	obl	16:obl:at	_
@@ -16221,7 +16221,7 @@
 16	people	people	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	suddenly	suddenly	ADV	RB	_	19	advmod	19:advmod	_
-19	discovered	discover	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obl:unmarked
+19	discovered	discover	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	fertilizer	fertilizer	NOUN	NN	Number=Sing	29	nsubj	29:nsubj|32:nsubj	_
 22	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
@@ -16476,12 +16476,12 @@
 16	informed	inform	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 17	that	that	SCONJ	IN	_	19	mark	19:mark	_
 18	there	there	PRON	EX	_	19	expl	19:expl	_
-19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	ccomp	16:ccomp	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	ccomp	16:ccomp	Cxn=Existential-CopPred-ThereExpl
 20	no	no	DET	DT	PronType=Neg	24	det	24:det	_
 21	available	available	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
 22	public	public	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	housing	housing	NOUN	NN	Number=Sing	24	compound	24:compound	_
-24	units	unit	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
+24	units	unit	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	CxnElt=19:Existential-CopPred-ThereExpl.Pivot
 25	at	at	ADP	IN	_	27	case	27:case	_
 26	River	River	PROPN	NNP	Number=Sing	27	compound	27:compound	_
 27	Garden	Garden	PROPN	NNP	Number=Sing	24	nmod	24:nmod:at	_
@@ -16513,7 +16513,7 @@
 13	for	for	ADP	IN	_	14	case	14:case	_
 14	which	which	PRON	WDT	PronType=Rel	16	obl	12:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	qualified	qualify	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obl-pfront
+16	qualified	qualify	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 17	prior	prior	ADJ	JJ	Degree=Pos|ExtPos=ADP	20	case	20:case	_
 18	to	to	ADP	IN	_	17	fixed	17:fixed	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
@@ -16743,7 +16743,7 @@
 18	oil	oil	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	operations	operation	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
+21	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = newsgroup-groups.google.com_marketplace_e019a6deff0a1c7f_ENG_20050922_024300-0007
@@ -16860,7 +16860,7 @@
 5	bellow	bellow	ADV	RB	_	4	advmod	4:advmod	_
 6	which	which	PRON	WDT	PronType=Rel	8	nsubj	4:ref	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
-8	excelnt	excellent	ADJ	JJ	Degree=Pos|Typo=Yes	4	acl:relcl	4:acl:relcl	CorrectForm=excellent|Cxn=rc-wh-nsubj
+8	excelnt	excellent	ADJ	JJ	Degree=Pos|Typo=Yes	4	acl:relcl	4:acl:relcl	CorrectForm=excellent
 9	,	,	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 10	thank	thanks	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	_
 11	for	for	ADP	IN	_	13	case	13:case	_
@@ -16982,7 +16982,7 @@
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	which	which	PRON	WDT	PronType=Rel	13	nsubj	4:ref	_
 12	only	only	ADV	RB	_	13	advmod	13:advmod	_
-13	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-wh-csubj
+13	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	with	with	ADP	IN	_	17	case	17:case	_
 16	18	18	NUM	CD	NumForm=Digit|NumType=Card	17	nummod	17:nummod	_
@@ -17135,13 +17135,13 @@
 5	industry	industry	NOUN	NN	Number=Sing	14	nsubj	14:nsubj	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	if	if	SCONJ	IN	_	8	mark	8:mark	_
-8	put	put	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	advcl	14:advcl:if	_
+8	put	put	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 9	to	to	ADP	IN	_	11	case	11:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	test	test	NOUN	NN	Number=Sing	8	obl	8:obl:to	SpaceAfter=No
 12	,	,	PUNCT	,	_	8	punct	8:punct	_
 13	can	can	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	do	do	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
+14	do	do	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=14:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 15	better	well	ADV	RBR	Degree=Cmp	14	advmod	14:advmod	_
 16	[	[	PUNCT	-LRB-	_	19	punct	19:punct	SpaceAfter=No
 17	than	than	ADP	IN	_	19	case	19:case	_
@@ -17183,13 +17183,13 @@
 # text = But seeing how the private sector has been able to successfully transport civilians to the ISS (at about a fifth of the cost), it would come to no surprise if corporate America was able to out perform their bureaucratic friends in government.
 1	But	but	CCONJ	CC	_	29	cc	29:cc	_
 2	seeing	see	VERB	VBG	Tense=Pres|VerbForm=Part	29	advcl	29:advcl	_
-3	how	how	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
+3	how	how	ADV	WRB	PronType=Int	9	advmod	9:advmod	CxnElt=9:Interrogative-WHInfo-Indirect.WHWord
 4	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 5	private	private	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	sector	sector	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|12:nsubj:xsubj	_
 7	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	been	be	AUX	VBN	Tense=Past|VerbForm=Part	9	cop	9:cop	_
-9	able	able	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	_
+9	able	able	ADJ	JJ	Degree=Pos	2	ccomp	2:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=9:Interrogative-WHInfo-Indirect.Clause
 10	to	to	PART	TO	_	12	mark	12:mark	_
 11	successfully	successfully	ADV	RB	_	12	advmod	12:advmod	_
 12	transport	transport	VERB	VB	VerbForm=Inf	9	xcomp	9:xcomp	_
@@ -17209,7 +17209,7 @@
 26	,	,	PUNCT	,	_	2	punct	2:punct	_
 27	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	nsubj	29:nsubj	_
 28	would	would	AUX	MD	VerbForm=Fin	29	aux	29:aux	_
-29	come	come	VERB	VB	VerbForm=Inf	0	root	0:root	_
+29	come	come	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=29:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 30	to	to	ADP	IN	_	32	case	32:case	_
 31	no	no	DET	DT	PronType=Neg	32	det	32:det	_
 32	surprise	surprise	NOUN	NN	Number=Sing	29	obl	29:obl:to	_
@@ -17217,7 +17217,7 @@
 34	corporate	corporate	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	America	America	PROPN	NNP	Number=Sing	37	nsubj	37:nsubj|39:nsubj:xsubj	_
 36	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	37	cop	37:cop	_
-37	able	able	ADJ	JJ	Degree=Pos	29	advcl	29:advcl:if	_
+37	able	able	ADJ	JJ	Degree=Pos	29	advcl	29:advcl:if	CxnElt=29:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 38	to	to	PART	TO	_	39	mark	39:mark	_
 39	out	outperform	VERB	AFX	Typo=Yes|VerbForm=Inf	37	xcomp	37:xcomp	_
 40	perform	_	X	VB	_	39	goeswith	39:goeswith	_
@@ -17290,14 +17290,14 @@
 31	land	land	NOUN	NN	Number=Sing	28	obj	28:obj|34:obj|41:nsubj	_
 32	that	that	PRON	WDT	PronType=Rel	34	obj	31:ref	_
 33	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	34	nsubj	34:nsubj	_
-34	occupies	occupy	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	Cxn=rc-that-obj
+34	occupies	occupy	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	_
 35	before	before	ADP	IN	_	38	case	38:case	_
 36	the	the	DET	DT	Definite=Def|PronType=Art	38	det	38:det	_
 37	1967	1967	NUM	CD	NumForm=Digit|NumType=Card	38	nummod	38:nummod	_
 38	border	border	NOUN	NN	Number=Sing	34	obl	34:obl:before	_
 39	(	(	PUNCT	-LRB-	_	41	punct	41:punct	SpaceAfter=No
 40	which	which	PRON	WDT	PronType=Rel	41	nsubj	31:ref	_
-41	includes	include	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	Cxn=rc-wh-nsubj
+41	includes	include	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	_
 42	East	East	PROPN	NNP	Number=Sing	43	compound	43:compound	_
 43	Jerusalem	Jerusalem	PROPN	NNP	Number=Sing	41	obj	41:obj	_
 44	by	by	ADP	IN	_	46	case	46:case	_
@@ -17320,7 +17320,7 @@
 # text = If Abbas keeps up this "macho talk" he will kill potential peace talks and might as well allow Hamas (which has probably done a better job at providing for the Palestinians) rule the West Bank.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	Abbas	Abbas	PROPN	NNP	Number=Sing	3	nsubj	3:nsubj	_
-3	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 6	"	"	PUNCT	``	_	8	punct	8:punct	SpaceAfter=No
@@ -17329,7 +17329,7 @@
 9	"	"	PUNCT	''	_	8	punct	8:punct	_
 10	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj|20:nsubj	_
 11	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
-12	kill	kill	VERB	VB	VerbForm=Inf	0	root	0:root	_
+12	kill	kill	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	potential	potential	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 14	peace	peace	NOUN	NN	Number=Sing	15	compound	15:compound	_
 15	talks	talk	NOUN	NNS	Number=Plur	12	obj	12:obj	_
@@ -17343,7 +17343,7 @@
 23	which	which	PRON	WDT	PronType=Rel	26	nsubj	21:ref	_
 24	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
 25	probably	probably	ADV	RB	_	26	advmod	26:advmod	_
-26	done	do	VERB	VBN	Tense=Past|VerbForm=Part	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-nsubj
+26	done	do	VERB	VBN	Tense=Past|VerbForm=Part	21	acl:relcl	21:acl:relcl	_
 27	a	a	DET	DT	Definite=Ind|PronType=Art	29	det	29:det	_
 28	better	good	ADJ	JJR	Degree=Cmp	29	amod	29:amod	_
 29	job	job	NOUN	NN	Number=Sing	26	obj	26:obj	_
@@ -17549,7 +17549,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 11	northern	northern	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 12	Israeli	Israeli	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	city	city	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	Cxn=rc-free-nsubj
+13	city	city	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	_
 14	of	of	ADP	IN	_	15	case	15:case	_
 15	Safed	Safed	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
 16	,	,	PUNCT	,	_	1	punct	1:punct	_
@@ -17600,7 +17600,7 @@
 2	Abbas	Abbas	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj|10:nsubj	_
 3	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	change	change	VERB	VB	VerbForm=Inf	21	advcl	21:advcl:if	_
+5	change	change	VERB	VB	VerbForm=Inf	21	advcl	21:advcl:if	CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
 7	former	former	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	thinking	thinking	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -17616,8 +17616,8 @@
 18	there	there	PRON	EX	_	21	expl	21:expl	_
 19	will	will	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 20	not	not	PART	RB	Polarity=Neg	21	advmod	21:advmod	_
-21	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
-22	peace	peace	NOUN	NN	Number=Sing	21	nsubj	21:nsubj	_
+21	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Existential-CopPred-ThereExpl|CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
+22	peace	peace	NOUN	NN	Number=Sing	21	nsubj	21:nsubj	CxnElt=21:Existential-CopPred-ThereExpl.Pivot
 23	in	in	ADP	IN	_	26	case	26:case	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 25	Holy	Holy	ADJ	NNP	Degree=Pos	26	amod	26:amod	_
@@ -17778,12 +17778,12 @@
 # sent_id = newsgroup-groups.google.com_hiddennook_5380fdd00f8e5e56_ENG_20050926_194800-0008
 # text = It looks as if Hamas has thrown in the towel for this round, unable to take the beating the Israeli Defense Forces have unleashed upon this terrorist group.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 3	as	as	SCONJ	IN	_	7	mark	7:mark	_
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	Hamas	Hamas	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
 6	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	thrown	throw	VERB	VBN	Tense=Past|VerbForm=Part	2	advcl	2:advcl:if	_
+7	thrown	throw	VERB	VBN	Tense=Past|VerbForm=Part	2	advcl	2:advcl:if	CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 8	in	in	ADV	RB	_	7	advmod	7:advmod	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	towel	towel	NOUN	NN	Number=Sing	7	obj	7:obj	_
@@ -17801,7 +17801,7 @@
 22	Defense	Defense	PROPN	NNP	Number=Sing	23	compound	23:compound	_
 23	Forces	Force	PROPN	NNPS	Number=Plur	25	nsubj	25:nsubj	_
 24	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
-25	unleashed	unleash	VERB	VBN	Tense=Past|VerbForm=Part	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj
+25	unleashed	unleash	VERB	VBN	Tense=Past|VerbForm=Part	19	acl:relcl	19:acl:relcl	_
 26	upon	upon	ADP	IN	_	29	case	29:case	_
 27	this	this	DET	DT	Number=Sing|PronType=Dem	29	det	29:det	_
 28	terrorist	terrorist	NOUN	NN	Number=Sing	29	compound	29:compound	_
@@ -18082,7 +18082,7 @@
 18	time	time	NOUN	NN	Number=Sing	11	obl	11:obl:by|21:obl	_
 19	Israel	Israel	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 20	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
-21	done	done	ADJ	JJ	Degree=Pos	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl
+21	done	done	ADJ	JJ	Degree=Pos	18	acl:relcl	18:acl:relcl	_
 22	reminding	remind	VERB	VBG	Tense=Pres|VerbForm=Part	21	advcl	21:advcl	_
 23	Hamas	Hamas	PROPN	NNP	Number=Sing	22	iobj	22:iobj	_
 24	of	of	ADP	IN	_	27	case	27:case	_
@@ -18097,7 +18097,7 @@
 33	thing	thing	NOUN	NN	Number=Sing	38	nsubj:outer	36:obj|38:nsubj:outer|41:nsubj:outer	_
 34	Abbas	Abbas	PROPN	NNP	Number=Sing	36	nsubj	36:nsubj	_
 35	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	36	aux	36:aux	_
-36	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	33	acl:relcl	33:acl:relcl	Cxn=rc-red-obj
+36	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	33	acl:relcl	33:acl:relcl	_
 37	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	38	cop	38:cop	_
 38	lashing	lash	VERB	VBG	Tense=Pres|VerbForm=Part	11	advcl	11:advcl:although	_
 39	out	out	ADP	RP	_	38	compound:prt	38:compound:prt	_
@@ -18167,8 +18167,8 @@
 # sent_id = answers-20110909115731AAl3uzs_ans-0001
 # newpar id = answers-20110909115731AAl3uzs_ans-p0001
 # text = How much is a big mac in your country?
-1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
-2	much	much	ADJ	JJ	Degree=Pos	0	root	0:root	_
+1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	much	much	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	2:cop	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	big	big	ADJ	NNP	Degree=Pos	6	amod	6:amod	_
@@ -18202,11 +18202,11 @@
 # sent_id = answers-20090717131608AAqDfYJ_ans-0001
 # newpar id = answers-20090717131608AAqDfYJ_ans-p0001
 # text = What foods do you eat in Miramar?
-1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
+1	What	what	DET	WDT	PronType=Int	2	det	2:det	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	foods	food	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	Miramar	Miramar	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 8	?	?	PUNCT	.	_	5	punct	5:punct	_
@@ -18289,7 +18289,7 @@
 # text = Can you recommend any restaurants in Buenos Aires?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	recommend	recommend	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	recommend	recommend	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 5	restaurants	restaurant	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	in	in	ADP	IN	_	7	case	7:case	_
@@ -18315,8 +18315,8 @@
 # sent_id = answers-20100308180028AAHCoBv_ans-0004
 # text = There are several just off their beautiful beach.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	several	several	ADJ	JJ	Degree=Pos	2	nsubj	2:nsubj	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+3	several	several	ADJ	JJ	Degree=Pos	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 4	just	just	ADV	RB	_	8	advmod	8:advmod	_
 5	off	off	ADP	IN	_	8	case	8:case	_
 6	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
@@ -18384,8 +18384,8 @@
 # sent_id = answers-20111108082957AAzQGgo_ans-0001
 # newpar id = answers-20111108082957AAzQGgo_ans-p0001
 # text = What influenced Picasso's cubism style of painting?
-1	What	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3-4	Picasso's	_	_	_	_	_	_	_	_
 3	Picasso	Picasso	PROPN	NNP	Number=Sing	6	nmod:poss	6:nmod:poss	_
 4	's	's	PART	POS	_	3	case	3:case	_
@@ -18413,9 +18413,9 @@
 12	all	all	DET	DT	PronType=Tot	9	obl	9:obl:at	_
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	14:nsubj	_
 14	says	say	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	3:parataxis	_
-15	what	what	PRON	WP	PronType=Int	17	obj	17:obj	_
+15	what	what	PRON	WP	PronType=Int	17	obj	17:obj	CxnElt=17:Interrogative-WHInfo-Indirect.WHWord
 16	cubism	cubism	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
-17	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	_
+17	influenced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=17:Interrogative-WHInfo-Indirect.Clause
 18	not	not	PART	RB	Polarity=Neg	20	advmod	20:advmod	_
 19	what	what	PRON	WP	PronType=Int	20	nsubj	20:nsubj	_
 20	influnced	influence	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	17	conj	14:ccomp|17:conj	CorrectForm=influenced
@@ -18430,10 +18430,10 @@
 # sent_id = answers-20080426141111AAgPUwU_ans-0001
 # newpar id = answers-20080426141111AAgPUwU_ans-p0001
 # text = What do you eat in Miramar?
-1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	eat	eat	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	Miramar	Miramar	PROPN	NNP	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -18446,7 +18446,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	stuff	stuff	NOUN	NN	Number=Sing	1	nmod	1:nmod:like|6:obj	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
+6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	Spanish	Spanish	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	countries	country	NOUN	NNS	Number=Plur	6	obl	6:obl:in	_
@@ -18511,11 +18511,11 @@
 18	Delaware	Delaware	PROPN	NNP	Number=Sing	16	obl	16:obl:to	_
 19	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	20	nsubj	20:nsubj	_
 20	know	know	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
-21	how	how	ADV	WRB	PronType=Int	25	advmod	25:advmod	_
+21	how	how	ADV	WRB	PronType=Int	25	advmod	25:advmod	CxnElt=25:Interrogative-WHInfo-Indirect.WHWord
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj:pass	25:nsubj:pass	_
 23	can	can	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
 24	get	get	AUX	VB	VerbForm=Inf	25	aux:pass	25:aux:pass	_
-25	certified	certify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	20	ccomp	20:ccomp	_
+25	certified	certify	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	20	ccomp	20:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=25:Interrogative-WHInfo-Indirect.Clause
 26	in	in	ADP	IN	_	27	case	27:case	_
 27	delaware	delaware	PROPN	NNP	Number=Sing	25	obl	25:obl:in	SpaceAfter=No
 28	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -18561,7 +18561,7 @@
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 8	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 9	easily	easily	ADV	RB	_	10	advmod	10:advmod	_
-10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obj
+10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 11	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	10	advcl	10:advcl	_
 12	any	any	DET	DT	PronType=Ind	14	det	14:det	_
 13	search	search	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -18576,9 +18576,9 @@
 # sent_id = answers-20111107213255AAT0HQq_ans-0001
 # newpar id = answers-20111107213255AAT0HQq_ans-p0001
 # text = How to prepare a silicon rubber mould for human statue of size 375mm in height?
-1	How	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	How	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	to	to	PART	TO	_	3	mark	3:mark	_
-3	prepare	prepare	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	prepare	prepare	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 5	silicon	silicon	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	rubber	rubber	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -18606,7 +18606,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	company	company	NOUN	NN	Number=Sing	5	nmod	5:nmod:from|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
+10	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	mold	mold	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	making	making	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	materials	material	NOUN	NNS	Number=Plur	10	obj	10:obj	_
@@ -18629,13 +18629,13 @@
 # sent_id = answers-20111108084633AAzZD8i_ans-0001
 # newpar id = answers-20111108084633AAzZD8i_ans-p0001
 # text = How many days will speed post take to reach from Delhi to Mumbai?
-1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=7:Interrogative-WHInfo-Direct.WHWord
 2	many	many	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	days	day	NOUN	NNS	Number=Plur	7	obj	7:obj	_
 4	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
 5	speed	speed	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	post	post	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	_
-7	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	_
+7	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause,7:Interrogative-WHInfo-Direct.Clause
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	reach	reach	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:to	_
 10	from	from	ADP	IN	_	11	case	11:case	_
@@ -18663,11 +18663,11 @@
 1	3	3	NUM	CD	NumForm=Digit|NumType=Card	4	nummod	4:nummod	_
 2	TO	to	ADP	IN	_	3	case	3:case	_
 3	4	4	NUM	CD	NumForm=Digit|NumType=Card	1	nmod	1:nmod:to	_
-4	DAYS	day	NOUN	NNS	Number=Plur	0	root	0:root	_
+4	DAYS	day	NOUN	NNS	Number=Plur	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
-8	lucky	lucky	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	_
+8	lucky	lucky	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 9	on	on	ADP	IN	_	10	case	10:case	_
 10	average	average	ADJ	JJ	Degree=Pos	12	obl	12:obl:on	_
 11	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
@@ -18688,7 +18688,7 @@
 # sent_id = answers-20111108092417AAt9bST_ans-0001
 # newpar id = answers-20111108092417AAt9bST_ans-p0001
 # text = What is the nearest National Park to Birmingham, UK?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	nearest	near	ADJ	JJS	Degree=Sup	6	amod	6:amod	_
@@ -18753,10 +18753,10 @@
 
 # sent_id = answers-20090705172848AAU56mj_ans-0002
 # text = When was Miramar founded?
-1	When	when	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	When	when	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 3	Miramar	Miramar	PROPN	NNP	Number=Sing	4	nsubj:pass	4:nsubj:pass	_
-4	founded	found	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
+4	founded	found	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20090705172848AAU56mj_ans-0003
@@ -18773,7 +18773,7 @@
 8	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	9	amod	9:amod	_
 9	person	person	NOUN	NN	Number=Sing	3	obl	3:obl:for|11:nsubj	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	9:ref	_
-11	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
+11	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj|13:nsubj:xsubj	_
 13	right	right	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 14	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -18823,7 +18823,7 @@
 3	Bare	bare	ADJ	JJ	Degree=Pos	5	amod	5:amod	SpaceAfter=No
 4	-	-	PUNCT	HYPH	_	3	punct	3:punct	SpaceAfter=No
 5	knuckle	knuckle	NOUN	NN	Number=Sing	6	obl:unmarked	6:obl:unmarked	_
-6	box	box	VERB	VB	VerbForm=Inf	0	root	0:root	_
+6	box	box	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Ireland	Ireland	PROPN	NNP	Number=Sing	6	obl	6:obl:in	SpaceAfter=No
 9	?	?	PUNCT	.	_	6	punct	6:punct	_
@@ -18887,7 +18887,7 @@
 # sent_id = answers-20111105145356AAtOJyP_ans-0001
 # newpar id = answers-20111105145356AAtOJyP_ans-p0001
 # text = What are some GOOD 18+ clubs in the bay area?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	PronType=Ind	7	det	7:det	_
 4	GOOD	good	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -18949,7 +18949,7 @@
 8	any	anywhere	ADV	GW	PronType=Ind|Typo=Yes	7	advmod	7:advmod|11:obl	CorrectForm=anywhere
 9	were	_	X	RB	_	8	goeswith	8:goeswith	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl:relcl	8:advcl:relcl	Cxn=rc-red-obl
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl:relcl	8:advcl:relcl	_
 
 # newdoc id = answers-20100605133330AAeW6nm_ans
 # sent_id = answers-20100605133330AAeW6nm_ans-0001
@@ -19033,7 +19033,7 @@
 2	r2d2	r2d2	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	stupid	stupid	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
-5	name	name	NOUN	NN	Number=Sing	0	root	0:root	_
+5	name	name	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	for	for	ADP	IN	_	8	case	8:case	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	cat	cat	NOUN	NN	Number=Sing	5	nmod	5:nmod:for	SpaceAfter=No
@@ -19085,7 +19085,7 @@
 8	and	any	DET	DT	PronType=Ind|Typo=Yes	9	det	9:det	CorrectForm=any
 9	name	name	NOUN	NN	Number=Sing	7	obj	7:obj|11:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 
 # sent_id = answers-20111108102900AA9qsc8_ans-0005
 # newpar id = answers-20111108102900AA9qsc8_ans-p0005
@@ -19113,9 +19113,9 @@
 # sent_id = answers-20111105140228AANN2ZV_ans-0001
 # newpar id = answers-20111105140228AANN2ZV_ans-p0001
 # text = What to do in San Rafael Ca?
-1	What	what	PRON	WP	PronType=Int	3	obj	3:obj	_
+1	What	what	PRON	WP	PronType=Int	3	obj	3:obj	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	to	to	PART	TO	_	3	mark	3:mark	_
-3	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	in	in	ADP	IN	_	7	case	7:case	_
 5	San	San	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 6	Rafael	Rafael	PROPN	NNP	Number=Sing	5	flat	5:flat	_
@@ -19128,7 +19128,7 @@
 1	okay	okay	INTJ	UH	_	4	discourse	4:discourse	_
 2	so	so	ADV	RB	_	4	advmod	4:advmod	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	live	live	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	in	in	ADP	IN	_	8	case	8:case	_
 6	San	San	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 7	Rafael	Rafael	PROPN	NNP	Number=Sing	6	flat	6:flat	_
@@ -19143,7 +19143,7 @@
 16	Home	Home	PROPN	NNP	Number=Sing	17	compound	17:compound	_
 17	Depot	Depot	PROPN	NNP	Number=Sing	12	conj	4:obl:by|12:conj:and	SpaceAfter=No
 18	..	..	PUNCT	,	_	19	punct	19:punct	_
-19	what	what	PRON	WP	PronType=Int	4	parataxis	4:parataxis	_
+19	what	what	PRON	WP	PronType=Int	4	parataxis	4:parataxis	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 21	fun	fun	ADJ	JJ	Degree=Pos	22	amod	22:amod	_
 22	things	thing	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
@@ -19171,7 +19171,7 @@
 # sent_id = answers-20111105140228AANN2ZV_ans-0005
 # newpar id = answers-20111105140228AANN2ZV_ans-p0003
 # text = what about downtown...?
-1	what	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	about	about	ADP	IN	_	3	case	3:case	_
 3	downtown	downtown	NOUN	NN	Number=Sing	1	nmod	1:nmod:about	SpaceAfter=No
 4	...	...	PUNCT	,	_	1	punct	1:punct	SpaceAfter=No
@@ -19190,12 +19190,12 @@
 # sent_id = answers-20090625143116AAhML1y_ans-0001
 # newpar id = answers-20090625143116AAhML1y_ans-p0001
 # text = Which of these do you like: McDonalds, Burger King, Taco Bell, Wendys?
-1	Which	which	PRON	WDT	PronType=Int	6	obj	6:obj	ManuallyChecked=PronType
+1	Which	which	PRON	WDT	PronType=Int	6	obj	6:obj	CxnElt=6:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	of	of	ADP	IN	_	3	case	3:case	_
 3	these	this	PRON	DT	Number=Plur|PronType=Dem	1	nmod	1:nmod:of	_
 4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	like	like	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+6	like	like	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 7	:	:	PUNCT	:	_	8	punct	8:punct	_
 8-9	McDonalds	_	_	_	_	_	_	_	SpaceAfter=No
 8	McDonald	McDonald	PROPN	NNP	Number=Sing	6	parataxis	6:parataxis	_
@@ -19259,7 +19259,7 @@
 1	the	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	one	one	NOUN	NN	Number=Sing	9	nsubj	4:obj|9:nsubj	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+4	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	most	most	ADV	RBS	Degree=Sup	4	advmod	4:advmod	_
 7	would	would	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -19275,7 +19275,7 @@
 # text = would someone give me some information about migratory birds in punjab ?
 1	would	would	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	someone	someone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	give	give	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	give	give	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	iobj	3:iobj	_
 5	some	some	DET	DT	PronType=Ind	6	det	6:det	_
 6	information	information	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -19344,7 +19344,7 @@
 # sent_id = answers-20111024210339AAIqPa3_ans-0001
 # newpar id = answers-20111024210339AAIqPa3_ans-p0001
 # text = What is the dress code for males at Del Frisco's Philadelphia?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	dress	dress	NOUN	NN	Number=Sing	5	compound	5:compound	_
@@ -19506,7 +19506,7 @@
 # sent_id = answers-20111024210025AAVtDL7_ans-0001
 # newpar id = answers-20111024210025AAVtDL7_ans-p0001
 # text = What is the dress code for females at Del Frisco's Philadelphia?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	dress	dress	NOUN	NN	Number=Sing	5	compound	5:compound	_
@@ -19542,7 +19542,7 @@
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	aux	17:aux	_
 17	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	4	conj	4:conj:and	_
-18	what	what	PRON	WP	PronType=Int	17	ccomp	17:ccomp	_
+18	what	what	PRON	WP	PronType=Int	17	ccomp	17:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=18:Interrogative-WHInfo-Indirect.Clause,18:Interrogative-WHInfo-Indirect.WHWord
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	dress	dress	NOUN	NN	Number=Sing	21	compound	21:compound	_
 21	code	code	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
@@ -19597,11 +19597,11 @@
 # text = Can you post a link that shows all the art works that were never found after the Natzi stole them?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	post	post	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	post	post	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	link	link	NOUN	NN	Number=Sing	3	obj	3:obj|7:nsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
+7	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	all	all	DET	PDT	PronType=Tot	11	det:predet	11:det:predet	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	art	art	NOUN	NN	Number=Sing	11	compound	11:compound	_
@@ -19609,7 +19609,7 @@
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj:pass	11:ref	_
 13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
 14	never	never	ADV	RB	PronType=Neg	15	advmod	15:advmod	_
-15	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj:pass
+15	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	_
 16	after	after	SCONJ	IN	_	19	mark	19:mark	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	Natzi	Natzi	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj	_
@@ -19651,8 +19651,8 @@
 20	..	..	PUNCT	,	_	23	punct	23:punct	SpaceAfter=No
 21	and	and	CCONJ	CC	_	23	cc	23:cc	_
 22	there	there	PRON	EX	_	23	expl	23:expl	_
-23	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	conj	18:xcomp|19:conj:and	_
-24	thousands	thousand	NOUN	NNS	Number=Plur	23	nsubj	23:nsubj|31:nsubj:pass	_
+23	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	conj	18:xcomp|19:conj:and	Cxn=Existential-CopPred-ThereExpl
+24	thousands	thousand	NOUN	NNS	Number=Plur	23	nsubj	23:nsubj|31:nsubj:pass	CxnElt=23:Existential-CopPred-ThereExpl.Pivot
 25	in	in	ADP	IN	_	26	case	26:case	_
 26	musems	musem	NOUN	NNS	Number=Plur	24	nmod	24:nmod:in	_
 27	that	that	PRON	WDT	PronType=Rel	31	nsubj:pass	24:ref	_
@@ -19660,7 +19660,7 @@
 28	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
 29	n't	not	PART	RB	Polarity=Neg	31	advmod	31:advmod	_
 30	been	be	AUX	VBN	Tense=Past|VerbForm=Part	31	aux:pass	31:aux:pass	_
-31	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	acl:relcl	24:acl:relcl	Cxn=rc-that-nsubj:pass
+31	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	acl:relcl	24:acl:relcl	_
 32	to	to	ADP	IN	_	36	case	36:case	_
 33	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	36	nmod:poss	36:nmod:poss	_
 34	right	rightful	ADJ	GW	Degree=Pos|Typo=Yes	36	amod	36:amod	CorrectForm=rightful
@@ -19682,7 +19682,7 @@
 1	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 3	just	just	ADV	RB	_	4	advmod	4:advmod	_
-4	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	these	this	DET	DT	Number=Plur|PronType=Dem	6	det	6:det	_
 6	places	place	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 7	up	up	ADP	RP	_	4	compound:prt	4:compound:prt	SpaceAfter=No
@@ -19729,11 +19729,11 @@
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	but	but	CCONJ	CC	_	8	cc	8:cc	_
 7	there	there	PRON	EX	_	8	expl	8:expl	_
-8	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+8	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	Cxn=Existential-CopPred-ThereExpl
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	CorrectSpaceAfter=Yes|SpaceAfter=No
-10	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|12:nsubj	_
+10	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|12:nsubj	CxnElt=8:Existential-CopPred-ThereExpl.Pivot
 11	that	that	PRON	WDT	PronType=Rel	12	nsubj	10:ref	_
-12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
+12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 13	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	12	obj	12:obj|14:nsubj:xsubj	_
 14	wonder	wonder	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -19742,11 +19742,11 @@
 # newpar id = answers-20070723111604AAzUvhb_ans-p0004
 # text = There are way more stranger names in the U.S for areas than Miramar.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	way	way	ADV	RB	_	4	advmod	4:advmod	_
 4	more	more	ADV	RBR	Degree=Cmp	5	advmod	5:advmod	_
 5	stranger	strange	ADJ	JJR	Degree=Cmp	6	amod	6:amod	_
-6	names	name	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
+6	names	name	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	U.S	U.S	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	_
@@ -19794,7 +19794,7 @@
 # sent_id = answers-20081229195853AAYQ8mR_ans-0002
 # newpar id = answers-20081229195853AAYQ8mR_ans-p0002
 # text = How about empanadas arabes or other empanadas from that area of Argentina?
-1	How	how	ADV	WRB	PronType=Int	0	root	0:root	_
+1	How	how	ADV	WRB	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	about	about	ADP	IN	_	3	case	3:case	_
 3	empanadas	empanada	NOUN	NNS	Foreign=Yes|Number=Plur	1	obl	1:obl:about	_
 4	arabes	arabes	NOUN	NN	Foreign=Yes|Number=Sing	3	flat	3:flat	_
@@ -19975,7 +19975,7 @@
 1-2	its	_	_	_	_	_	_	_	_
 1	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	3:expl	_
 2	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	3	cop	3:cop	CorrectForm='s
-3	illegal	illegal	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	illegal	illegal	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	sell	sell	VERB	VB	VerbForm=Inf	3	csubj	3:csubj	_
 6	stolen	steal	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	amod	7:amod	_
@@ -19987,7 +19987,7 @@
 12-13	don't	_	_	_	_	_	_	_	_
 12	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	Polarity=Neg	14	advmod	14:advmod	_
-14	know	know	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:if	_
+14	know	know	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 15-16	its	_	_	_	_	_	_	_	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	17:nsubj:pass	_
 16	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	17	aux:pass	17:aux:pass	CorrectForm='s
@@ -20000,10 +20000,10 @@
 # text = Erm ya How can I watch Fair City Online in England lols?
 1	Erm	erm	INTJ	UH	_	6	discourse	6:discourse	_
 2	ya	ya	INTJ	UH	_	6	discourse	6:discourse	_
-3	How	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+3	How	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 4	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
-6	watch	watch	VERB	VB	VerbForm=Inf	0	root	0:root	_
+6	watch	watch	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause
 7	Fair	Fair	ADJ	NNP	Degree=Pos	8	amod	8:amod	_
 8	City	City	PROPN	NNP	Number=Sing	6	obj	6:obj	_
 9	Online	online	ADV	RB	_	6	advmod	6:advmod	_
@@ -20063,7 +20063,7 @@
 23	(	(	PUNCT	-LRB-	_	26	punct	26:punct	SpaceAfter=No
 24	who	who	PRON	WP	PronType=Rel	26	nsubj	22:ref	_
 25	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
-26	become	become	VERB	VBN	Tense=Past|VerbForm=Part	22	acl:relcl	22:acl:relcl	Cxn=rc-wh-nsubj
+26	become	become	VERB	VBN	Tense=Past|VerbForm=Part	22	acl:relcl	22:acl:relcl	_
 27	her	her	PRON	PRP$	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	30	nmod:poss	30:nmod:poss	_
 28	new	new	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
 29	best	good	ADJ	JJS	Degree=Sup	30	amod	30:amod	_
@@ -20174,9 +20174,9 @@
 5	adviser	adviser	NOUN	NN	Number=Sing	1	obl	1:obl:to	SpaceAfter=No
 6	,	,	PUNCT	,	_	7	punct	7:punct	_
 7	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
-8	what	what	PRON	WP	PronType=Int	10	obj	10:obj	_
+8	what	what	PRON	WP	PronType=Int	10	obj	10:obj	CxnElt=10:Interrogative-WHInfo-Indirect.WHWord
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	recommend	recommend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	SpaceAfter=No
+10	recommend	recommend	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	7:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=10:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 11	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = answers-20111108083850AAzIsFI_ans-0006
@@ -20211,7 +20211,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 5	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	7	amod	7:amod	_
 6	Smart	smart	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
-7	Phone	phone	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+7	Phone	phone	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=7:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 8	?	?	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = answers-20111108083304AAryBu9_ans-0002
@@ -20237,7 +20237,7 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 18	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	20	amod	20:amod	_
 19	Smart	smart	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
-20	Phone	phone	NOUN	NN	Number=Sing	12	ccomp	12:ccomp	SpaceAfter=No
+20	Phone	phone	NOUN	NN	Number=Sing	12	ccomp	12:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=20:Interrogative-Polar-Indirect.Clause|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108083304AAryBu9_ans-0003
@@ -20303,7 +20303,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	way	way	NOUN	NN	Number=Sing	4	obj	4:obj|8:obl	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl
+8	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	of	of	ADP	IN	_	12	case	12:case	_
 10	as	as	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -20324,11 +20324,11 @@
 # sent_id = answers-20111108072305AAPJTjj_ans-0002
 # newpar id = answers-20111108072305AAPJTjj_ans-p0002
 # text = Which one should i get ?
-1	Which	which	DET	WDT	PronType=Int	2	det	2:det	ManuallyChecked=PronType
+1	Which	which	DET	WDT	PronType=Int	2	det	2:det	CxnElt=5:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	one	one	NOUN	NN	Number=Sing	5	obj	5:obj	_
 3	should	should	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	?	?	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = answers-20111108072305AAPJTjj_ans-0003
@@ -20368,7 +20368,7 @@
 8	capability	capability	NOUN	NN	Number=Sing	4	list	4:list	_
 9	(	(	PUNCT	-LRB-	_	10	punct	10:punct	SpaceAfter=No
 10	SX40	SX40	PROPN	NNP	Number=Sing	8	parataxis	8:parataxis|10.1:nsubj	_
-10.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	8:parataxis	CopyOf=-1
+10.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	8:parataxis	CopyOf=-1|wordform=__EMPTY__
 11	only	only	ADV	RB	_	12	advmod	12:advmod	_
 12	3200	3200	NUM	CD	NumForm=Digit|NumType=Card	10	orphan	10.1:obj	SpaceAfter=No
 13	)	)	PUNCT	-RRB-	_	10	punct	10:punct	SpaceAfter=No
@@ -20380,7 +20380,7 @@
 19	and	and	CCONJ	CC	_	21	cc	21:cc|21.1:cc	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	SX40	SX40	PROPN	NNP	Number=Sing	16	conj	16:conj:and|21.1:nsubj	_
-21.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	16:conj:and	CopyOf=-1
+21.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	16:conj:and	CopyOf=-1|wordform=__EMPTY__
 22	only	only	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	f	f	NOUN	NN	Number=Sing	21	orphan	21.1:obj	SpaceAfter=No
 24	/	/	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
@@ -20469,7 +20469,7 @@
 # text = Will we need a passport?
 1	Will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	passport	passport	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -20480,7 +20480,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
-4	unsure	unsure	ADJ	JJ	Degree=Pos	16	advcl	16:advcl:if	_
+4	unsure	unsure	ADJ	JJ	Degree=Pos	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	whether	whether	SCONJ	IN	ExtPos=SCONJ	9	mark	9:mark	_
 6	or	or	CCONJ	CC	_	5	fixed	5:fixed	_
 7	not	not	PART	RB	Polarity=Neg	5	fixed	5:fixed	_
@@ -20492,7 +20492,7 @@
 13	Faz	Faz	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj|18:nsubj:xsubj	_
 14	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 15	be	be	AUX	VB	VerbForm=Inf	16	cop	16:cop	_
-16	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	_
+16	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	help	help	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	SpaceAfter=No
 19	!	!	PUNCT	.	_	16	punct	16:punct	_
@@ -20502,7 +20502,7 @@
 # text = uh, where?
 1	uh	uh	INTJ	UH	_	3	discourse	3:discourse	SpaceAfter=No
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
-3	where	where	ADV	WRB	PronType=Int	0	root	0:root	SpaceAfter=No
+3	where	where	ADV	WRB	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111107173224AA22AwU_ans-0007
@@ -20531,14 +20531,14 @@
 3	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|Typo=Yes|VerbForm=Fin	6	cop	6:cop	CorrectForm='re
 4	in	in	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
-6	USA	USA	PROPN	NNP	Number=Sing	13	advcl	13:advcl:in	_
+6	USA	USA	PROPN	NNP	Number=Sing	13	advcl	13:advcl:in	CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	and	and	CCONJ	CC	_	8	cc	8:cc	_
 8	venture	venture	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and|13:advcl:in	_
 9	into	into	ADP	IN	_	10	case	10:case	_
 10	Cuba	Cuba	PROPN	NNP	Number=Sing	8	obl	8:obl:into	_
 11	then	then	ADV	RB	PronType=Dem	13	advmod	13:advmod	_
 12	u	you	PRON	PRP	Abbr=Yes|Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	CorrectForm=you
-13	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+13	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	passport	passport	NOUN	NN	Number=Sing	13	obj	13:obj	_
 
@@ -20546,10 +20546,10 @@
 # sent_id = answers-20111106210027AAhMxfE_ans-0001
 # newpar id = answers-20111106210027AAhMxfE_ans-p0001
 # text = How can i get Weed in Auckland?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	Weed	weed	NOUN	NN	Number=Sing	4	obj	4:obj	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	Auckland	Auckland	PROPN	NNP	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
@@ -20614,7 +20614,7 @@
 # text = Anyone who looks like a druggy or dodgy.
 1	Anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	0	root	0:root|3:nsubj	_
 2	who	who	PRON	WP	PronType=Rel	3	nsubj	1:ref	_
-3	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-wh-nsubj
+3	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
 4	like	like	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	druggy	druggy	NOUN	NN	Number=Sing	3	obl	3:obl:like	_
@@ -20625,10 +20625,10 @@
 # sent_id = answers-20111106210027AAhMxfE_ans-0008
 # newpar id = answers-20111106210027AAhMxfE_ans-p0004
 # text = Why would someone post the location of a dealer in a public place?
-1	Why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj	_
-4	post	post	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	post	post	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	location	location	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	of	of	ADP	IN	_	9	case	9:case	_
@@ -20670,12 +20670,12 @@
 # sent_id = answers-20111107154308AAKOZNX_ans-0001
 # newpar id = answers-20111107154308AAKOZNX_ans-p0001
 # text = What is this irish tune called!?
-1	What	what	PRON	WP	PronType=Int	6	obj	6:obj	_
+1	What	what	PRON	WP	PronType=Int	6	obj	6:obj	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 4	irish	Irish	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	tune	tune	NOUN	NN	Number=Sing	6	nsubj:pass	6:nsubj:pass	_
-6	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
+6	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 7	!?	!?	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111107154308AAKOZNX_ans-0002
@@ -20711,7 +20711,7 @@
 11	only	only	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	line	line	NOUN	NN	Number=Sing	16	nsubj	14:obj|16:nsubj|21:nsubj	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
+14	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	de	de	X	FW	Foreign=Yes	4	parataxis	4:parataxis	_
 17	lunde	lunde	X	FW	Foreign=Yes	16	flat	16:flat	_
@@ -20725,11 +20725,11 @@
 25	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	aux	27:aux	_
 26	anybody	anybody	PRON	NN	Number=Sing|PronType=Ind	27	nsubj	27:nsubj	_
 27	know	know	VERB	VB	VerbForm=Inf	4	parataxis	4:parataxis	_
-28	which	which	DET	WDT	PronType=Int	29	det	29:det	ManuallyChecked=PronType
+28	which	which	DET	WDT	PronType=Int	29	det	29:det	CxnElt=32:Interrogative-WHInfo-Indirect.WHWord|ManuallyChecked=PronType
 29	song	song	NOUN	NN	Number=Sing	32	obl	32:obl:about	_
 30	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	32	nsubj	32:nsubj	_
 31	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	aux	32:aux	_
-32	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	27	ccomp	27:ccomp	_
+32	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	27	ccomp	27:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=32:Interrogative-WHInfo-Indirect.Clause
 33	about	about	ADP	IN	_	29	case	29:case	SpaceAfter=No
 34	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -20777,12 +20777,12 @@
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 3	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	5	cop	5:cop	CorrectForm='s
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-5	reel	reel	NOUN	NN	Number=Sing	9	advcl	9:advcl:if	_
+5	reel	reel	NOUN	NN	Number=Sing	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	then	then	ADV	RB	PronType=Dem	9	advmod	9:advmod	_
 7-8	its	_	_	_	_	_	_	_	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	9	cop	9:cop	CorrectForm='s
-9	scottish	Scottish	ADJ	JJ	Degree=Pos	0	root	0:root	_
+9	scottish	Scottish	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 
 # newdoc id = answers-20111107080027AA9zCIG_ans
 # sent_id = answers-20111107080027AA9zCIG_ans-0001
@@ -20818,7 +20818,7 @@
 14	if	if	SCONJ	IN	_	17	mark	17:mark	_
 15	somone	somone	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
 16	could	could	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	tell	tell	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	_
+17	tell	tell	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=17:Interrogative-Polar-Indirect.Clause
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	iobj	17:iobj	_
 19	about	about	ADP	IN	_	22	case	22:case	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
@@ -20896,12 +20896,12 @@
 # sent_id = answers-20111106032810AA43zpY_ans-0001
 # newpar id = answers-20111106032810AA43zpY_ans-p0001
 # text = What would happen if you flew the flag of South Vietnam in Modern day Vietnam?
-1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	_
+1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	would	would	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	happen	happen	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	happen	happen	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-WHInfo-Direct|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,3:Interrogative-WHInfo-Direct.Clause
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	flew	fly	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	_
+6	flew	fly	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	flag	flag	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -21020,10 +21020,10 @@
 
 # sent_id = answers-20111106213308AA5Nh2g_ans-0002
 # text = Where do we vote?
-1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111106213308AA5Nh2g_ans-0003
@@ -21038,10 +21038,10 @@
 # sent_id = answers-20111106213308AA5Nh2g_ans-0004
 # newpar id = answers-20111106213308AA5Nh2g_ans-p0002
 # text = Where do we vote?
-1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111106213308AA5Nh2g_ans-0005
@@ -21061,13 +21061,13 @@
 3	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	6	nsubj	6:nsubj	_
 4	else	else	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 5	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	voted	vote	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl	12:advcl:if	SpaceAfter=No
+6	voted	vote	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 7	,	,	PUNCT	,	_	6	punct	6:punct	_
-8	what	what	PRON	WP	PronType=Int	12	obj	12:obj	_
+8	what	what	PRON	WP	PronType=Int	12	obj	12:obj	CxnElt=12:Interrogative-WHInfo-Direct.WHWord
 9	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux	12:aux	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	det	11:det	_
 11	guys	guy	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-12	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	_
+12	vote	vote	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-WHInfo-Direct|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,12:Interrogative-WHInfo-Direct.Clause
 13	for	for	ADP	IN	_	12	obl	12:obl	Promoted=Yes|SpaceAfter=No
 14	?	?	PUNCT	.	_	12	punct	12:punct	_
 
@@ -21101,9 +21101,9 @@
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 5	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 6	'	'	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
-7	head	head	NOUN	NN	Number=Sing	5	obl:unmarked	5:obl:unmarked	_
-8	to	to	ADP	IN	_	9	case	9:case	_
-9	head	head	NOUN	NN	Number=Sing	7	nmod	7:nmod:to	SpaceAfter=No
+7	head	head	NOUN	NN	Number=Sing	5	obl:unmarked	5:obl:unmarked	Cxn=NPN|CxnElt=7:NPN.N1
+8	to	to	ADP	IN	_	9	case	9:case	CxnElt=7:NPN.P
+9	head	head	NOUN	NN	Number=Sing	7	nmod	7:nmod:to	CxnElt=7:NPN.N2|SpaceAfter=No
 10	'	'	PUNCT	''	_	7	punct	7:punct	_
 11	in	in	ADP	IN	_	14	case	14:case	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
@@ -21111,7 +21111,7 @@
 14	vote	vote	NOUN	NN	Number=Sing	5	obl	5:obl:in|17:nsubj	_
 15	on	on	ADP	IN	_	16	reparandum	16:reparandum	_
 16	that	that	PRON	WDT	PronType=Rel	17	nsubj	14:ref	_
-17	opens	open	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
+17	opens	open	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 18	on	on	ADP	IN	_	19	case	19:case	_
 19	Wednesday	Wednesday	PROPN	NNP	Number=Sing	17	obl	17:obl:on	_
 20	on	on	ADP	IN	_	22	case	22:case	_
@@ -21180,7 +21180,7 @@
 23	if	if	SCONJ	IN	_	26	mark	26:mark	_
 24	air	Air	PROPN	NNP	Number=Sing	25	compound	25:compound	_
 25	asia	Asia	PROPN	NNP	Number=Sing	26	nsubj	26:nsubj	_
-26	recruits	recruit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	ccomp	22:ccomp	_
+26	recruits	recruit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	ccomp	22:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=26:Interrogative-Polar-Indirect.Clause
 27	foreigners	foreigner	NOUN	NNS	Number=Plur	26	obj	26:obj	SpaceAfter=No
 28	?	?	PUNCT	.	_	7	punct	7:punct	SpaceAfter=No
 
@@ -21231,8 +21231,8 @@
 37	but	but	CCONJ	CC	_	39	cc	39:cc	_
 38-39	there's	_	_	_	_	_	_	_	_
 38	there	there	PRON	EX	_	39	expl	39:expl	_
-39	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	conj	28:conj:but	_
-40	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	39	nsubj	39:nsubj	_
+39	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	conj	28:conj:but	Cxn=Existential-CopPred-ThereExpl
+40	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	39	nsubj	39:nsubj	CxnElt=39:Existential-CopPred-ThereExpl.Pivot
 41	useful	useful	ADJ	JJ	Degree=Pos	40	amod	40:amod	_
 42	on	on	ADP	IN	_	43	case	43:case	_
 43	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	39	obl	39:obl:on	_
@@ -21260,7 +21260,7 @@
 # sent_id = answers-20101109081414AAZ3hSI_ans-0001
 # newpar id = answers-20101109081414AAZ3hSI_ans-p0001
 # text = What kind of Meal do peopel in Argentina have?
-1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
+1	What	what	DET	WDT	PronType=Int	2	det	2:det	CxnElt=9:Interrogative-WHInfo-Direct.WHWord
 2	kind	kind	NOUN	NN	Number=Sing	9	obj	9:obj	_
 3	of	of	ADP	IN	_	4	case	4:case	_
 4	Meal	meal	NOUN	NN	Number=Sing	2	nmod	2:nmod:of	_
@@ -21268,7 +21268,7 @@
 6	peopel	peopel	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	Argentina	Argentina	PROPN	NNP	Number=Sing	6	nmod	6:nmod:in	_
-9	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+9	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=9:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 10	?	?	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = answers-20101109081414AAZ3hSI_ans-0002
@@ -21283,13 +21283,13 @@
 7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	know	know	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
-10	what	what	DET	WDT	PronType=Int	11	det	11:det	_
+10	what	what	DET	WDT	PronType=Int	11	det	11:det	CxnElt=15:Interrogative-WHInfo-Indirect.WHWord
 11	kind	kind	NOUN	NN	Number=Sing	15	obj	15:obj	_
-11.1	_	of	ADP	IN	Typo=Yes	_	_	12:case	CorrectForm=of
+11.1	_	of	ADP	IN	Typo=Yes	_	_	12:case	CorrectForm=of|wordform=__EMPTY__
 12	food	food	NOUN	NN	Number=Sing	11	nmod	11:nmod:of	_
 13	Argentina	Argentina	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	people	people	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
-15	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
+15	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=15:Interrogative-WHInfo-Indirect.Clause
 16	for	for	ADP	IN	_	17	case	17:case	_
 17	breakfast	breakfast	NOUN	NN	Number=Sing	15	obl	15:obl:for	SpaceAfter=No
 18	,	,	PUNCT	,	_	19	punct	19:punct	_
@@ -21360,9 +21360,9 @@
 
 # sent_id = answers-20101109081414AAZ3hSI_ans-0007
 # text = Why not look it up!
-1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	not	not	PART	RB	Polarity=Neg	3	advmod	3:advmod	_
-3	look	look	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	look	look	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	_
 5	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	SpaceAfter=No
 6	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -21389,10 +21389,10 @@
 # sent_id = answers-20111108103447AAI7MDa_ans-0001
 # newpar id = answers-20111108103447AAI7MDa_ans-p0001
 # text = why do i want to do work experience at an animal center?
-1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
-4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	want	want	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	do	do	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	work	work	NOUN	NN	Number=Sing	8	compound	8:compound	_
@@ -21412,10 +21412,10 @@
 # sent_id = answers-20111108103447AAI7MDa_ans-0003
 # newpar id = answers-20111108103447AAI7MDa_ans-p0003
 # text = How are strangers supposed to know why YOU want to do that sort of job?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
 3	strangers	stranger	NOUN	NNS	Number=Plur	4	nsubj:pass	4:nsubj:pass|6:nsubj:xsubj	_
-4	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+4	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	know	know	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	why	why	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
@@ -21439,7 +21439,7 @@
 6	reasons	reason	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of|9:obl	_
 7	why	why	ADV	WRB	PronType=Rel	9	advmod	6:ref	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
+9	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	job	job	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -21452,9 +21452,9 @@
 19	searching	searching	NOUN	NN	Number=Sing	16	nmod	16:nmod:of	_
 20	to	to	PART	TO	_	21	mark	21:mark	_
 21	see	see	VERB	VB	VerbForm=Inf	13	advcl	13:advcl:to	_
-22	what	what	PRON	WP	PronType=Int	24	obj	24:obj	_
+22	what	what	PRON	WP	PronType=Int	24	obj	24:obj	CxnElt=24:Interrogative-WHInfo-Indirect.WHWord
 23	people	people	NOUN	NNS	Number=Plur	24	nsubj	24:nsubj	_
-24	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	ccomp	21:ccomp	_
+24	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	ccomp	21:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=24:Interrogative-WHInfo-Indirect.Clause
 25	to	to	PART	TO	_	26	mark	26:mark	_
 26	say	say	VERB	VB	VerbForm=Inf	24	advcl	24:advcl:to	_
 27	about	about	SCONJ	IN	_	31	mark	31:mark	_
@@ -21506,13 +21506,13 @@
 14	ca	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 15	n't	not	PART	RB	Polarity=Neg	17	advmod	17:advmod	_
 16	be	be	AUX	VB	VerbForm=Inf	17	cop	17:cop	_
-17	ha[[y	happy	ADJ	JJ	Degree=Pos|Typo=Yes	6	conj	0:root|6:conj:and	CorrectForm=happy
+17	ha[[y	happy	ADJ	JJ	Degree=Pos|Typo=Yes	6	conj	0:root|6:conj:and	CorrectForm=happy|Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 18	if	if	SCONJ	IN	_	22	mark	22:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj	_
 20-21	weren't	_	_	_	_	_	_	_	_
 20	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	22	aux	22:aux	_
 21	n't	not	PART	RB	Polarity=Neg	22	advmod	22:advmod	_
-22	soing	do	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	17	advcl	17:advcl:if	CorrectForm=doing
+22	soing	do	VERB	VBG	Tense=Pres|Typo=Yes|VerbForm=Part	17	advcl	17:advcl:if	CorrectForm=doing|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 23	that	that	DET	DT	Number=Sing|PronType=Dem	24	det	24:det	_
 24	job	job	NOUN	NN	Number=Sing	22	obj	22:obj	_
 
@@ -21578,9 +21578,9 @@
 8	n't	not	PART	RB	Polarity=Neg	10	advmod	10:advmod	_
 9	really	really	ADV	RB	_	10	advmod	10:advmod	_
 10	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-11	where	where	ADV	WRB	PronType=Int	13	advmod	13:advmod	_
+11	where	where	ADV	WRB	PronType=Int	13	advmod	13:advmod	CxnElt=13:Interrogative-WHInfo-Indirect.WHWord
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
-13	cheap	cheap	ADJ	JJ	Degree=Pos	10	ccomp	10:ccomp	SpaceAfter=No
+13	cheap	cheap	ADJ	JJ	Degree=Pos	10	ccomp	10:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=13:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 14	,	,	PUNCT	,	_	15	punct	15:punct	_
 15	safe	safe	ADJ	JJ	Degree=Pos	13	conj	10:ccomp|13:conj:and	SpaceAfter=No
 16	,	,	PUNCT	,	_	18	punct	18:punct	_
@@ -21601,7 +21601,7 @@
 # text = Does anyone have any ideas for restaurants within walking distance where I can't get lost?
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 5	ideas	idea	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	for	for	ADP	IN	_	7	case	7:case	_
@@ -21614,7 +21614,7 @@
 13-14	can't	_	_	_	_	_	_	_	_
 13	ca	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	n't	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
-15	get	get	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-obl
+15	get	get	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	_
 16	lost	lost	ADJ	JJ	Degree=Pos	15	xcomp	15:xcomp	SpaceAfter=No
 17	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -21633,14 +21633,14 @@
 1	Maybe	maybe	ADV	RB	_	11	advmod	11:advmod	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	post	post	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
+4	post	post	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	question	question	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	again	again	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 8	,	,	PUNCT	,	_	4	punct	4:punct	_
 9	someone	someone	PRON	NN	Number=Sing|PronType=Ind	11	nsubj	11:nsubj	_
 10	will	will	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	give	give	VERB	VB	VerbForm=Inf	0	root	0:root	_
+11	give	give	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 12	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	11	iobj	11:iobj	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	good	good	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
@@ -21654,7 +21654,7 @@
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	Crack	Crack	PROPN	NNP	Number=Sing	3	compound	3:compound	_
 3	Barrel	Barrel	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	ban	ban	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	ban	ban	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	employees	employee	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	from	from	SCONJ	IN	_	7	mark	7:mark	_
 7	having	have	VERB	VBG	Tense=Pres|VerbForm=Part	4	advcl	4:advcl:from	_
@@ -21700,25 +21700,25 @@
 # text = If you know or work there could you enlighten me?
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj	_
-3	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	or	or	CCONJ	CC	_	5	cc	5:cc	_
 5	work	work	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	conj	3:conj:or|9:advcl:if	_
 6	there	there	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
 7	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	enlighten	enlighten	VERB	VB	VerbForm=Inf	0	root	0:root	_
+9	enlighten	enlighten	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,9:Interrogative-Polar-Direct.Clause
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	SpaceAfter=No
 11	?	?	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = answers-20111104115557AAEDR78_ans-0004
 # newpar id = answers-20111104115557AAEDR78_ans-p0003
 # text = Why don't you phone another location and ask♥
-1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2-3	don't	_	_	_	_	_	_	_	_
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	n't	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj|9:nsubj	_
-5	phone	phone	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	phone	phone	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	another	another	DET	DT	PronType=Ind	7	det	7:det	_
 7	location	location	NOUN	NN	Number=Sing	5	obj	5:obj	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
@@ -21734,14 +21734,14 @@
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	ban	ban	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+6	ban	ban	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	if	if	SCONJ	IN	_	12	mark	12:mark	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	tats	tat	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
 10-11	aren't	_	_	_	_	_	_	_	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 11	n't	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
-12	offensive	offensive	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	_
+12	offensive	offensive	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	and	and	CCONJ	CC	_	16	cc	16:cc	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
 15	should	should	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
@@ -21766,11 +21766,11 @@
 34	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	37	nsubj	37:nsubj	_
 35	can	can	AUX	MD	VerbForm=Fin	37	aux	37:aux	_
 36	really	really	ADV	RB	_	37	advmod	37:advmod	_
-37	say	say	VERB	VB	VerbForm=Inf	33	acl:relcl	33:acl:relcl	Cxn=rc-red-obj
+37	say	say	VERB	VB	VerbForm=Inf	33	acl:relcl	33:acl:relcl	_
 38	if	if	SCONJ	IN	_	39	mark	39:mark	_
-39	so	so	ADV	RB	_	41	advcl	41:advcl:if	_
+39	so	so	ADV	RB	_	41	advcl	41:advcl:if	CxnElt=41:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 40	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	41	nsubj	41:nsubj	_
-41	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	33	parataxis	33:parataxis	_
+41	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	33	parataxis	33:parataxis	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=41:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 42	a	a	DET	DT	Definite=Ind|PronType=Art	43	det	43:det	_
 43	sue	sue	NOUN	NN	Number=Sing	41	obj	41:obj	SpaceAfter=No
 44	/	/	SYM	,	_	45	cc	45:cc	SpaceAfter=No
@@ -21924,9 +21924,9 @@
 8	,	,	PUNCT	,	_	11	punct	11:punct	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	there	there	PRON	EX	_	11	expl	11:expl	_
-11	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+11	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	Cxn=Existential-CopPred-ThereExpl
 12	2	2	NUM	CD	NumForm=Digit|NumType=Card	13	nummod	13:nummod	_
-13	eggs	egg	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	_
+13	eggs	egg	NOUN	NNS	Number=Plur	11	nsubj	11:nsubj	CxnElt=11:Existential-CopPred-ThereExpl.Pivot
 14	in	in	ADP	IN	_	16	case	16:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	bottom	bottom	NOUN	NN	Number=Sing	11	obl	11:obl:in	_
@@ -21944,14 +21944,14 @@
 # text = Most likely not, if there is not a bird sitting on the eggs.
 1	Most	most	ADV	RBS	Degree=Sup	2	advmod	2:advmod	_
 2	likely	likely	ADV	RB	_	3	advmod	3:advmod	_
-3	not	not	PART	RB	Polarity=Neg	0	root	0:root	Promoted=Yes|SpaceAfter=No
+3	not	not	PART	RB	Polarity=Neg	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|Promoted=Yes|SpaceAfter=No
 4	,	,	PUNCT	,	_	7	punct	7:punct	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	there	there	PRON	EX	_	7	expl	7:expl	_
-7	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+7	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	Cxn=Existential-CopPred-ThereExpl|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 8	not	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
-10	bird	bird	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	_
+10	bird	bird	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	CxnElt=7:Existential-CopPred-ThereExpl.Pivot
 11	sitting	sit	VERB	VBG	VerbForm=Ger	10	acl	10:acl	_
 12	on	on	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -22025,7 +22025,7 @@
 # text = If you see a dark spot in the egg, that means it is fertilized and will hatch if cared for properly.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	dark	dark	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	spot	spot	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -22034,15 +22034,15 @@
 9	egg	egg	NOUN	NN	Number=Sing	3	obl	3:obl:in	SpaceAfter=No
 10	,	,	PUNCT	,	_	3	punct	3:punct	_
 11	that	that	PRON	DT	Number=Sing|PronType=Dem	12	nsubj	12:nsubj	_
-12	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+12	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj|18:nsubj	_
 14	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 15	fertilized	fertilized	ADJ	JJ	Degree=Pos	12	ccomp	12:ccomp	_
 16	and	and	CCONJ	CC	_	18	cc	18:cc	_
 17	will	will	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	hatch	hatch	VERB	VB	VerbForm=Inf	15	conj	12:ccomp|15:conj:and	_
+18	hatch	hatch	VERB	VB	VerbForm=Inf	15	conj	12:ccomp|15:conj:and	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=18:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 19	if	if	SCONJ	IN	_	20	mark	20:mark	_
-20	cared	care	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	18	advcl	18:advcl:if	_
+20	cared	care	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	18	advcl	18:advcl:if	CxnElt=18:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 21	for	for	ADP	IN	_	20	obl	20:obl	Promoted=Yes
 22	properly	properly	ADV	RB	_	20	advmod	20:advmod	SpaceAfter=No
 23	.	.	PUNCT	.	_	12	punct	12:punct	_
@@ -22057,11 +22057,11 @@
 # sent_id = answers-20090717131757AAVh6rG_ans-0001
 # newpar id = answers-20090717131757AAVh6rG_ans-p0001
 # text = Why is the city called Miramar?
-1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux:pass	5:aux:pass	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	city	city	NOUN	NN	Number=Sing	5	nsubj:pass	5:nsubj:pass|6:nsubj:xsubj	_
-5	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+5	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	Miramar	Miramar	PROPN	NNP	Number=Sing	5	xcomp	5:xcomp	SpaceAfter=No
 7	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -22081,9 +22081,9 @@
 10	name	name	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	_
 11	but	but	CCONJ	CC	_	13	cc	13:cc	_
 12	they	there	PRON	EX	Typo=Yes	13	expl	13:expl	CorrectForm=there
-13	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	_
+13	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	conj	4:conj:but	Cxn=Existential-CopPred-ThereExpl
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
-15	lot	lot	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
+15	lot	lot	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	CxnElt=13:Existential-CopPred-ThereExpl.Pivot
 16	of	of	ADP	IN	_	18	case	18:case	_
 17	different	different	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	cities	city	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
@@ -22108,8 +22108,8 @@
 # text = There's lots of towns called Miramar, it'd help alot if you listed a state or some sort of context you're looking for it in.
 1-2	There's	_	_	_	_	_	_	_	_
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	lots	lot	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
+2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+3	lots	lot	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 4	of	of	ADP	IN	_	5	case	5:case	_
 5	towns	town	NOUN	NNS	Number=Plur	3	nmod	3:nmod:of	_
 6	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl	5:acl	_
@@ -22118,12 +22118,12 @@
 9-10	it'd	_	_	_	_	_	_	_	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	'd	would	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	help	help	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
+11	help	help	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 13	lot	lot	NOUN	NN	Number=Sing	11	obl:unmarked	11:obl:unmarked	_
 14	if	if	SCONJ	IN	_	16	mark	16:mark	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	listed	list	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:if	_
+16	listed	list	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	state	state	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	or	or	CCONJ	CC	_	21	cc	21:cc	_
@@ -22134,7 +22134,7 @@
 24-25	you're	_	_	_	_	_	_	_	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
 25	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
-26	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obl-pstrand
+26	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	23	acl:relcl	23:acl:relcl	_
 27	for	for	ADP	IN	_	28	case	28:case	_
 28	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	obl	26:obl:for	_
 29	in	in	ADP	IN	_	26	obl	26:obl	Promoted=Yes|SpaceAfter=No
@@ -22153,9 +22153,9 @@
 # text = There's a Miramar in Florida, just north of Miami.
 1-2	There's	_	_	_	_	_	_	_	_
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
-4	Miramar	Miramar	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
+4	Miramar	Miramar	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	Florida	Florida	PROPN	NNP	Number=Sing	2	obl	2:obl:in	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
@@ -22169,10 +22169,10 @@
 # text = There's also a Miramar in California, the site of a rather large Air Force Base...
 1-2	There's	_	_	_	_	_	_	_	_
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	also	also	ADV	RB	_	2	advmod	2:advmod	_
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
-5	Miramar	Miramar	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	_
+5	Miramar	Miramar	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	California	California	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	SpaceAfter=No
 8	,	,	PUNCT	,	_	10	punct	10:punct	_
@@ -22245,7 +22245,7 @@
 31	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 32	guys	guy	NOUN	NNS	Number=Plur	29	nmod	29:nmod:of|34:obj	_
 33	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	34	nsubj	34:nsubj	_
-34	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	Cxn=rc-red-obj
+34	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
 35	and	and	CCONJ	CC	_	38	cc	38:cc	_
 36	one	one	NUM	CD	NumForm=Word|NumType=Card	37	nummod	37:nummod	_
 37	guy	guy	NOUN	NN	Number=Sing	38	nsubj	38:nsubj	_
@@ -22298,9 +22298,9 @@
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	tell	tell	VERB	VB	VerbForm=Inf	5	conj	5:conj:and	_
 10	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	9	iobj	9:iobj	_
-11	how	how	ADV	WRB	PronType=Int	13	advmod	13:advmod	_
+11	how	how	ADV	WRB	PronType=Int	13	advmod	13:advmod	CxnElt=13:Interrogative-WHInfo-Indirect.WHWord
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
-13	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	_
+13	feel	feel	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	ccomp	9:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=13:Interrogative-WHInfo-Indirect.Clause
 
 # sent_id = answers-20090205181308AAZghOH_ans-0005
 # text = it may sound like a bad idea
@@ -22337,10 +22337,10 @@
 # sent_id = answers-20090205181308AAZghOH_ans-0008
 # text = whose better looking ?
 1-2	whose	_	_	_	_	_	_	_	_
-1	who	who	PRON	WP	PronType=Int	4	nsubj	4:nsubj	_
+1	who	who	PRON	WP	PronType=Int	4	nsubj	4:nsubj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	se	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	4	cop	4:cop	CorrectForm='s
 3	better	well	ADV	RBR	Degree=Cmp	4	advmod	4:advmod	_
-4	looking	looking	ADJ	JJ	Degree=Pos	0	root	0:root	_
+4	looking	looking	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20090205181308AAZghOH_ans-0009
@@ -22366,7 +22366,7 @@
 3	montparnasse	Montparnasse	PROPN	NNP	Number=Sing	2	flat	2:flat	_
 4	storage	storage	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
 5	still	still	ADV	RB	_	6	advmod	6:advmod	_
-6	available	available	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+6	available	available	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 7	?	?	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111108024148AAO8oFI_ans-0002
@@ -22375,7 +22375,7 @@
 1	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 3	still	still	ADV	RB	_	4	advmod	4:advmod	_
-4	available	available	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+4	available	available	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108024148AAO8oFI_ans-0003
@@ -22386,13 +22386,13 @@
 4	read	read	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
 5	that	that	SCONJ	IN	_	7	mark	7:mark	_
 6	there	there	PRON	EX	_	7	expl	7:expl	_
-7	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
-8	times	time	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj|12:obl	_
+7	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Existential-CopPred-ThereExpl
+8	times	time	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj|12:obl	CxnElt=7:Existential-CopPred-ThereExpl.Pivot
 9-10	its	_	_	_	_	_	_	_	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 10	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	12	cop	12:cop	CorrectForm='s
 11	not	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
-12	available	available	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
+12	available	available	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108024148AAO8oFI_ans-0004
@@ -22402,11 +22402,11 @@
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	5:nsubj	_
 3	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	5	cop	5:cop	CorrectForm='s
 4	not	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	available	available	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	_
-6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	available	available	ADJ	JJ	Degree=Pos	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
+6	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Existential-CopPred-ThereExpl|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	there	there	PRON	EX	_	6	expl	6:expl	_
 8	nearby	nearby	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
-9	alternative	alternative	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
+9	alternative	alternative	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	store	store	VERB	VB	VerbForm=Inf	9	acl	9:acl:to	_
 12	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
@@ -22457,9 +22457,9 @@
 3	,	,	PUNCT	,	_	13	punct	13:punct	_
 4	altough	although	SCONJ	IN	Typo=Yes	6	mark	6:mark	CorrectForm=although
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:although	_
+6	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:although	Cxn=Existential-CopPred-ThereExpl
 7	automatic	automatic	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
-8	storage	storage	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	SpaceAfter=No
+8	storage	storage	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 9	,	,	PUNCT	,	_	6	punct	6:punct	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
 11	can	can	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
@@ -22479,7 +22479,7 @@
 23	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj|28:nsubj:xsubj	_
 24	'll	will	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	26	cop	26:cop	_
-26	able	able	ADJ	JJ	Degree=Pos	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-obl_xcomp
+26	able	able	ADJ	JJ	Degree=Pos	21	acl:relcl	21:acl:relcl	_
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	pay	pay	VERB	VB	VerbForm=Inf	26	xcomp	26:xcomp	_
 29	with	with	ADP	IN	_	31	case	31:case	_
@@ -22578,13 +22578,13 @@
 # text = they will talk to me if i am mexican?
 1	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	talk	talk	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	talk	talk	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	obl	3:obl:to	_
 6	if	if	SCONJ	IN	_	9	mark	9:mark	_
 7	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	am	be	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-9	mexican	Mexican	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	SpaceAfter=No
+9	mexican	Mexican	ADJ	JJ	Degree=Pos	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 10	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108110008AA7xHnL_ans-0005
@@ -22739,7 +22739,7 @@
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	not	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
 14	TOO	too	ADV	RB	_	15	advmod	15:advmod	_
-15	far	far	ADV	RB	_	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
+15	far	far	ADV	RB	_	10	acl:relcl	10:acl:relcl	_
 16	from	from	ADP	IN	_	19	case	19:case	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 18	main	main	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -22754,7 +22754,7 @@
 2	way	way	NOUN	NN	Number=Sing	0	root	0:root|5:obl	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	could	could	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
-5	get	get	VERB	VB	VerbForm=Inf	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
+5	get	get	VERB	VB	VerbForm=Inf	2	acl:relcl	2:acl:relcl	_
 6	there	there	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
 7	by	by	ADP	IN	_	8	case	8:case	_
 8	boat	boat	NOUN	NN	Number=Sing	5	obl	5:obl:by	_
@@ -22806,7 +22806,7 @@
 7	where	where	ADV	WRB	PronType=Rel	10	advmod	6:ref	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	do	do	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
+10	do	do	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
 11	fun	fun	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	activities	activity	NOUN	NNS	Number=Plur	10	obj	10:obj	SpaceAfter=No
 13	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -22834,10 +22834,10 @@
 3-4	cannot	_	_	_	_	_	_	_	_
 3	can	can	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	wait	wait	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	_
+5	wait	wait	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	should	should	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	book	book	VERB	VB	VerbForm=Inf	0	root	0:root	_
+8	book	book	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 9	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	earlier	early	ADJ	JJR	Degree=Cmp	11	amod	11:amod	_
 11	flight	flight	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
@@ -22847,10 +22847,10 @@
 # sent_id = answers-20070404104007AAY1Chs_ans-0001
 # newpar id = answers-20070404104007AAY1Chs_ans-p0001
 # text = where can I get morcillas in tampa bay , I will like the argentinian type , but I will to try anothers please?
-1	where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	morcillas	morcilla	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 6	in	in	ADP	IN	_	8	case	8:case	_
 7	tampa	Tampa	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -22893,7 +22893,7 @@
 16	Tampa	Tampa	PROPN	NNP	Number=Sing	17	compound	17:compound	_
 17	Bay	Bay	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	14:ref	_
-19	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
+19	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 20	morcillas	morcilla	NOUN	NNS	Number=Plur	19	obj	19:obj	SpaceAfter=No
 21	,	,	PUNCT	,	_	23	punct	23:punct	_
 22	also	also	ADV	RB	_	23	advmod	23:advmod	_
@@ -22941,7 +22941,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	where	where	ADV	WRB	PronType=Rel	12	advmod	6:ref	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
+12	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 13	all	all	DET	DT	PronType=Tot	14	det	14:det	_
 14	types	type	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	of	of	ADP	IN	_	16	case	16:case	_
@@ -23017,10 +23017,10 @@
 # sent_id = answers-20111108093942AAYF9Dn_ans-0001
 # newpar id = answers-20111108093942AAYF9Dn_ans-p0001
 # text = Is there any kind of public transport available between noida and greater noida?
-1	Is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	4	det	4:det	_
-4	kind	kind	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	_
+4	kind	kind	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot
 5	of	of	ADP	IN	_	7	case	7:case	_
 6	public	public	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	transport	transport	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
@@ -23065,11 +23065,11 @@
 2	from	from	ADP	IN	_	3	case	3:case	_
 3	these	this	PRON	DT	Number=Plur|PronType=Dem	1	obl	1:obl:from	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 6	numerous	numerous	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
-7	cabs	cab	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj|9:nsubj	_
+7	cabs	cab	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj|9:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	ferry	ferry	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
+9	ferry	ferry	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	passengers	passenger	NOUN	NNS	Number=Plur	9	obj	9:obj	_
 11	between	between	ADP	IN	_	15	case	15:case	_
 12	Sector	Sector	PROPN	NNP	Number=Sing	15	compound	15:compound	SpaceAfter=No
@@ -23128,9 +23128,9 @@
 # sent_id = answers-20111108093942AAYF9Dn_ans-0008
 # text = There are UP Govt.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	UP	UP	PROPN	NNP	Number=Sing	4	compound	4:compound	_
-4	Govt	Govt	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
+4	Govt	Govt	PROPN	NNP	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 5	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108093942AAYF9Dn_ans-0009
@@ -23191,10 +23191,10 @@
 # sent_id = answers-20111108081748AAkQhGe_ans-0001
 # newpar id = answers-20111108081748AAkQhGe_ans-p0001
 # text = how can you get wifi anywhere 24/7 on your apple ipod 8gb?
-1	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	wifi	wifi	NOUN	NN	Number=Sing	4	obj	4:obj	_
 6	anywhere	anywhere	ADV	RB	PronType=Ind	4	advmod	4:advmod	_
 7	24	24	NUM	CD	NumForm=Digit|NumType=Card	9	nummod	9:nummod	SpaceAfter=No
@@ -23227,13 +23227,13 @@
 13	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	14	nmod:poss	14:nmod:poss	_
 14	house	house	NOUN	NN	Number=Sing	10	obl	10:obl:at	SpaceAfter=No
 15	...	...	PUNCT	,	_	16	punct	16:punct	SpaceAfter=No
-16	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+16	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	Cxn=Existential-CopPred-ThereExpl
 17	there	there	PRON	EX	_	16	expl	16:expl	_
 18	any	any	DET	DT	PronType=Ind	19	det	19:det	CorrectSpaceAfter=Yes|SpaceAfter=No
-19	way	way	NOUN	NN	Number=Sing	16	nsubj	16:nsubj|22:obl	_
+19	way	way	NOUN	NN	Number=Sing	16	nsubj	16:nsubj|22:obl	CxnElt=16:Existential-CopPred-ThereExpl.Pivot
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	buy	buy	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obl
+22	buy	buy	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	_
 23	some	some	DET	DT	PronType=Ind	24	det	24:det	_
 24	card	card	NOUN	NN	Number=Sing	22	obj	22:obj	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
@@ -23280,7 +23280,7 @@
 30	,	,	PUNCT	,	_	29	punct	29:punct	SpaceAfter=No
 31	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	32	nsubj	32:nsubj	_
 32	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	26	conj	26:conj:and	_
-33	what	what	PRON	WP	PronType=Int	32	ccomp	32:ccomp	_
+33	what	what	PRON	WP	PronType=Int	32	ccomp	32:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=33:Interrogative-WHInfo-Indirect.Clause,33:Interrogative-WHInfo-Indirect.WHWord
 34	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
 35	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	cop	33:cop	_
 36	so	so	ADV	RB	_	38	advmod	38:advmod	_
@@ -23324,16 +23324,16 @@
 12	...	...	PUNCT	,	_	15	punct	15:punct	SpaceAfter=No
 13	actually	actually	ADV	RB	_	15	advmod	15:advmod	_
 14	there	there	PRON	EX	_	15	expl	15:expl	_
-15	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	parataxis	11:parataxis	_
+15	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	parataxis	11:parataxis	Cxn=Existential-CopPred-ThereExpl
 16	a	a	DET	DT	Definite=Ind|PronType=Art	17	det	17:det	_
-17	thing	thing	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|20:obl|24:nsubj	_
+17	thing	thing	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|20:obl|24:nsubj	CxnElt=15:Existential-CopPred-ThereExpl.Pivot
 18	that	that	PRON	WDT	PronType=Rel	20	obl	17:ref	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
-20	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-obl-pstrand
+20	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 21	for	for	ADP	IN	_	18	case	18:case	_
 22	monthly	monthly	ADV	RB	_	20	advmod	20:advmod	_
 23	that	that	PRON	WDT	PronType=Rel	24	nsubj	17:ref	_
-24	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
+24	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 25	wifi	wifi	NOUN	NN	Number=Sing	24	obj	24:obj	_
 26	from	from	ADP	IN	_	27	case	27:case	_
 27	satellite	satellite	NOUN	NN	Number=Sing	24	obl	24:obl:from	_
@@ -23357,12 +23357,12 @@
 # sent_id = answers-20111107115952AAqfsHV_ans-0001
 # newpar id = answers-20111107115952AAqfsHV_ans-p0001
 # text = how are vietnam and Afghanistan alike?
-1	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+1	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	vietnam	Vietnam	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
 4	and	and	CCONJ	CC	_	5	cc	5:cc	_
 5	Afghanistan	Afghanistan	PROPN	NNP	Number=Sing	3	conj	3:conj:and|6:nsubj	_
-6	alike	alike	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+6	alike	alike	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 7	?	?	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111107115952AAqfsHV_ans-0002
@@ -23419,10 +23419,10 @@
 2	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
+5	how	how	ADV	WRB	PronType=Int	8	advmod	8:advmod	CxnElt=8:Interrogative-WHInfo-Indirect.WHWord
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|10:nsubj	_
 7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
-8	different	different	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
+8	different	different	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=8:Interrogative-WHInfo-Indirect.Clause
 9	and	and	CCONJ	CC	_	10	cc	10:cc	_
 10	alike	alike	ADJ	JJ	Degree=Pos	8	conj	4:ccomp|8:conj:and	_
 11	in	in	ADP	IN	_	13	case	13:case	_
@@ -23456,8 +23456,8 @@
 
 # sent_id = answers-20111107115952AAqfsHV_ans-0009
 # text = who fought the wars?
-1	who	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	fought	fight	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	who	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	fought	fight	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	wars	war	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -23561,7 +23561,7 @@
 # sent_id = answers-20111108105146AAtiEx7_ans-0001
 # newpar id = answers-20111108105146AAtiEx7_ans-p0001
 # text = What is your cats name and why did you name him/her that?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
 4-5	cats	_	_	_	_	_	_	_	_
@@ -23696,7 +23696,7 @@
 6	Cat	cat	NOUN	NN	Number=Sing	2	obj	2:obj|9:nsubj:pass|10:nsubj:xsubj	_
 7	that	that	PRON	WDT	PronType=Rel	9	nsubj:pass	6:ref	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj:pass
+9	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	_
 10	Achilles	Achilles	PROPN	NNP	Number=Sing	9	xcomp	9:xcomp	_
 11	bc	because	SCONJ	IN	Abbr=Yes	17	mark	17:mark	_
 12	as	as	ADP	IN	_	14	case	14:case	_
@@ -23726,14 +23726,14 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	year	year	NOUN	NN	Number=Sing	14	nsubj	10:obl|14:nsubj	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl
+10	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obj	10:obj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	year	year	NOUN	NN	Number=Sing	4	advcl	4:advcl:because|17:obl	_
 15	Frank	Frank	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj	_
 16	Sinatra	Sinatra	PROPN	NNP	Number=Sing	15	flat	15:flat	_
-17	died	die	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obl
+17	died	die	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 
 # sent_id = answers-20111108105146AAtiEx7_ans-0011
 # text = He also had bright blue eyes like Frank Sinatra did :)
@@ -23753,10 +23753,10 @@
 # sent_id = answers-20111108104131AAWUQHU_ans-0001
 # newpar id = answers-20111108104131AAWUQHU_ans-p0001
 # text = what does it mean when a veiled chameleon egg is soft?
-1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	mean	mean	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	when	when	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 7	veiled	veiled	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -23811,20 +23811,20 @@
 # text = If there is no male they are probably infertile!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	there	there	PRON	EX	_	3	expl	3:expl	_
-3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	Cxn=Existential-CopPred-ThereExpl|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	no	no	DET	DT	PronType=Neg	5	det	5:det	_
-5	male	male	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+5	male	male	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 7	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 8	probably	probably	ADV	RB	_	9	advmod	9:advmod	_
-9	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+9	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 10	!	!	PUNCT	.	_	9	punct	9:punct	_
 
 # sent_id = answers-20111108104131AAWUQHU_ans-0005
 # text = If you take a flash light and shine it through the eggs and you see nothing throw them away!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|8:nsubj	_
-3	take	take	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+3	take	take	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	flash	flash	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	light	light	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -23838,7 +23838,7 @@
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
 15	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	conj	3:conj:and|17:advcl:if	_
 16	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	15	obj	15:obj	_
-17	throw	throw	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+17	throw	throw	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 18	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	17	obj	17:obj	_
 19	away	away	ADP	RP	_	17	compound:prt	17:compound:prt	SpaceAfter=No
 20	!	!	PUNCT	.	_	17	punct	17:punct	_
@@ -23847,11 +23847,11 @@
 # text = If you do not they will start to rot!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	not	not	PART	RB	Polarity=Neg	3	advmod	3:advmod	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
-7	start	start	VERB	VB	VerbForm=Inf	0	root	0:root	_
+7	start	start	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	rot	rot	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	SpaceAfter=No
 10	!	!	PUNCT	.	_	7	punct	7:punct	_
@@ -23860,7 +23860,7 @@
 # text = If she has no male to fertilize the eggs, the eggs will aways be infertile.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
+3	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	no	no	DET	DT	PronType=Neg	5	det	5:det	_
 5	male	male	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -23873,7 +23873,7 @@
 13	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 14	aways	aways	ADV	RB	_	16	advmod	16:advmod	_
 15	be	be	AUX	VB	VerbForm=Inf	16	cop	16:cop	_
-16	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+16	infertile	infertile	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 17	.	.	PUNCT	.	_	16	punct	16:punct	_
 
 # sent_id = answers-20111108104131AAWUQHU_ans-0008
@@ -23881,7 +23881,7 @@
 1	if	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	have	have	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:if	_
+4	have	have	VERB	VB	VerbForm=Inf	25	advcl	25:advcl:if	CxnElt=25:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	male	male	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	but	but	CCONJ	CC	_	14	cc	14:cc	_
@@ -23902,7 +23902,7 @@
 22	her	she	PRON	PRP	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	20	parataxis	19:obj|20:parataxis	_
 23	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	25:nsubj|30:nsubj	_
 24	will	will	AUX	MD	VerbForm=Fin	25	aux	25:aux	_
-25	smell	smell	VERB	VB	VerbForm=Inf	0	root	0:root	_
+25	smell	smell	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=25:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 26	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	27	nmod:poss	27:nmod:poss	_
 27	sent	sent	NOUN	NN	Number=Sing	25	obj	25:obj	_
 28	and	and	CCONJ	CC	_	30	cc	30:cc	_
@@ -23944,14 +23944,14 @@
 # newpar id = answers-20111107155302AAXXuM1_ans-p0001
 # text = I have 24hrs in San Francisco - what are the best sights to see in my short time?
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	24	24	NUM	CD	NumForm=Digit|NumType=Card	4	nummod	4:nummod	SpaceAfter=No
 4	hrs	hour	NOUN	NNS	Abbr=Yes|Number=Plur	2	obj	2:obj	_
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	San	San	PROPN	NNP	Number=Sing	2	obl	2:obl:in	_
 7	Francisco	Francisco	PROPN	NNP	Number=Sing	6	flat	6:flat	_
 8	-	-	PUNCT	:	_	9	punct	9:punct	_
-9	what	what	PRON	WP	PronType=Int	2	parataxis	2:parataxis	_
+9	what	what	PRON	WP	PronType=Int	2	parataxis	2:parataxis	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	best	good	ADJ	JJS	Degree=Sup	13	amod	13:amod	_
@@ -24001,7 +24001,7 @@
 7	airport	airport	NOUN	NN	Number=Sing	4	obl	4:obl:to|10:nsubj:pass	_
 8	which	which	PRON	WDT	PronType=Rel	10	nsubj:pass	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass
+10	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
 11	next	next	ADV	RB	_	10	advmod	10:advmod	_
 12	to	to	ADP	IN	_	13	case	13:case	_
 13	BARTrail	BARTrail	PROPN	NNP	Number=Sing	11	obl	11:obl:to	SpaceAfter=No
@@ -24010,10 +24010,10 @@
 # sent_id = answers-20111107155302AAXXuM1_ans-0004
 # text = We have limited time What are the best sights to see, geiven that we only have a short time?
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	limited	limited	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	time	time	NOUN	NN	Number=Sing	2	obj	2:obj	_
-5	What	what	PRON	WP	PronType=Int	9	nsubj	9:nsubj	_
+5	What	what	PRON	WP	PronType=Int	9	nsubj	9:nsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	best	good	ADJ	JJS	Degree=Sup	9	amod	9:amod	_
@@ -24089,7 +24089,7 @@
 24	off	off	ADV	RB	_	23	advmod	23:advmod	_
 25	anyplace	anyplace	ADV	RB	PronType=Ind	23	advmod	23:advmod|29:obl:at	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
-27	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	advcl:relcl	25:advcl:relcl	Cxn=rc-red-obl_xcomp-pstrand
+27	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	advcl:relcl	25:advcl:relcl	_
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	spend	spend	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	_
 30	more	more	ADJ	JJR	Degree=Cmp	31	amod	31:amod	_
@@ -24238,12 +24238,12 @@
 10	hype	hype	NOUN	NN	Number=Sing	7	nmod	7:nmod:but|13:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj:pass	13:nsubj:pass	_
 12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux:pass	13:aux:pass	_
-13	told	tell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj
+13	told	tell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	_
 14	and	and	CCONJ	CC	_	16	cc	16:cc	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	packages	package	NOUN	NNS	Number=Plur	10	conj	10:conj:and|18:obj	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj|19:nsubj:xsubj	_
-18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obj
+18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
 19	available	available	ADJ	JJ	Degree=Pos	18	xcomp	18:xcomp	_
 20	to	to	ADP	IN	_	21	case	21:case	_
 21	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	19	obl	19:obl:to	SpaceAfter=No
@@ -24256,7 +24256,7 @@
 3	time	time	NOUN	NN	Number=Sing	14	obl:unmarked	6:obl|14:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	actually	actually	ADV	RB	_	6	advmod	6:advmod	_
-6	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
+6	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 7	through	through	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	travel	travel	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -24271,7 +24271,7 @@
 18	amenities	amenity	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of|21:obl	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	21	aux	21:aux	_
-21	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl-pstrand
+21	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part	18	acl:relcl	18:acl:relcl	_
 22	for	for	ADP	IN	_	21	obl	21:obl	Promoted=Yes|SpaceAfter=No
 23	.	.	PUNCT	.	_	14	punct	14:punct	_
 
@@ -24282,7 +24282,7 @@
 3	times	time	NOUN	NNS	Number=Plur	13	obl:unmarked	6:obl|13:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	consulted	consult	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
+6	consulted	consult	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
 7	with	with	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	travel	travel	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -24307,7 +24307,7 @@
 28	what	what	PRON	WP	PronType=Rel	25	obl	25:obl:than|31:obj	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	31	nsubj	31:nsubj	_
 30	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
-31	selling	sell	VERB	VBG	Tense=Pres|VerbForm=Part	28	acl:relcl	28:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+31	selling	sell	VERB	VBG	Tense=Pres|VerbForm=Part	28	acl:relcl	28:acl:relcl	SpaceAfter=No
 32	.	.	PUNCT	.	_	13	punct	13:punct	_
 
 # sent_id = answers-20111107201700AAKdymq_ans-0008
@@ -24396,10 +24396,10 @@
 6	,	,	PUNCT	,	_	9	punct	9:punct	_
 7	but	but	CCONJ	CC	_	9	cc	9:cc	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	_
+9	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	conj	5:conj:but	Cxn=Existential-CopPred-ThereExpl
 10	so	so	ADV	RB	_	11	advmod	11:advmod	_
 11	many	many	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
-12	things	thing	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
+12	things	thing	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 13	inside	inside	ADP	IN	_	14	case	14:case	_
 14	there	there	ADV	RB	PronType=Dem	12	nmod	12:nmod:inside	SpaceAfter=No
 15	,	,	PUNCT	,	_	19	punct	19:punct	_
@@ -24408,9 +24408,9 @@
 17	du	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	n	not	PART	RB	Polarity=Neg	19	advmod	19:advmod	_
 19	no	know	VERB	VB	VerbForm=Inf	5	parataxis	5:parataxis	_
-20	what	what	PRON	WP	PronType=Int	22	obj	22:obj	_
+20	what	what	PRON	WP	PronType=Int	22	obj	22:obj	CxnElt=22:Interrogative-WHInfo-Indirect.WHWord
 21	to	to	PART	TO	_	22	mark	22:mark	_
-22	do	do	VERB	VB	VerbForm=Inf	19	ccomp	19:ccomp	SpaceAfter=No
+22	do	do	VERB	VB	VerbForm=Inf	19	ccomp	19:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=22:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 23	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = answers-20111108105022AA0Q5wb_ans-0005
@@ -24577,7 +24577,7 @@
 8	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	mother	mother	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
 10	will	will	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	let	let	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj_xcomp
+11	let	let	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
 12	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	11	obj	11:obj|13:nsubj:xsubj	_
 13	have	have	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	please	please	INTJ	UH	_	15	discourse	15:discourse	_
@@ -24707,10 +24707,10 @@
 # text = If you want easy then go with a gold fish or hamster.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	easy	easy	ADJ	JJ	Degree=Pos	3	obj	3:obj	_
 5	then	then	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
-6	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+6	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	with	with	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	gold	gold	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -24724,7 +24724,7 @@
 # text = I would go with a small rodent such as a mouse, rat, hamster or gerbil if you want something you can handle and hold.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	would	would	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	with	with	ADP	IN	_	7	case	7:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 6	small	small	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -24741,11 +24741,11 @@
 17	gerbil	gerbil	NOUN	NN	Number=Sing	11	conj	7:nmod:such_as|11:conj:or	_
 18	if	if	SCONJ	IN	_	20	mark	20:mark	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 21	something	something	PRON	NN	Number=Sing|PronType=Ind	20	obj	20:obj|24:obj	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj|26:nsubj	_
 23	can	can	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	handle	handle	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	Cxn=rc-red-obj
+24	handle	handle	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	_
 25	and	and	CCONJ	CC	_	26	cc	26:cc	_
 26	hold	hold	VERB	VB	VerbForm=Inf	24	conj	21:acl:relcl|24:conj:and	SpaceAfter=No
 27	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -24890,11 +24890,11 @@
 
 # sent_id = answers-20111108071348AAWu2FU_ans-0007
 # text = What do french men find sexy?
-1	What	what	PRON	WP	PronType=Int	5	obj	5:obj|6:nsubj:xsubj	_
+1	What	what	PRON	WP	PronType=Int	5	obj	5:obj|6:nsubj:xsubj	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 3	french	French	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	men	man	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
-5	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	sexy	sexy	ADJ	JJ	Degree=Pos	5	xcomp	5:xcomp	SpaceAfter=No
 7	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -24913,7 +24913,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	way	way	NOUN	NN	Number=Sing	19	nsubj	13:obl|19:nsubj	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl
+13	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 16	not	not	PART	RB	Polarity=Neg	19	advmod	19:advmod	_
@@ -24929,9 +24929,9 @@
 
 # sent_id = answers-20111108071348AAWu2FU_ans-0009
 # text = Why not wait for him in a sexy dress with lunch or dinner, or a light snack at his house.
-1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	not	not	PART	RB	Polarity=Neg	3	advmod	3:advmod	_
-3	wait	wait	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	wait	wait	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	for	for	ADP	IN	_	5	case	5:case	_
 5	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obl	3:obl:for	_
 6	in	in	ADP	IN	_	9	case	9:case	_
@@ -25231,7 +25231,7 @@
 # text = Whatever you order, you will LOVE!
 1	Whatever	whatever	PRON	WP	PronType=Rel	7	obj	3:obj|7:obj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	order	order	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+3	order	order	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	SpaceAfter=No
 4	,	,	PUNCT	,	_	1	punct	1:punct	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -25330,18 +25330,18 @@
 # newpar id = reviews-014629-p0001
 # text = There is no delivery.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	no	no	DET	DT	PronType=Neg	4	det	4:det	_
-4	delivery	delivery	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
+4	delivery	delivery	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-014629-0002
 # newpar id = reviews-014629-p0002
 # text = There is no delivery.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	no	no	DET	DT	PronType=Neg	4	det	4:det	_
-4	delivery	delivery	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	SpaceAfter=No
+4	delivery	delivery	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 5	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-317480
@@ -25774,7 +25774,7 @@
 2-3	you're	_	_	_	_	_	_	_	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	13	advcl	13:advcl:if	_
+4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	13	advcl	13:advcl:if	CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	for	for	ADP	IN	_	8	case	8:case	_
 6	homestyle	homestyle	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 7	Japanese	Japanese	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -25784,7 +25784,7 @@
 11-12	can't	_	_	_	_	_	_	_	_
 11	ca	can	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	beat	beat	VERB	VB	VerbForm=Inf	0	root	0:root	_
+13	beat	beat	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 14	this	this	PRON	DT	Number=Sing|PronType=Dem	13	obj	13:obj	_
 
 # newdoc id = reviews-224123
@@ -25923,10 +25923,10 @@
 # text = + there is a free cola with every pizza.
 1	+	+	SYM	SYM	_	3	cc	3:cc	_
 2	there	there	PRON	EX	_	3	expl	3:expl	_
-3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	free	free	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
-6	cola	cola	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+6	cola	cola	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 7	with	with	ADP	IN	_	9	case	9:case	_
 8	every	every	DET	DT	PronType=Tot	9	det	9:det	_
 9	pizza	pizza	NOUN	NN	Number=Sing	3	obl	3:obl:with	SpaceAfter=No
@@ -26156,7 +26156,7 @@
 1	A	a	DET	DT	Definite=Ind|PronType=Art	2	det	2:det	_
 2	company	company	NOUN	NN	Number=Sing	0	root	0:root|4:nsubj	_
 3	which	which	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	provide	provide	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	2	acl:relcl	2:acl:relcl	CorrectForm=provides|CorrectNumber=Sing|Cxn=rc-wh-nsubj
+4	provide	provide	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	2	acl:relcl	2:acl:relcl	CorrectForm=provides|CorrectNumber=Sing
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	quality	quality	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	portals	portal	NOUN	NNS	Number=Plur	4	obj	4:obj	SpaceAfter=No
@@ -26324,11 +26324,11 @@
 # sent_id = reviews-103609-0002
 # newpar id = reviews-103609-p0002
 # text = What more can be said: "Burch's Karate is the GREATEST!"
-1	What	what	PRON	WP	PronType=Int	5	nsubj:pass	5:nsubj:pass	_
+1	What	what	PRON	WP	PronType=Int	5	nsubj:pass	5:nsubj:pass	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	more	more	ADJ	JJR	Degree=Cmp	1	amod	1:amod	_
 3	can	can	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	be	be	AUX	VB	VerbForm=Inf	5	aux:pass	5:aux:pass	_
-5	said	say	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	SpaceAfter=No
+5	said	say	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 6	:	:	PUNCT	:	_	13	punct	13:punct	_
 7	"	"	PUNCT	``	_	13	punct	13:punct	SpaceAfter=No
 8-9	Burch's	_	_	_	_	_	_	_	_
@@ -26665,7 +26665,7 @@
 8	Toyota	Toyota	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	Venza	Venza	PROPN	NNP	Number=Sing	5	nmod	5:nmod:for	_
 10	that	that	PRON	WDT	PronType=Rel	11	nsubj	5:ref	_
-11	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
+11	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 12	amazing	amazing	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -26701,7 +26701,7 @@
 13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
 14	friend	friend	NOUN	NN	Number=Sing	13	obj	13:obj|16:nsubj	_
 15	who	who	PRON	WP	PronType=Rel	16	nsubj	14:ref	_
-16	drive	drive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	14	acl:relcl	14:acl:relcl	CorrectForm=drives|CorrectNumber=Sing|Cxn=rc-wh-nsubj
+16	drive	drive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	14	acl:relcl	14:acl:relcl	CorrectForm=drives|CorrectNumber=Sing
 17	from	from	ADP	IN	_	19	case	19:case	_
 18	central	central	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	Phx	Phoenix	PROPN	NNP	Abbr=Yes|Number=Sing	16	obl	16:obl:from	_
@@ -26898,7 +26898,7 @@
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	PronType=Ind	8	advmod	8:advmod	_
-8	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+8	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-363633-0003
@@ -27372,7 +27372,7 @@
 9	Mrs.	Mrs.	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	Lynda	Lynda	PROPN	NNP	Number=Sing	9	flat	9:flat	_
 11	Mcmanus	Mcmanus	PROPN	NNP	Number=Sing	9	flat	9:flat	_
-12	taught	teach	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
+12	taught	teach	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	iobj	12:iobj	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -27410,7 +27410,7 @@
 5	pizza	pizza	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	place	place	NOUN	NN	Number=Sing	0	root	0:root|8:obj	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+8	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	in	in	ADP	IN	_	11	case	11:case	_
 10	Woodland	Woodland	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	Hills	Hill	PROPN	NNPS	Number=Plur	6	obl	6:obl:in	SpaceAfter=No
@@ -27591,7 +27591,7 @@
 7	about	about	ADV	RB	_	8	advmod	8:advmod	_
 8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	6	obj	6:obj|10:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 11	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-262422-0004
@@ -27708,7 +27708,7 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	hairstyles	hairstyle	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	last	last	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+6	last	last	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-162992-0002
@@ -27722,7 +27722,7 @@
 6	service	service	NOUN	NN	Number=Sing	3	obl	3:obl:with|9:obj	_
 7	that	that	PRON	WDT	PronType=Rel	9	obj	6:ref	_
 8	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj
+9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 10	at	at	ADP	IN	_	11	case	11:case	_
 11	Luxe	Luxe	PROPN	NNP	Number=Sing	9	obl	9:obl:at	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -28060,7 +28060,7 @@
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	what	what	PRON	WP	PronType=Rel	0	root	0:root|5:obj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obj
+5	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	customer	customer	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	service	service	NOUN	NN	Number=Sing	5	xcomp	5:xcomp	SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -28082,7 +28082,7 @@
 1-2	It's	_	_	_	_	_	_	_	_
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj|28:nsubj	_
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
-3	fine	fine	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	fine	fine	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	for	for	ADP	IN	_	8	case	8:case	_
 5	mass	mass	ADJ	JJ	Degree=Pos	7	amod	7:amod	SpaceAfter=No
 6	-	-	PUNCT	HYPH	_	5	punct	5:punct	SpaceAfter=No
@@ -28107,7 +28107,7 @@
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	area	area	NOUN	NN	Number=Sing	12	nmod	12:nmod:in	SpaceAfter=No
 27	,	,	PUNCT	,	_	12	punct	12:punct	_
-28	why	why	ADV	WRB	PronType=Int	3	conj	3:conj:but	SpaceAfter=No
+28	why	why	ADV	WRB	PronType=Int	3	conj	3:conj:but	CxnElt=3:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 29	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = reviews-147825
@@ -28390,7 +28390,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
 12	fast	fast	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	food	food	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+13	food	food	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-058274-0002
@@ -28490,7 +28490,7 @@
 9	Duty	Duty	PROPN	NNP	Number=Sing	10	compound	10:compound	_
 10	Free	Free	PROPN	NNP	Number=Sing	12	nsubj:pass	12:nsubj:pass	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
-12	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl:relcl	4:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
+12	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl:relcl	4:advcl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-090390-0003
@@ -28558,7 +28558,7 @@
 9	experience	experience	NOUN	NN	Number=Sing	0	root	0:root|12:obj	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	9	punct	9:punct	_
 
 # newdoc id = reviews-188461
@@ -28639,13 +28639,13 @@
 # text = If you mention the name Amir you will receive %10 off at time of purchase
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	mention	mention	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	mention	mention	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	name	name	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	Amir	Amir	PROPN	NNP	Number=Sing	5	appos	5:appos	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	will	will	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	receive	receive	VERB	VB	VerbForm=Inf	0	root	0:root	_
+9	receive	receive	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 10	%	%	SYM	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
 11	10	10	NUM	CD	NumForm=Digit|NumType=Card	10	nummod	10:nummod	_
 12	off	off	ADV	RB	_	10	advmod	10:advmod	_
@@ -28744,13 +28744,13 @@
 # text = I highly recommend Bay View if you are looking for Accommodation in Camps Bay.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	highly	highly	ADV	RB	_	3	advmod	3:advmod	_
-3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	Bay	Bay	PROPN	NNP	Number=Sing	5	compound	5:compound	_
 5	View	View	PROPN	NNP	Number=Sing	3	obj	3:obj	_
 6	if	if	SCONJ	IN	_	9	mark	9:mark	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
-9	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	3	advcl	3:advcl:if	_
+9	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 10	for	for	ADP	IN	_	11	case	11:case	_
 11	Accommodation	accommodation	NOUN	NN	Number=Sing	9	obl	9:obl:for	_
 12	in	in	ADP	IN	_	14	case	14:case	_
@@ -28776,7 +28776,7 @@
 12-13	I've	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
-14	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
+14	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
 15	in	in	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 17	Tampa	Tampa	PROPN	NNP	Number=Sing	18	compound	18:compound	_
@@ -28910,7 +28910,7 @@
 8	for	for	ADP	IN	_	9	case	9:case	_
 9	what	what	PRON	WP	PronType=Rel	6	obl	6:obl:for|11:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-148012-0005
@@ -28939,9 +28939,9 @@
 5	,	,	PUNCT	,	_	1	punct	1:punct	_
 6	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	exactly	exactly	ADV	RB	_	6	advmod	6:advmod	_
-8	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
+8	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	CxnElt=10:Interrogative-WHInfo-Indirect.WHWord
 9	to	to	PART	TO	_	10	mark	10:mark	_
-10	make	make	VERB	VB	VerbForm=Inf	6	ccomp	6:ccomp	_
+10	make	make	VERB	VB	VerbForm=Inf	6	ccomp	6:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=10:Interrogative-WHInfo-Indirect.Clause
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	obj	10:obj|12:nsubj:xsubj|13:nsubj:xsubj	_
 12	feel	feel	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	beautiful	beautiful	ADJ	JJ	Degree=Pos	12	xcomp	12:xcomp	_
@@ -28992,11 +28992,11 @@
 # sent_id = reviews-335815-0002
 # text = There are a couple decent people working there, but the rest are VERY dishonest, as well as rude, I have yet to hear the truth come out of their mouths.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	couple	couple	NOUN	NN	Number=Sing	6	nmod:unmarked	6:nmod:unmarked	_
 5	decent	decent	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
-6	people	people	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
+6	people	people	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 7	working	work	VERB	VBG	VerbForm=Ger	6	acl	6:acl	_
 8	there	there	ADV	RB	PronType=Dem	7	advmod	7:advmod	SpaceAfter=No
 9	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -29075,12 +29075,12 @@
 
 # sent_id = reviews-114941-0004
 # text = How much better does it get?!
-1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 2	much	much	ADV	RB	_	3	advmod	3:advmod	_
 3	better	good	ADJ	JJR	Degree=Cmp	6	xcomp	6:xcomp	_
 4	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	3:nsubj:xsubj|6:nsubj	_
-6	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+6	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 7	?!	?!	PUNCT	.	_	6	punct	6:punct	_
 
 # newdoc id = reviews-077034
@@ -29166,7 +29166,7 @@
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	ever	ever	ADV	RB	PronType=Ind	14	advmod	14:advmod	_
-14	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+14	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-173944-0004
@@ -29202,14 +29202,14 @@
 3	check	check	VERB	VB	VerbForm=Inf	1	xcomp	1:xcomp	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	_
+6	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=6:Interrogative-Polar-Indirect.Clause
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	product	product	NOUN	NN	Number=Sing	6	obj	6:obj|12:obj	_
 9-10	I've	_	_	_	_	_	_	_	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	aux	12:aux	_
-12	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
+12	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 13	on	on	ADP	IN	_	15	case	15:case	_
 14	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	dog	dog	NOUN	NN	Number=Sing	12	obl	12:obl:on	_
@@ -29219,7 +29219,7 @@
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	boy	boy	NOUN	NN	Number=Sing	30	nsubj	22:nsubj|30:nsubj	_
 21	who	who	PRON	WP	PronType=Rel	22	nsubj	20:ref	_
-22	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	Cxn=rc-wh-nsubj
+22	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	phone	phone	NOUN	NN	Number=Sing	22	obj	22:obj	_
 25-26	couldn't	_	_	_	_	_	_	_	_
@@ -29368,7 +29368,7 @@
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 7	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	ever	ever	ADV	RB	PronType=Ind	9	advmod	9:advmod	_
-9	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl-pstrand
+9	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
 10	with	with	ADP	IN	_	9	obl	9:obl	Promoted=Yes|SpaceAfter=No
 11	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -29551,7 +29551,7 @@
 4	excellent	excellent	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	host	host	NOUN	NN	Number=Sing	0	root	0:root|7:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	5:ref	_
-7	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+7	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	yummy	yummy	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	breakfasts	breakfast	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -29857,7 +29857,7 @@
 2	recommended	recommend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 3	for	for	ADP	IN	_	4	case	4:case	_
 4	who	whoever	PRON	WP	PronType=Rel|Typo=Yes	2	obl	2:obl:for|5:nsubj	CorrectForm=whoever
-5	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-free-nsubj
+5	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	have	have	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	website	website	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
@@ -30318,7 +30318,7 @@
 10	on	on	ADP	IN	_	13	case	13:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	next	next	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	block	block	NOUN	NN	Number=Sing	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
+13	block	block	NOUN	NN	Number=Sing	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 14	)	)	PUNCT	-RRB-	_	13	punct	13:punct	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -30369,7 +30369,7 @@
 12	other	other	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	services	service	NOUN	NNS	Number=Plur	7	obj	7:obj|9:obj|15:obj	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-15	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+15	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
 16	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-323248-0004
@@ -30428,16 +30428,16 @@
 # text = If you want an attorney who will defend your right, contact Law Offices of Armando Villega
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	an	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	attorney	attorney	NOUN	NN	Number=Sing	3	obj	3:obj|8:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	will	will	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	defend	defend	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+8	defend	defend	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 9	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	right	right	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
 11	,	,	PUNCT	,	_	3	punct	3:punct	_
-12	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+12	contact	contact	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	Law	Law	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	Offices	Office	PROPN	NNPS	Number=Plur	12	obj	12:obj	_
 15	of	of	ADP	IN	_	16	case	16:case	_
@@ -30494,7 +30494,7 @@
 6	and	and	CCONJ	CC	_	17	cc	17:cc	_
 7	if	if	SCONJ	IN	_	9	mark	9:mark	_
 8	ever	ever	ADV	RB	PronType=Ind	9	advmod	9:advmod	_
-9	back	back	ADV	RB	_	17	advcl	17:advcl	_
+9	back	back	ADV	RB	_	17	advcl	17:advcl	CxnElt=17:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	area	area	NOUN	NN	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
@@ -30502,7 +30502,7 @@
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 15	will	will	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 16	be	be	AUX	VB	VerbForm=Inf	17	aux	17:aux	_
-17	staying	stay	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:and	_
+17	staying	stay	VERB	VBG	Tense=Pres|VerbForm=Part	2	conj	2:conj:and	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=17:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 18	here	here	ADV	RB	PronType=Dem	17	advmod	17:advmod	_
 19	again	again	ADV	RB	_	17	advmod	17:advmod	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -30589,7 +30589,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
-4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	12	advcl	12:advcl:if	_
+4	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	for	for	ADP	IN	_	9	case	9:case	_
 6	authentic	authentic	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 7	British	British	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -30597,7 +30597,7 @@
 9	pies	pie	NOUN	NNS	Number=Plur	4	obl	4:obl:for	SpaceAfter=No
 10	,	,	PUNCT	,	_	4	punct	4:punct	_
 11	then	then	ADV	RB	PronType=Dem	12	advmod	12:advmod	_
-12	look	look	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+12	look	look	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	know	no	ADV	RB	Typo=Yes	14	advmod	14:advmod	CorrectForm=no
 14	further	far	ADV	RBR	Degree=Cmp	12	advmod	12:advmod	SpaceAfter=No
 15	.	.	PUNCT	.	_	12	punct	12:punct	_
@@ -30670,7 +30670,7 @@
 12-13	wouldn't	_	_	_	_	_	_	_	_
 12	would	would	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	Polarity=Neg	14	advmod	14:advmod	_
-14	expect	expect	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
+14	expect	expect	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -30744,7 +30744,7 @@
 11	Your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	Boys	boy	NOUN	NNS	Number=Plur	9	conj	9:conj:and|14:nsubj	_
 13	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
-14	Done	do	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj
+14	Done	do	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
 15	On	on	ADP	IN	_	19	case	19:case	_
 16	Our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 17	New	new	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -30763,7 +30763,7 @@
 30	Power	power	NOUN	NN	Number=Sing	40	nsubj	33:obj|40:nsubj	_
 31	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	33	nsubj	33:nsubj	_
 32	Are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
-33	Putting	put	VERB	VBG	Tense=Pres|VerbForm=Part	30	acl:relcl	30:acl:relcl	Cxn=rc-red-obj
+33	Putting	put	VERB	VBG	Tense=Pres|VerbForm=Part	30	acl:relcl	30:acl:relcl	_
 34	Back	back	ADV	RB	_	33	advmod	33:advmod	_
 35	In	into	ADP	GW	Typo=Yes	38	case	38:case	_
 36	To	_	X	IN	_	35	goeswith	35:goeswith	_
@@ -30791,7 +30791,7 @@
 2	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	3	amod	3:amod	_
 3	time	time	NOUN	NN	Number=Sing	14	obl:unmarked	5:obl|14:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
+5	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	there	there	ADV	RB	PronType=Dem	5	obl	5:obl:in	_
 8	with	with	ADP	IN	_	12	case	12:case	_
@@ -30826,7 +30826,7 @@
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	everything	everything	PRON	NN	Number=Sing|PronType=Tot	5	conj	3:obj|5:conj:and|15:obj	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj|17:nsubj:xsubj	_
-15	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
+15	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	keep	keep	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -30926,9 +30926,9 @@
 9	city	city	NOUN	NN	Number=Sing	6	nmod	6:nmod:of	_
 10	and	and	CCONJ	CC	_	12	cc	12:cc	_
 11	there	there	PRON	EX	_	12	expl	12:expl	_
-12	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
+12	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	Cxn=Existential-CopPred-ThereExpl
 13	also	also	ADV	RB	_	12	advmod	12:advmod	_
-14	attractions	attraction	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
+14	attractions	attraction	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	CxnElt=12:Existential-CopPred-ThereExpl.Pivot
 15	like	like	ADP	IN	_	16	case	16:case	_
 16	simulator	simulator	NOUN	NN	Number=Sing	14	nmod	14:nmod:like	SpaceAfter=No
 17	,	,	PUNCT	,	_	19	punct	19:punct	_
@@ -31024,7 +31024,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	reason	reason	NOUN	NN	Number=Sing	12	nsubj:outer	4:obl|12:nsubj:outer	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
+4	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	back	back	ADV	RB	_	4	advmod	4:advmod	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 7	because	because	SCONJ	IN	_	12	mark	12:mark	_
@@ -31067,7 +31067,7 @@
 3	guy	guy	NOUN	NN	Number=Sing	20	nsubj	6:nsubj|20:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	6	nsubj	3:ref	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
-6	there	there	ADV	RB	PronType=Dem	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
+6	there	there	ADV	RB	PronType=Dem	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
@@ -31087,7 +31087,7 @@
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 22	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	ever	ever	ADV	RB	PronType=Ind	24	advmod	24:advmod	_
-24	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	20	acl:relcl	20:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+24	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	20	acl:relcl	20:acl:relcl	SpaceAfter=No
 25	.	.	PUNCT	.	_	20	punct	20:punct	_
 
 # sent_id = reviews-061768-0004
@@ -31095,10 +31095,10 @@
 1	But	but	CCONJ	CC	_	4	cc	4:cc	_
 2	thankfully	thankfully	ADV	RB	_	4	advmod	4:advmod	_
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	other	other	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	flowers	flower	NOUN	NNS	Number=Plur	7	compound	7:compound	_
-7	shops	shop	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
+7	shops	shop	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 8	around	around	ADP	IN	_	9	case	9:case	_
 9	Norman	Norman	PROPN	NNP	Number=Sing	7	nmod	7:nmod:around	SpaceAfter=No
 10	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -31306,7 +31306,7 @@
 # text = If you want cheaply made glass from India and China, this is not your place.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	cheaply	cheaply	ADV	RB	_	5	advmod	5:advmod	_
 5	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	amod	6:amod	_
 6	glass	glass	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -31319,7 +31319,7 @@
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 14	not	not	PART	RB	Polarity=Neg	16	advmod	16:advmod	_
 15	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
-16	place	place	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+16	place	place	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 17	.	.	PUNCT	.	_	16	punct	16:punct	_
 
 # sent_id = reviews-140164-0002
@@ -31406,7 +31406,7 @@
 33-34	wouldn't	_	_	_	_	_	_	_	_
 33	would	would	AUX	MD	VerbForm=Fin	35	aux	35:aux	_
 34	n't	not	PART	RB	Polarity=Neg	35	advmod	35:advmod	_
-35	do	do	VERB	VB	VerbForm=Inf	29	acl:relcl	29:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+35	do	do	VERB	VB	VerbForm=Inf	29	acl:relcl	29:acl:relcl	SpaceAfter=No
 36	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-063754-0002
@@ -31626,11 +31626,11 @@
 # text = if you want good pizza, go to famoso.
 1	if	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	pizza	pizza	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
-7	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+7	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 8	to	to	ADP	IN	_	9	case	9:case	_
 9	famoso	famoso	PROPN	NNP	Number=Sing	7	obl	7:obl:to	SpaceAfter=No
 10	.	.	PUNCT	.	_	7	punct	7:punct	_
@@ -31653,11 +31653,11 @@
 7	suspicious	suspicious	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
 8	that	that	SCONJ	IN	_	10	mark	10:mark	_
 9	there	there	PRON	EX	_	10	expl	10:expl	_
-10	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+10	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	Cxn=Existential-CopPred-ThereExpl
 11	not	not	PART	RB	Polarity=Neg	10	advmod	10:advmod	_
 12	only	only	ADV	RB	_	10	advmod	10:advmod	_
 13	20	20	NUM	CD	NumForm=Digit|NumType=Card	14	nummod	14:nummod	_
-14	reviews	review	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	_
+14	reviews	review	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	CxnElt=10:Existential-CopPred-ThereExpl.Pivot
 15	for	for	ADP	IN	_	17	case	17:case	_
 16	this	this	DET	DT	Number=Sing|PronType=Dem	17	det	17:det	_
 17	dentist	dentist	NOUN	NN	Number=Sing	14	nmod	14:nmod:for	_
@@ -31736,16 +31736,16 @@
 4	always	always	ADV	RB	PronType=Tot	5	advmod	5:advmod	_
 5	ready	ready	ADJ	JJ	Degree=Pos	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
-7	help	help	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
+7	help	help	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 8	if	if	SCONJ	IN	_	12	mark	12:mark	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
 10-11	can't	_	_	_	_	_	_	_	_
 10	ca	can	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 11	n't	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
-12	decide	decide	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:if|15:csubj	_
+12	decide	decide	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:if|15:csubj	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	(	(	PUNCT	-LRB-	_	15	punct	15:punct	SpaceAfter=No
 14	which	which	PRON	WDT	PronType=Rel	15	nsubj	12:ref	_
-15	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-csubj
+15	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl:relcl	12:advcl:relcl	_
 16	every	every	DET	DT	PronType=Tot	17	det	17:det	_
 17	time	time	NOUN	NN	Number=Sing	15	obl:unmarked	15:obl:unmarked	TemporalNPAdjunct=Yes
 18	for	for	ADP	IN	_	19	case	19:case	_
@@ -31867,7 +31867,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	been	be	AUX	VBN	Tense=Past|VerbForm=Part	11	cop	11:cop	_
-11	to	to	ADP	IN	_	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes|SpaceAfter=No
+11	to	to	ADP	IN	_	7	acl:relcl	7:acl:relcl	Promoted=Yes|SpaceAfter=No
 12	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-228944-0003
@@ -31880,7 +31880,7 @@
 6	which	which	PRON	WDT	PronType=Rel	9	obl	4:ref	_
 7	everything	everything	PRON	NN	Number=Sing|PronType=Tot	9	nsubj	9:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-9	expensive	expensive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pstrand
+9	expensive	expensive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	_
 10	on	on	ADP	IN	_	6	case	6:case	_
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
@@ -31898,7 +31898,7 @@
 24	other	other	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	shop	shop	NOUN	NN	Number=Sing	21	obl	21:obl:than|27:obj	_
 26	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
-27	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+27	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	SpaceAfter=No
 28	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-228944-0004
@@ -31910,7 +31910,7 @@
 5	place	place	NOUN	NN	Number=Sing	0	root	0:root|8:obl	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	take	take	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
+8	take	take	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	car	car	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	peiod	period	NOUN	NN	Number=Sing|Typo=Yes	8	obl:unmarked	8:obl:unmarked	CorrectForm=period|SpaceAfter=No
@@ -32111,10 +32111,10 @@
 2	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	what	what	PRON	WP	PronType=Int	8	obj	8:obj	_
+5	what	what	PRON	WP	PronType=Int	8	obj	8:obj	CxnElt=8:Interrogative-WHInfo-Indirect.WHWord
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	aux	8:aux	_
-8	missing	miss	VERB	VBG	Tense=Pres|VerbForm=Part	4	ccomp	4:ccomp	SpaceAfter=No
+8	missing	miss	VERB	VBG	Tense=Pres|VerbForm=Part	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=8:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 9	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-280170-0005
@@ -32227,15 +32227,15 @@
 1	Dentist	dentist	NOUN	NN	Number=Sing	0	root	0:root|4:obj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	trust	trust	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+4	trust	trust	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 
 # sent_id = reviews-313558-0002
 # newpar id = reviews-313558-p0002
 # text = If possible I try the services on myself before I bring in my son.
 1	If	if	SCONJ	IN	_	2	mark	2:mark	_
-2	possible	possible	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	_
+2	possible	possible	ADJ	JJ	Degree=Pos	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	try	try	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	try	try	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=4:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	services	service	NOUN	NNS	Number=Plur	4	obj	4:obj	_
 7	on	on	ADP	IN	_	8	case	8:case	_
@@ -32418,8 +32418,8 @@
 # sent_id = reviews-162253-0003
 # text = There is something wrong or maybe the individual made a mistake but to me that is not integrity.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	something	something	PRON	NN	Number=Sing|PronType=Ind	2	nsubj	2:nsubj	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+3	something	something	PRON	NN	Number=Sing|PronType=Ind	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 4	wrong	wrong	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 5	or	or	CCONJ	CC	_	9	cc	9:cc	_
 6	maybe	maybe	ADV	RB	_	9	advmod	9:advmod	_
@@ -32456,7 +32456,7 @@
 1	All	all	DET	DT	PronType=Tot	11	nsubj:outer	4:obj|11:nsubj:outer	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	say	say	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+4	say	say	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 6	that	that	SCONJ	IN	_	11	mark	11:mark	_
 7	Elmira	Elmira	PROPN	NNP	Number=Sing	11	vocative	11:vocative	_
@@ -32467,7 +32467,7 @@
 12-13	Ive	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	14	aux	14:aux	CorrectForm='ve
-14	experienced	experience	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+14	experienced	experience	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
 16	never	never	ADV	RB	PronType=Neg	17	advmod	17:advmod	_
 17	before	before	ADV	RB	_	21	advmod	21:advmod	_

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -1599,7 +1599,7 @@
 6	anything	anything	PRON	NN	Number=Sing|PronType=Ind	5	obj	5:obj|8.1:obj	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|8.1:nsubj:xsubj	_
 8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj_xcomp
-8.1	write	write	VERB	VB	VerbForm=Inf	_	_	8:xcomp	CopyOf=5|wordform=__EMPTY__
+8.1	write	write	VERB	VB	VerbForm=Inf	_	_	8:xcomp	CopyOf=5
 9	about	about	ADP	IN	_	11	case	11:case	_
 10	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
 11	prophet	prophet	NOUN	NN	Number=Sing	6	nmod	6:nmod:about	SpaceAfter=No
@@ -20368,7 +20368,7 @@
 8	capability	capability	NOUN	NN	Number=Sing	4	list	4:list	_
 9	(	(	PUNCT	-LRB-	_	10	punct	10:punct	SpaceAfter=No
 10	SX40	SX40	PROPN	NNP	Number=Sing	8	parataxis	8:parataxis|10.1:nsubj	_
-10.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	8:parataxis	CopyOf=-1|wordform=__EMPTY__
+10.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	8:parataxis	CopyOf=-1
 11	only	only	ADV	RB	_	12	advmod	12:advmod	_
 12	3200	3200	NUM	CD	NumForm=Digit|NumType=Card	10	orphan	10.1:obj	SpaceAfter=No
 13	)	)	PUNCT	-RRB-	_	10	punct	10:punct	SpaceAfter=No
@@ -20380,7 +20380,7 @@
 19	and	and	CCONJ	CC	_	21	cc	21:cc|21.1:cc	_
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	SX40	SX40	PROPN	NNP	Number=Sing	16	conj	16:conj:and|21.1:nsubj	_
-21.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	16:conj:and	CopyOf=-1|wordform=__EMPTY__
+21.1	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	_	_	16:conj:and	CopyOf=-1
 22	only	only	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	f	f	NOUN	NN	Number=Sing	21	orphan	21.1:obj	SpaceAfter=No
 24	/	/	PUNCT	,	_	25	punct	25:punct	SpaceAfter=No
@@ -21285,7 +21285,7 @@
 9	know	know	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	what	what	DET	WDT	PronType=Int	11	det	11:det	CxnElt=15:Interrogative-WHInfo-Indirect.WHWord
 11	kind	kind	NOUN	NN	Number=Sing	15	obj	15:obj	_
-11.1	_	of	ADP	IN	Typo=Yes	_	_	12:case	CorrectForm=of|wordform=__EMPTY__
+11.1	_	of	ADP	IN	Typo=Yes	_	_	12:case	CorrectForm=of
 12	food	food	NOUN	NN	Number=Sing	11	nmod	11:nmod:of	_
 13	Argentina	Argentina	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	people	people	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_

--- a/en_ewt-ud-dev.conllu
+++ b/en_ewt-ud-dev.conllu
@@ -368,7 +368,7 @@
 26	ways	way	NOUN	NNS	Number=Plur	20	conj	19:xcomp|20:conj:or|29:nsubj	_
 27	that	that	PRON	WDT	PronType=Rel	29	nsubj	26:ref	_
 28	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	bad	bad	ADJ	JJ	Degree=Pos	26	acl:relcl	26:acl:relcl	_
+29	bad	bad	ADJ	JJ	Degree=Pos	26	acl:relcl	26:acl:relcl	Cxn=rc-that-nsubj
 30	for	for	ADP	IN	_	32	case	32:case	_
 31	US	US	PROPN	NNP	Number=Sing	32	compound	32:compound	_
 32	standing	standing	NOUN	NN	Number=Sing	29	obl	29:obl:for	_
@@ -410,7 +410,7 @@
 26-27	haven't	_	_	_	_	_	_	_	_
 26	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	28	aux	28:aux	_
 27	n't	not	PART	RB	Polarity=Neg	28	advmod	28:advmod	_
-28	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	24	acl:relcl	24:acl:relcl	_
+28	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	24	acl:relcl	24:acl:relcl	Cxn=rc-wh-nsubj
 29	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	28	obj	28:obj	SpaceAfter=No
 30	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -465,7 +465,7 @@
 16	who's	whose	PRON	WP$	Poss=Yes|PronType=Rel|Typo=Yes	18	nmod:poss	15:ref	CorrectForm=whose
 17	stated	state	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	18	amod	18:amod	_
 18	goals	goal	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
-19	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+19	include	include	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nmod:poss_nsubj
 20	"	"	PUNCT	``	_	24	punct	24:punct	SpaceAfter=No
 21-22	Don't	_	_	_	_	_	_	_	_
 21	Do	do	AUX	VB	Mood=Imp|VerbForm=Fin	24	aux	24:aux	_
@@ -488,7 +488,7 @@
 37	Do	do	AUX	VB	Mood=Imp|VerbForm=Fin	40	aux	40:aux	_
 38	n't	not	PART	RB	Polarity=Neg	40	advmod	40:advmod	_
 39	be	be	AUX	VB	VerbForm=Inf	40	cop	40:cop	_
-40	profitable	profitable	ADJ	JJ	Degree=Pos	30	acl:relcl	30:acl:relcl	SpaceAfter=No
+40	profitable	profitable	ADJ	JJ	Degree=Pos	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-nmod:poss_nsubj:outer|SpaceAfter=No
 41	.	.	PUNCT	.	_	40	punct	40:punct	SpaceAfter=No
 42	"	"	PUNCT	''	_	40	punct	40:punct	_
 
@@ -531,7 +531,7 @@
 32	strategy	strategy	NOUN	NN	Number=Sing	54	nsubj	35:nsubj|54:nsubj	SpaceAfter=No
 33	,	,	PUNCT	,	_	35	punct	35:punct	_
 34	which	which	PRON	WDT	PronType=Rel	35	nsubj	32:ref	_
-35	gives	give	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
+35	gives	give	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	Cxn=rc-wh-nsubj
 36	employees	employee	NOUN	NNS	Number=Plur	35	iobj	35:iobj	_
 37	one	one	NUM	CD	NumForm=Word|NumType=Card	38	nummod	38:nummod	_
 38	day	day	NOUN	NN	Number=Sing	35	obj	35:obj	_
@@ -671,7 +671,7 @@
 33	Sharon	Sharon	PROPN	NNP	Number=Sing	36	nsubj	36:nsubj	_
 34	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	aux	36:aux	_
 35	always	always	ADV	RB	PronType=Tot	36	advmod	36:advmod	_
-36	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part	30	acl:relcl	30:acl:relcl	SpaceAfter=No
+36	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
 37	.	.	PUNCT	.	_	13	punct	13:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041120060600_ENG_20041120_060600-0005
@@ -691,7 +691,7 @@
 12	not	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
 13	soon	soon	ADV	RB	Degree=Pos	15	advmod	15:advmod	_
 14	be	be	AUX	VB	VerbForm=Inf	15	aux:pass	15:aux:pass	_
-15	filled	fill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+15	filled	fill	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj:pass|SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041120060600_ENG_20041120_060600-0006
@@ -744,7 +744,7 @@
 25	grow	grow	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=25:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 26	up	up	ADP	RP	_	25	compound:prt	25:compound:prt	_
 27	that	that	PRON	WDT	PronType=Rel	28	nsubj	23:ref	_
-28	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	_
+28	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	acl:relcl	23:acl:relcl	Cxn=rc-that-nsubj
 29	to	to	ADP	IN	_	30	case	30:case	_
 30	bin	bin	PROPN	NNP	Number=Sing	28	obl	28:obl:to	_
 31	Laden	Laden	PROPN	NNP	Number=Sing	30	flat	30:flat	_
@@ -807,7 +807,7 @@
 11	United	United	ADJ	NNP	Degree=Pos	12	amod	12:amod	_
 12	States	State	PROPN	NNPS	Number=Plur	14	nsubj	14:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	deploy	deploy	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
+14	deploy	deploy	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
 15	in	in	ADP	IN	_	17	case	17:case	_
 16	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
 17	war	war	NOUN	NN	Number=Sing	14	obl	14:obl:in	_
@@ -918,7 +918,7 @@
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	fight	fight	NOUN	NN	Number=Sing	4	obl	4:obl:in|11:nsubj	_
 10	that	that	PRON	WDT	PronType=Rel	11	nsubj	9:ref	_
-11	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	left	leave	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-nsubj
 12	one	one	NUM	CD	NumForm=Word|NumType=Card	13	nummod	13:nummod	_
 13	Iraqi	Iraqi	PROPN	NNP	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	dead	dead	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -1051,7 +1051,7 @@
 8	Iraqis	Iraqi	PROPN	NNPS	Number=Plur	5	nmod	5:nmod:of|11:nsubj	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
-11	suffer	suffer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+11	suffer	suffer	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	American	American	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	occupation	occupation	NOUN	NN	Number=Sing	11	obj	11:obj	_
@@ -1219,7 +1219,7 @@
 # text = What they wonder is whether Google can be anything more than what it's always been -- a great search engine with some real grass-roots support, successful by the grace of simplicity.
 1	What	what	PRON	WP	PronType=Rel	9	nsubj:outer	3:obj|9:nsubj:outer	_
 2	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
-3	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	wonder	wonder	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-free-obj
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 5	whether	whether	SCONJ	IN	_	9	mark	9:mark	_
 6	Google	Google	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
@@ -1233,7 +1233,7 @@
 13	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 14	's	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	16:aux	_
 15	always	always	ADV	RB	PronType=Tot	16	advmod	16:advmod	_
-16	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Promoted=Yes
+16	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
 17	--	--	PUNCT	:	_	21	punct	21:punct	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 19	great	great	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
@@ -1309,7 +1309,7 @@
 15	loyal	loyal	ADJ	JJ	Degree=Pos	0	root	0:root|18:obj	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	find	find	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	_
+18	find	find	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj
 19	--	--	PUNCT	,	_	20	punct	20:punct	_
 20	witness	witness	VERB	VB	Mood=Imp|VerbForm=Fin	15	parataxis	15:parataxis	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
@@ -1502,7 +1502,7 @@
 13	what	what	PRON	WP	PronType=Rel	11	obl	11:obl:to|16:obj	_
 14	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 15	can	can	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	expect	expect	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	_
+16	expect	expect	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-free-obj
 17	in	in	ADP	IN	_	21	case	21:case	_
 18	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
 19	new	new	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
@@ -1563,7 +1563,7 @@
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	freedom	freedom	NOUN	NN	Number=Sing	9	nmod	9:nmod:of|13:obl	_
 12	Westerners	Westerner	PROPN	NNPS	Number=Plur	13	nsubj	13:nsubj	_
-13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl-pstrand
 14	in	in	ADP	IN	_	13	obl	13:obl	Promoted=Yes|SpaceAfter=No
 15	,	,	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
 16	"	"	PUNCT	''	_	3	punct	3:punct	_
@@ -1598,7 +1598,7 @@
 5	write	write	VERB	VB	VerbForm=Inf	32	ccomp	32:ccomp	_
 6	anything	anything	PRON	NN	Number=Sing|PronType=Ind	5	obj	5:obj|8.1:obj	_
 7	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj	8:nsubj|8.1:nsubj:xsubj	_
-8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	like	like	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj_xcomp
 8.1	write	write	VERB	VB	VerbForm=Inf	_	_	8:xcomp	CopyOf=5|wordform=__EMPTY__
 9	about	about	ADP	IN	_	11	case	11:case	_
 10	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	11	nmod:poss	11:nmod:poss	_
@@ -2098,7 +2098,7 @@
 11	earlier	early	ADV	RBR	Degree=Cmp	14	advmod	14:advmod	_
 12	been	be	AUX	VBN	Tense=Past|VerbForm=Part	14	aux:pass	14:aux:pass	_
 13	absolutely	absolutely	ADV	RB	_	14	advmod	14:advmod	_
-14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
+14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass
 15	to	to	SCONJ	IN	_	16	mark	16:mark	_
 16	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:to	_
 17	out	out	ADP	RP	_	16	compound:prt	16:compound:prt	_
@@ -2184,7 +2184,7 @@
 9	Unconfirmed	Unconfirmed	ADJ	NNP	Degree=Pos	10	amod	10:amod	_
 10	Sources	Source	PROPN	NNPS	Number=Plur	8	obj	8:obj|12:nsubj	_
 11	which	which	PRON	WDT	PronType=Rel	12	nsubj	10:ref	_
-12	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+12	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nsubj
 13	some	some	DET	DT	PronType=Ind	14	det	14:det	_
 14	fun	fun	NOUN	NN	Number=Sing	12	obj	12:obj	_
 15	with	with	ADP	IN	_	17	case	17:case	_
@@ -2261,7 +2261,7 @@
 18	all	all	DET	DT	PronType=Tot	24	nsubj:outer	21:obj|24:nsubj:outer	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	US	US	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
-21	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+21	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj
 22	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
 24	give	give	VERB	VB	VerbForm=Inf	4	conj	4:conj:and	_
@@ -2305,7 +2305,7 @@
 27	European	European	ADJ	NNP	Degree=Pos	28	amod	28:amod	_
 28	Union	Union	PROPN	NNP	Number=Sing	24	obl	24:obl:through	_
 29	that	that	PRON	WDT	PronType=Rel	30	nsubj	22:ref	_
-30	meets	meet	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	acl:relcl	22:acl:relcl	_
+30	meets	meet	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	acl:relcl	22:acl:relcl	Cxn=rc-that-nsubj
 31	with	with	ADP	IN	_	33	case	33:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	approval	approval	NOUN	NN	Number=Sing	30	obl	30:obl:with	_
@@ -2360,7 +2360,7 @@
 15	that	that	PRON	WDT	PronType=Rel	18	obj	14:ref	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	group	group	NOUN	NN	Number=Sing	18	nsubj	18:nsubj	_
-18	presented	present	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
+18	presented	present	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 19	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0006
@@ -2382,7 +2382,7 @@
 14	world	world	NOUN	NN	Number=Sing	17	nsubj	17:nsubj	_
 15	’s	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	ever	ever	ADV	RB	PronType=Ind	17	advmod	17:advmod	_
-17	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
+17	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 18	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0007
@@ -2406,7 +2406,7 @@
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
 18	will	will	AUX	MD	VerbForm=Fin	15	conj	15:conj:and	_
 19	not	not	PART	RB	Polarity=Neg	18	advmod	18:advmod	_
-20	have	have	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+20	have	have	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 21	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_thelameduck_20041119192207_ENG_20041119_192207-0008
@@ -2498,7 +2498,7 @@
 20	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 21	never	never	ADV	RB	PronType=Neg	23	advmod	23:advmod	_
 22	officially	officially	ADV	RB	_	23	advmod	23:advmod	_
-23	said	say	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
+23	said	say	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
 24	that	that	SCONJ	IN	_	26	mark	26:mark	_
 25	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	26	nsubj	26:nsubj	_
 26	posses	possess	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	23	ccomp	23:ccomp	CorrectForm=possess
@@ -2636,7 +2636,7 @@
 7	uranium	uranium	NOUN	NN	Number=Sing	10	nsubj:pass	10:nsubj:pass	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	being	be	AUX	VBG	Tense=Pres|VerbForm=Part	10	aux:pass	10:aux:pass	_
-10	enriched	enrich	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+10	enriched	enrich	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
 11	,	,	PUNCT	,	_	14	punct	14:punct	_
 12	somewhat	somewhat	ADV	RB	_	14	advmod	14:advmod	_
 13	like	like	ADP	IN	_	14	case	14:case	_
@@ -2721,7 +2721,7 @@
 21	"	"	PUNCT	``	_	24	punct	24:punct	SpaceAfter=No
 22	dual	dual	ADJ	JJ	Degree=Pos	24	amod	24:amod	SpaceAfter=No
 23	-	-	PUNCT	HYPH	_	22	punct	22:punct	SpaceAfter=No
-24	citizens	citizen	NOUN	NNS	Number=Plur	15	acl:relcl	15:acl:relcl	SpaceAfter=No
+24	citizens	citizen	NOUN	NNS	Number=Plur	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
 25	"	"	PUNCT	''	_	24	punct	24:punct	SpaceAfter=No
 26	)	)	PUNCT	-RRB-	_	24	punct	24:punct	SpaceAfter=No
 27	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -2743,7 +2743,7 @@
 13	fees	fee	NOUN	NNS	Number=Plur	11	obj	11:obj|16:obj	_
 14	that	that	PRON	WDT	PronType=Rel	16	obj	13:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	charge	charge	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-that-obj
 17	for	for	SCONJ	IN	_	18	mark	18:mark	_
 18	evacuating	evacuate	VERB	VBG	Tense=Pres|VerbForm=Part	16	advcl	16:advcl:for	_
 19	U.S.	U.S.	PROPN	NNP	Number=Sing	20	compound	20:compound	_
@@ -2840,7 +2840,7 @@
 18	that	that	PRON	WDT	PronType=Rel	21	nsubj	17:ref	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	cop	21:cop	_
 20	totally	totally	ADV	RB	_	21	advmod	21:advmod	_
-21	predictable	predictable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+21	predictable	predictable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 22	.	.	PUNCT	.	_	8	punct	8:punct	_
 
 # sent_id = weblog-blogspot.com_alaindewitt_20060827093500_ENG_20060827_093500-0009
@@ -2870,14 +2870,14 @@
 9	Asia	Asia	PROPN	NNP	Number=Sing	5	nmod	5:nmod:in	_
 10	when	when	ADV	WRB	PronType=Rel	12	advmod	5:ref	_
 11	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+12	evacuated	evacuate	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl
 13	U.S.	U.S.	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	citizens	citizen	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	from	from	ADP	IN	_	16	case	16:case	_
 16	areas	area	NOUN	NNS	Number=Plur	12	obl	12:obl:from|19:nsubj:pass	_
 17	that	that	PRON	WDT	PronType=Rel	19	nsubj:pass	16:ref	_
 18	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux:pass	19:aux:pass	_
-19	hit	hit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	_
+19	hit	hit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	Cxn=rc-that-nsubj:pass
 20	by	by	ADP	IN	_	22	case	22:case	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	tsunami	tsunami	NOUN	NN	Number=Sing	19	obl:agent	19:obl:agent	_
@@ -2888,7 +2888,7 @@
 27	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	cop	30:cop	_
 28	much	much	ADV	RB	_	29	advmod	29:advmod	_
 29	less	less	ADV	RBR	Degree=Cmp	30	advmod	30:advmod	_
-30	predictable	predictable	ADJ	JJ	Degree=Pos	25	acl:relcl	25:acl:relcl	_
+30	predictable	predictable	ADJ	JJ	Degree=Pos	25	acl:relcl	25:acl:relcl	Cxn=rc-that-nsubj
 31	than	than	ADP	IN	_	36	case	36:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	36	det	36:det	_
 33	Hezbollah	Hezbollah	PROPN	NNP	Number=Sing	35	compound	35:compound	SpaceAfter=No
@@ -2896,7 +2896,7 @@
 35	provoked	provoke	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	36	amod	36:amod	_
 36	destruction	destruction	NOUN	NN	Number=Sing	30	obl	30:obl:than|38:nsubj	_
 37	that	that	PRON	WDT	PronType=Rel	38	nsubj	36:ref	_
-38	rained	rain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
+38	rained	rain	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	Cxn=rc-that-nsubj
 39	down	down	ADV	RB	_	38	advmod	38:advmod	_
 40	on	on	ADP	IN	_	41	case	41:case	_
 41	Lebanon	Lebanon	PROPN	NNP	Number=Sing	38	obl	38:obl:on	SpaceAfter=No
@@ -2984,7 +2984,7 @@
 11	among	among	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	amod	14:amod	_
-14	plaintiffs	plaintiff	NOUN	NNS	Number=Plur	1	acl:relcl	1:acl:relcl	_
+14	plaintiffs	plaintiff	NOUN	NNS	Number=Plur	1	acl:relcl	1:acl:relcl	Cxn=rc-wh-nsubj
 15	in	in	ADP	IN	_	17	case	17:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	lawsuit	lawsuit	NOUN	NN	Number=Sing	14	nmod	14:nmod:in	SpaceAfter=No
@@ -3090,7 +3090,7 @@
 11	way	way	NOUN	NN	Number=Sing	9	nsubj	9:nsubj|14:obl:unmarked	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 12	that	that	PRON	WDT	PronType=Rel	14	obl:unmarked	11:ref	_
 13	anybody	anybody	PRON	NN	Number=Sing|PronType=Ind	14	nsubj	14:nsubj	_
-14	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+14	helped	help	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obl:unmarked
 15	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -3162,11 +3162,11 @@
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	countries	country	NOUN	NNS	Number=Plur	9	obl	9:obl:in|13:nsubj|23:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	house	house	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	house	house	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
 14	illegal	illegal	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	militias	militia	NOUN	NNS	Number=Plur	13	obj	13:obj|17:nsubj	_
 16	that	that	PRON	WDT	PronType=Rel	17	nsubj	15:ref	_
-17	attack	attack	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	attack	attack	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
 18	other	other	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	countries	country	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
@@ -3290,7 +3290,7 @@
 4	example	example	NOUN	NN	Number=Sing	0	root	0:root	_
 5	of	of	ADP	IN	_	6	case	6:case	_
 6	what	what	PRON	WP	PronType=Rel	4	nmod	4:nmod:of|7:nsubj	_
-7	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+7	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-free-nsubj
 8	when	when	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
 9	Bush	Bush	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
 10	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:when	_
@@ -3301,7 +3301,7 @@
 15-16	hasn't	_	_	_	_	_	_	_	_
 15	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	17:aux	_
 16	n't	not	PART	RB	Polarity=Neg	17	advmod	17:advmod	_
-17	anticipated	anticipate	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
+17	anticipated	anticipate	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 18	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_tacitusproject_20040712123425_ENG_20040712_123425-0004
@@ -3473,7 +3473,7 @@
 13	Oval	Oval	PROPN	NNP	Number=Sing	14	compound	14:compound	_
 14	Office	Office	PROPN	NNP	Number=Sing	10	nmod	10:nmod:in	_
 15	that	that	PRON	WDT	PronType=Rel	16	nsubj	7:ref	_
-16	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+16	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	horseman	horseman	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	charging	charge	VERB	VBG	VerbForm=Ger	18	acl	18:acl	_
@@ -3836,7 +3836,7 @@
 16	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
 17	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	19:aux	_
 18	not	not	PART	RB	Polarity=Neg	19	advmod	19:advmod	_
-19	change	change	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	_
+19	change	change	VERB	VB	VerbForm=Inf	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
 20	once	once	SCONJ	IN	_	22	mark	22:mark	_
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 22	got	get	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	19	advcl	19:advcl:once	_
@@ -3997,7 +3997,7 @@
 13	today	today	NOUN	NN	Number=Sing	11	obl:unmarked	11:obl:unmarked	TemporalNPAdjunct=Yes
 14	that	that	PRON	WDT	PronType=Rel	16	nsubj	12:ref	_
 15	strongly	strongly	ADV	RB	_	16	advmod	16:advmod	_
-16	indicate	indicate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+16	indicate	indicate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj
 17	that	that	SCONJ	IN	_	21	mark	21:mark	_
 18	Google	Google	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
@@ -4170,7 +4170,7 @@
 14	Darin	Darin	PROPN	NNP	Number=Sing	5	obl	5:obl:to|17:nsubj	_
 15	Fisher	Fisher	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	who	who	PRON	WP	PronType=Rel	17	nsubj	14:ref	_
-17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	obj	17:obj	_
 19	at	at	ADP	IN	_	20	case	20:case	_
 20	Google	Google	PROPN	NNP	Number=Sing	17	obl	17:obl:at	_
@@ -4393,7 +4393,7 @@
 19	this	this	DET	DT	Number=Sing|PronType=Dem	20	det	20:det	_
 20	year	year	NOUN	NN	Number=Sing	16	obl:unmarked	16:obl:unmarked	TemporalNPAdjunct=Yes
 21	that	that	PRON	WDT	PronType=Rel	22	nsubj	18:ref	_
-22	formalizes	formalize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+22	formalizes	formalize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-that-nsubj
 23	the	the	DET	DT	Definite=Def|PronType=Art	29	det	29:det	_
 24	Google	Google	PROPN	NNP	Number=Sing	29	compound	29:compound	SpaceAfter=No
 25	-	-	SYM	SYM	_	26	cc	26:cc	SpaceAfter=No
@@ -4483,7 +4483,7 @@
 1	Every	every	DET	DT	PronType=Tot	2	det	2:det	_
 2	move	move	NOUN	NN	Number=Sing	5	nsubj	4:obj|5:nsubj	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 5	brings	bring	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 7	particular	particular	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
@@ -4549,7 +4549,7 @@
 26	source	source	NOUN	NN	Number=Sing	27	compound	27:compound	_
 27	thing	thing	NOUN	NN	Number=Sing	29	nsubj	29:nsubj	_
 28	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	about	about	ADP	IN	_	22	acl:relcl	22:acl:relcl	Promoted=Yes|SpaceAfter=No
+29	about	about	ADP	IN	_	22	acl:relcl	22:acl:relcl	Cxn=rc-free-pred-pstrand|Promoted=Yes|SpaceAfter=No
 30	.	.	PUNCT	.	_	22	punct	22:punct	_
 
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0031
@@ -4566,7 +4566,7 @@
 9	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	5	ccomp	5:ccomp	_
 10	what	what	PRON	WP	PronType=Rel	9	obj	9:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	can	can	AUX	MD	VerbForm=Fin	10	acl:relcl	10:acl:relcl	Promoted=Yes
+12	can	can	AUX	MD	VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
 13	to	to	PART	TO	_	15	mark	15:mark	_
 14	both	both	CCONJ	CC	_	15	cc:preconj	15:cc:preconj	_
 15	shape	shape	VERB	VB	VerbForm=Inf	9	advcl	9:advcl:to	_
@@ -4644,7 +4644,7 @@
 7	self	self	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	interest	interest	NOUN	NN	Number=Sing	4	nmod	4:nmod:of	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	4:ref	_
-10	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
+10	keeps	keep	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-cleft.that-nsubj
 11	large	large	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 12	open	open	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	source	source	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -4678,7 +4678,7 @@
 2	,	,	PUNCT	,	_	1	punct	1:punct	_
 3	What	what	PRON	WP	PronType=Rel	6	nsubj	5:obj|6:nsubj	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obj
 6	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 7	sense	sense	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -4706,7 +4706,7 @@
 19	source	source	NOUN	NN	Number=Sing	20	compound	20:compound	_
 20	project	project	NOUN	NN	Number=Sing	22	nsubj	22:nsubj	_
 21	will	will	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	go	go	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	SpaceAfter=No
+22	go	go	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
 23	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = weblog-typepad.com_ripples_20050410122300_ENG_20050410_122300-0037
@@ -4795,7 +4795,7 @@
 9	where	where	ADV	WRB	PronType=Rel	12	advmod	8:ref	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
+12	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obl
 13	even	even	ADV	RB	_	15	advmod	15:advmod	_
 14	Iraqi	Iraqi	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
 15	Shiites	Shiite	PROPN	NNPS	Number=Plur	12	obj	12:obj|20:nsubj	SpaceAfter=No
@@ -4803,7 +4803,7 @@
 17	who	who	PRON	WP	PronType=Rel	20	nsubj	15:ref	_
 18	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	cop	20:cop	_
 19	initially	initially	ADV	RB	_	20	advmod	20:advmod	_
-20	grateful	grateful	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	_
+20	grateful	grateful	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nsubj
 21	for	for	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	removal	removal	NOUN	NN	Number=Sing	20	obl	20:obl:for	_
@@ -4838,7 +4838,7 @@
 17	US	US	PROPN	NNP	Number=Sing	18	compound	18:compound	_
 18	troops	troops	NOUN	NNS	Number=Ptan	20	nsubj	20:nsubj|26:nsubj|28:nsubj:xsubj	_
 19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
-20	rotating	rotate	VERB	VBG	Tense=Pres|VerbForm=Part	15	acl:relcl	15:acl:relcl	_
+20	rotating	rotate	VERB	VBG	Tense=Pres|VerbForm=Part	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-obl:unmarked
 21	on	on	ADP	IN	_	24	case	24:case	_
 22	a	a	DET	DT	Definite=Ind|PronType=Art	24	det	24:det	_
 23	massive	massive	ADJ	JJ	Degree=Pos	24	amod	24:amod	_
@@ -4868,7 +4868,7 @@
 11	contingents	contingent	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
 12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	already	already	ADV	RB	_	14	advmod	14:advmod	_
-14	committed	committed	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	_
+14	committed	committed	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-obl:unmarked
 15	to	to	SCONJ	IN	_	16	mark	16:mark	_
 16	leaving	leave	VERB	VBG	Tense=Pres|VerbForm=Part	14	advcl	14:advcl:to	SpaceAfter=No
 17	,	,	PUNCT	,	_	22	punct	22:punct	_
@@ -4949,7 +4949,7 @@
 12	most	most	ADJ	JJS	Degree=Sup	15	nsubj	15:nsubj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
 14	whom	whom	PRON	WP	PronType=Rel	12	nmod	10:ref	_
-15	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+15	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
 16	no	no	DET	DT	PronType=Neg	18	det	18:det	_
 17	administrative	administrative	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	experience	experience	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
@@ -5028,7 +5028,7 @@
 13	social	social	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	experiments	experiment	NOUN	NNS	Number=Plur	11	conj	8:nmod:of|11:conj:and|18:obj	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	want	want	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obj_xcomp
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	impose	impose	VERB	VB	VerbForm=Inf	16	xcomp	16:xcomp	_
 19	on	on	ADP	IN	_	22	case	22:case	_
@@ -5107,7 +5107,7 @@
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj	5:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
-10	close	close	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	_
+10	close	close	ADJ	JJ	Degree=Pos	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 11	to	to	ADP	IN	_	14	case	14:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	Bush	Bush	PROPN	NNP	Number=Sing	14	compound	14:compound	_
@@ -5234,7 +5234,7 @@
 14	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 15	scarcely	scarcely	ADV	RB	_	17	advmod	17:advmod	_
 16	be	be	AUX	VB	VerbForm=Inf	17	aux:pass	17:aux:pass	_
-17	guessed	guess	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
+17	guessed	guess	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass-pstrand
 18	at	at	ADP	IN	_	17	obl	17:obl	Promoted=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -5402,7 +5402,7 @@
 12	which	which	PRON	WDT	PronType=Rel	15	obl	11:ref	_
 13	Hassan	Hassan	PROPN	NNP	Number=Sing	15	nsubj	15:nsubj	_
 14	Nasrallah	Nasrallah	PROPN	NNP	Number=Sing	13	flat	13:flat	_
-15	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+15	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pstrand
 16	for	for	ADP	IN	_	12	case	12:case	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	stand	stand	VERB	VB	VerbForm=Inf	9	acl	9:acl:to	_
@@ -5550,7 +5550,7 @@
 33	organization	organization	NOUN	NN	Number=Sing	30	nmod	30:nmod:with	SpaceAfter=No
 34	,	,	PUNCT	,	_	36	punct	36:punct	_
 35	which	which	PRON	WDT	PronType=Rel	36	nsubj	30:ref	_
-36	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
+36	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	Cxn=rc-wh-nsubj
 37	7	7	NUM	CD	NumForm=Digit|NumType=Card	39	nummod	39:nummod	_
 38	US	US	PROPN	NNP	Number=Sing	39	compound	39:compound	_
 39	soldiers	soldier	NOUN	NNS	Number=Plur	36	obj	36:obj|40:nsubj:xsubj	_
@@ -5601,7 +5601,7 @@
 20	CPA	CPA	PROPN	NNP	Number=Sing	23	nsubj	23:nsubj	_
 21	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	been	be	AUX	VBN	Tense=Past|VerbForm=Part	23	aux	23:aux	_
-23	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	18	acl:relcl	18:acl:relcl	SpaceAfter=No
+23	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	18	acl:relcl	18:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 24	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040404101100_ENG_20040404_101100-0029
@@ -5770,7 +5770,7 @@
 11	idea	idea	NOUN	NN	Number=Sing	7	obj	7:obj|14:obj	_
 12	what	what	PRON	WP	PronType=Rel	14	obj	11:ref	_
 13	that	that	PRON	DT	Number=Sing|PronType=Dem	14	nsubj	14:nsubj	_
-14	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+14	means	mean	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
 15	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # newdoc id = email-enronsent23_08
@@ -5990,7 +5990,7 @@
 7	pinchers	pinscher	NOUN	NNS	Number=Plur|Typo=Yes	2	advcl	2:advcl:like|10:nsubj:pass	CorrectForm=pinschers
 8	who	who	PRON	WP	PronType=Rel	10	nsubj:pass	7:ref	_
 9	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	shrunk	shrink	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	SpaceAfter=No
+10	shrunk	shrink	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass|SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_11-0007
@@ -6050,7 +6050,7 @@
 4	in	in	ADP	IN	_	5	case	5:case	_
 5	college	college	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	3:ref	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj
 8	one	one	NUM	CD	NumForm=Word|NumType=Card	7	obj	7:obj	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
@@ -6187,7 +6187,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	administartion	administration	NOUN	NN	Number=Sing|Typo=Yes	8	nsubj	8:nsubj	CorrectForm=administration
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
-8	acting	act	VERB	VBG	Tense=Pres|VerbForm=Part	2	acl:relcl	2:acl:relcl	_
+8	acting	act	VERB	VBG	Tense=Pres|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-obl-pfront
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	cop	24:cop	_
 10	that	that	SCONJ	IN	_	24	mark	24:mark	_
 11	if	if	SCONJ	IN	_	14	mark	14:mark	_
@@ -6214,7 +6214,7 @@
 31	access	access	NOUN	NN	Number=Sing	32	compound	32:compound	_
 32	coalition	coalition	NOUN	NN	Number=Sing	34	nsubj	34:nsubj	_
 33	must	must	AUX	MD	VerbForm=Fin	34	aux	34:aux	_
-34	break	break	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	_
+34	break	break	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	Cxn=rc-wh-obl-pstrand
 35	through	through	ADP	IN	_	28	case	28:case	SpaceAfter=No
 36	.	.	PUNCT	.	_	24	punct	24:punct	_
 
@@ -6239,7 +6239,7 @@
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	dishes	dish	NOUN	NNS	Number=Plur	9	nsubj:pass	9:nsubj:pass	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl:relcl	5:advcl:relcl	SpaceAfter=No
+9	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	advcl:relcl	5:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent05_01-0008
@@ -6330,7 +6330,7 @@
 2	be	be	AUX	VB	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	where	where	ADV	WRB	PronType=Rel	0	root	0:root|5:advmod	_
 4	power	power	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
-5	lies	lie	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	SpaceAfter=No
+5	lies	lie	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = email-enronsent23_14
@@ -7086,7 +7086,7 @@
 14	which	which	PRON	WDT	PronType=Rel	17	obl	10:ref	_
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	17:nsubj:pass	_
 16	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	17:aux:pass	_
-17	addressed	address	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	_
+17	addressed	address	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-obl-pfront
 18	and	and	CCONJ	CC	_	20	cc	20:cc	_
 19	may	may	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 20	contain	contain	VERB	VB	VerbForm=Inf	6	conj	6:conj:and	_
@@ -7294,7 +7294,7 @@
 7	companies	company	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 8	who	who	PRON	WP	PronType=Rel	10	nsubj	7:ref	_
 9	all	all	DET	DT	PronType=Tot	10	advmod	10:advmod	_
-10	bid	bid	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+10	bid	bid	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 11	higher	high	ADV	RBR	Degree=Cmp	10	advmod	10:advmod	_
 12	than	than	ADP	IN	_	13	case	13:case	_
 13	ENA	ENA	PROPN	NNP	Number=Sing	11	obl	11:obl:than	SpaceAfter=No
@@ -7477,7 +7477,7 @@
 8	sources	source	NOUN	NNS	Number=Plur	6	obl	6:obl:on|11:obj|14:nsubj:xsubj	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	8:ref	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+11	believe	believe	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-obj
 12	to	to	PART	TO	_	14	mark	14:mark	_
 13	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 14	reliable	reliable	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -7834,7 +7834,7 @@
 11	agreement	agreement	NOUN	NN	Number=Sing	7	nmod	7:nmod:of	SpaceAfter=No
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	which	which	PRON	WDT	PronType=Rel	14	nsubj	7:ref	_
-14	reads	read	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+14	reads	read	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	part	part	NOUN	NN	Number=Sing	14	obl	14:obl:in	SpaceAfter=No
 17	:	:	PUNCT	:	_	20	punct	20:punct	_
@@ -7861,7 +7861,7 @@
 38	counterparty	counterparty	NOUN	NN	Number=Sing	41	nsubj	41:nsubj	_
 39	will	will	AUX	MD	VerbForm=Fin	41	aux	41:aux	_
 40	be	be	AUX	VB	VerbForm=Inf	41	aux	41:aux	_
-41	transporting	transport	VERB	VBG	Tense=Pres|VerbForm=Part	35	acl:relcl	35:acl:relcl	_
+41	transporting	transport	VERB	VBG	Tense=Pres|VerbForm=Part	35	acl:relcl	35:acl:relcl	Cxn=rc-that-obj
 42	on	on	ADP	IN	_	43	case	43:case	_
 43	HPL	hpl	NOUN	NN	Number=Sing	41	obl	41:obl:on	_
 44	may	may	AUX	MD	VerbForm=Fin	32	advcl	32:advcl:because	_
@@ -7990,7 +7990,7 @@
 17	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
 18	both	both	ADV	RB	_	20	advmod	20:advmod	_
 19	previously	previously	ADV	RB	_	20	advmod	20:advmod	_
-20	approved	approve	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	SpaceAfter=No
+20	approved	approve	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
 21	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent28_03-0017
@@ -8303,7 +8303,7 @@
 2	to	to	ADP	IN	_	3	case	3:case	_
 3	all	all	DET	DT	PronType=Tot	1	nmod	1:nmod:to|5:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	5	nsubj	3:ref	_
-5	volunteered	volunteer	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	SpaceAfter=No
+5	volunteered	volunteer	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
 6	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent01_01-0009
@@ -8912,7 +8912,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	little	little	ADJ	JJ	Degree=Pos	13	obl:unmarked	13:obl:unmarked	_
-13	sooner	soon	ADJ	JJR	Degree=Cmp	8	acl:relcl	8:acl:relcl	_
+13	sooner	soon	ADJ	JJR	Degree=Cmp	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
 14	than	than	SCONJ	IN	_	16	mark	16:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
 16	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	13	advcl	13:advcl:than	_
@@ -9011,7 +9011,7 @@
 7	like	like	ADP	IN	_	8	case	8:case	_
 8	that	that	PRON	DT	Number=Sing|PronType=Dem	6	nmod	6:nmod:like	_
 9	which	which	PRON	WDT	PronType=Rel	10	nsubj	6:ref	MissingWordAfter=Yes
-10	working	work	VERB	VBG	VerbForm=Ger	6	acl:relcl	6:acl:relcl	_
+10	working	work	VERB	VBG	VerbForm=Ger	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj
 11	through	through	ADV	RB	_	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -9241,7 +9241,7 @@
 4	next	next	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	time	time	NOUN	NN	Number=Sing	3	obl:unmarked	3:obl:unmarked|7:obl	TemporalNPAdjunct=Yes
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
 8	amstel	Amstel	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	lights	Light	PROPN	NNPS	Number=Plur	7	obj	7:obj	_
 10	together	together	ADV	RB	_	7	advmod	7:advmod	SpaceAfter=No
@@ -9527,7 +9527,7 @@
 14	there	there	PRON	EX	_	17	expl	17:expl	_
 15	could	could	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 16	be	be	AUX	VB	VerbForm=Inf	17	cop	17:cop	_
-17	love	love	NOUN	NN	Number=Sing	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+17	love	love	NOUN	NN	Number=Sing	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
 19	self	self	NOUN	NN	Number=Sing	21	compound	21:compound	SpaceAfter=No
 20	-	-	PUNCT	HYPH	_	19	punct	19:punct	SpaceAfter=No
@@ -9593,7 +9593,7 @@
 15	that	that	PRON	WDT	PronType=Rel	20	obl	14:ref	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj|20:nsubj:xsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
-18	had	have	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	_
+18	had	have	VERB	VBN	Tense=Past|VerbForm=Part	14	acl:relcl	14:acl:relcl	Cxn=rc-that-obl_xcomp-pstrand
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	do	do	VERB	VB	VerbForm=Inf	18	xcomp	18:xcomp	_
 21	without	without	ADP	IN	_	15	case	15:case	SpaceAfter=No
@@ -9616,7 +9616,7 @@
 13	situation	situation	NOUN	NN	Number=Sing	11	conj	6:obl:on|11:conj:or|16:nsubj|23:nsubj	_
 14	that	that	PRON	WDT	PronType=Rel	16	nsubj	11:ref	_
 15	could	could	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
-16	give	give	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
+16	give	give	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
 17	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	16	iobj	16:iobj	_
 18	greater	great	ADJ	JJR	Degree=Cmp	19	amod	19:amod	_
 19	prestige	prestige	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -9663,7 +9663,7 @@
 29	all	all	DET	PDT	PronType=Tot	30	det:predet	30:det:predet	_
 30	those	that	PRON	DT	Number=Plur|PronType=Dem	20	obl	20:obl:to|32:nsubj	_
 31	that	that	PRON	WDT	PronType=Rel	32	nsubj	30:ref	_
-32	show	show	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	_
+32	show	show	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	acl:relcl	30:acl:relcl	Cxn=rc-that-nsubj
 33	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	32	iobj	32:iobj	_
 34	a	a	DET	DT	Definite=Ind|PronType=Art	36	det	36:det	_
 35	little	little	ADJ	JJ	Degree=Pos	36	amod	36:amod	_
@@ -9735,7 +9735,7 @@
 6	and	and	CCONJ	CC	_	19	cc	19:cc	_
 7	all	all	DET	DT	PronType=Tot	19	nsubj	9:obj|19:nsubj	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	demand	demand	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj
 10	from	from	ADP	IN	_	11	case	11:case	_
 11	life	life	NOUN	NN	Number=Sing	9	obl	9:obl:from	SpaceAfter=No
 12	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -9749,7 +9749,7 @@
 20	whom	whom	PRON	WP	PronType=Rel	23	iobj	19:ref	_
 21	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	23	nsubj	23:nsubj	_
 22	can	can	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
-23	trust	trust	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	_
+23	trust	trust	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-wh-iobj
 24	and	and	CCONJ	CC	_	32	cc	32:cc	_
 25	with	with	ADP	IN	_	26	case	26:case	_
 26	whom	whom	PRON	WP	PronType=Rel	32	obl	19:ref	_
@@ -9805,7 +9805,7 @@
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	all	all	DET	DT	PronType=Tot	16	nsubj	14:obj|16:nsubj|21:nsubj	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
-14	seek	seek	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	seek	seek	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	sincerity	sincerity	NOUN	NN	Number=Sing	2	conj	2:conj:and	_
 17	and	and	CCONJ	CC	_	21	cc	21:cc	_
@@ -9864,7 +9864,7 @@
 # text = All you want is for "them" to get on with it - and to leave you alone..
 1	All	all	DET	DT	PronType=Tot	10	nsubj:outer	3:obj|10:nsubj:outer|17:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	10:cop	_
 5	for	for	SCONJ	IN	_	10	mark	10:mark	_
 6	"	"	PUNCT	``	_	7	punct	7:punct	SpaceAfter=No
@@ -9966,7 +9966,7 @@
 9	file	file	NOUN	NN	Number=Sing	4	obj	4:obj|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	created	create	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+12	created	create	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-obj
 13	for	for	ADP	IN	_	17	case	17:case	_
 14-15	Lavo's	_	_	_	_	_	_	_	_
 14	Lavo	Lavo	PROPN	NNP	Number=Sing	17	nmod:poss	17:nmod:poss	_
@@ -10274,7 +10274,7 @@
 38	that	that	PRON	WDT	PronType=Rel	41	obl	32:ref	_
 39	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	41	nsubj	41:nsubj	_
 40	can	can	AUX	MD	VerbForm=Fin	41	aux	41:aux	_
-41	speak	speak	VERB	VB	VerbForm=Inf	32	acl:relcl	32:acl:relcl	_
+41	speak	speak	VERB	VB	VerbForm=Inf	32	acl:relcl	32:acl:relcl	Cxn=rc-that-obl-pstrand
 42	to	to	ADP	IN	_	38	case	32:case	SpaceAfter=No
 43	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -10408,7 +10408,7 @@
 15	issues	issue	NOUN	NNS	Number=Plur	13	conj	11:obj|13:conj:or	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	may	may	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	_
+18	have	have	VERB	VB	VerbForm=Inf	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
 19	regarding	regard	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
 20	this	this	DET	DT	Number=Sing|PronType=Dem	21	det	21:det	_
 21	matter	matter	NOUN	NN	Number=Sing	13	nmod	13:nmod:regarding	SpaceAfter=No
@@ -10587,7 +10587,7 @@
 3	agreement	agreement	NOUN	NN	Number=Sing	11	nsubj	6:obj|11:nsubj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
-6	find	find	VERB	VB	VerbForm=Inf	3	acl:relcl	3:acl:relcl	_
+6	find	find	VERB	VB	VerbForm=Inf	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obj
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 9	Master	master	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -10739,7 +10739,7 @@
 5-6	your	_	_	_	_	_	_	_	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	r	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|Typo=Yes|VerbForm=Fin	7	aux	7:aux	CorrectForm='re
-7	referencing	reference	VERB	VBG	Tense=Pres|VerbForm=Part	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+7	referencing	reference	VERB	VBG	Tense=Pres|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 8	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent29_01-0047
@@ -11130,7 +11130,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	data	data	NOUN	NN	Number=Sing	3	obj	3:obj|8:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+8	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 9	:	:	PUNCT	:	_	3	punct	3:punct	_
 10	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	shall	shall	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
@@ -11458,7 +11458,7 @@
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	uncertainties	uncertainty	NOUN	NNS	Number=Plur	5	obl	5:obl:given|11:obj	_
 10	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
-11	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+11	face	face	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 12	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent19_02-0027
@@ -11565,7 +11565,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	who	who	PRON	WP	PronType=Rel	20	nsubj	15:ref	_
 19	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	cop	20:cop	_
-20	responsible	responsible	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	_
+20	responsible	responsible	ADJ	JJ	Degree=Pos	15	acl:relcl	15:acl:relcl	Cxn=rc-wh-nsubj
 21	for	for	ADP	IN	_	23	case	23:case	_
 22	Georgia	Georgia	PROPN	NNP	Number=Sing	23	compound	23:compound	_
 23	Tech	Tech	PROPN	NNP	Number=Sing	20	obl	20:obl:for	_
@@ -11823,7 +11823,7 @@
 4	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:obl	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj:pass	7:nsubj:pass	_
 6	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+7	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-free-obl|SpaceAfter=No
 8	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent19_02-0053
@@ -12069,7 +12069,7 @@
 6	employees	employee	NOUN	NNS	Number=Plur	3	obl	3:obl:to|9:nsubj:pass	_
 7	who	who	PRON	WP	PronType=Rel	9	nsubj:pass	6:ref	_
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	_
+9	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj:pass
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
@@ -12087,7 +12087,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	tax	tax	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	law	law	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
-6	works	work	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	SpaceAfter=No
+6	works	work	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
 7	,	,	PUNCT	,	_	2	punct	2:punct	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	tax	tax	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -12313,7 +12313,7 @@
 8	time	time	NOUN	NN	Number=Sing	6	conj	4:obj|6:conj:and	_
 9	that	that	PRON	WDT	PronType=Rel	11	nsubj	6:ref	_
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
-11	convenient	convenient	ADJ	JJ	Degree=Pos	6	acl:relcl	6:acl:relcl	_
+11	convenient	convenient	ADJ	JJ	Degree=Pos	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
 12	for	for	ADP	IN	_	13	case	13:case	_
 13	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	11	obl	11:obl:for	SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -12804,7 +12804,7 @@
 4	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	5	nmod:poss	5:nmod:poss	_
 5	clients	client	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 6	usually	usually	ADV	RB	_	7	advmod	7:advmod	_
-7	evaluate	evaluate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	_
+7	evaluate	evaluate	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod
 8	these	this	DET	DT	Number=Plur|PronType=Dem	9	det	9:det	_
 9	properties	property	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -12840,7 +12840,7 @@
 6	limitations	limitation	NOUN	NNS	Number=Plur	3	obl	3:obl:than|9:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	were	be	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	aux	9:aux	_
-9	describing	describe	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+9	describing	describe	VERB	VBG	Tense=Pres|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 10	in	in	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	meeting	meeting	NOUN	NN	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
@@ -12904,7 +12904,7 @@
 # text = All you have to do is sign up for one free offer (such as efax) and then cancel within the offer time frame.
 1	All	all	DET	DT	PronType=Tot	7	nsubj:outer	5:obj|7:nsubj:outer|20:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj_xcomp
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -13086,7 +13086,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13143,7 +13143,7 @@
 1	for	for	ADP	IN	_	2	case	2:case	_
 2	Books	book	NOUN	NNS	Number=Plur	0	root	0:root|4:nsubj	_
 3	that	that	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	Speak	speak	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	Themselves	themselves	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	4	obl	4:obl:for	SpaceAfter=No
 7	....	....	PUNCT	,	_	2	punct	2:punct	_
@@ -13252,7 +13252,7 @@
 2	a	a	DET	DT	Definite=Ind|PronType=Art	3	det	3:det	_
 3	moment	moment	NOUN	NN	Number=Sing	0	root	0:root|5:nsubj	_
 4	that	that	PRON	WDT	PronType=Rel	5	nsubj	3:ref	_
-5	speaks	speak	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	speaks	speak	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-that-nsubj
 6	for	for	ADP	IN	_	7	case	7:case	_
 7	itself	itself	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obl	5:obl:for	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -13336,7 +13336,7 @@
 4	program	program	NOUN	NN	Number=Sing	1	obj	1:obj|7:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	7	nsubj	4:ref	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
-7	generate	generate	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	_
+7	generate	generate	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	blast	blast	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	16	case	16:case	_
@@ -13358,7 +13358,7 @@
 # text = All you have to do is become a member and watch your earnings grow!
 1	All	all	DET	DT	PronType=Tot	7	nsubj:outer	3:obj|7:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	do	do	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
@@ -13609,7 +13609,7 @@
 3	update	update	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 4	whatever	whatever	PRON	WP	PronType=Rel	3	obj	3:obj|6:xcomp	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-free-xcomp-auxstrand
 7	to	to	PART	TO	_	6	xcomp	4:mark	Promoted=Yes
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	go	go	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	_
@@ -13674,7 +13674,7 @@
 23	text	text	NOUN	NN	Number=Sing	21	obj	21:obj|26:obj	_
 24	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj:pass	26:nsubj:pass|28:nsubj:xsubj	CorrectSpaceAfter=Yes|SpaceAfter=No
 25	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	26	aux:pass	26:aux:pass	_
-26	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	23	acl:relcl	23:acl:relcl	_
+26	supposed	suppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obj
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	put	put	VERB	VB	VerbForm=Inf	26	xcomp	26:xcomp	_
 29	up	up	ADV	RB	_	28	advmod	28:advmod	_
@@ -13821,14 +13821,14 @@
 12	where	where	ADV	WRB	PronType=Rel	15	advmod	11:ref	_
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
 14	can	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	hear	hear	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
+15	hear	hear	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
 16	talking	talk	VERB	VBG	VerbForm=Ger	17	amod	17:amod	_
 17	parakeets	parakeet	NOUN	NNS	Number=Plur	15	obj	15:obj|22:nsubj|26:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	22	nsubj	17:ref	_
 19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	22:aux	_
 20	not	not	PART	RB	Polarity=Neg	22	advmod	22:advmod	_
 21	just	just	ADV	RB	_	22	advmod	22:advmod	_
-22	mimicking	mimic	VERB	VBG	Tense=Pres|VerbForm=Part	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+22	mimicking	mimic	VERB	VBG	Tense=Pres|VerbForm=Part	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 23	,	,	PUNCT	,	_	26	punct	26:punct	_
 24	but	but	CCONJ	CC	_	26	cc	26:cc	_
 25	actually	actually	ADV	RB	_	26	advmod	26:advmod	_
@@ -13998,7 +13998,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	friend	friend	NOUN	NN	Number=Sing	2	obj	2:obj|6:nsubj|8:nsubj:xsubj|9:nsubj:xsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	get	get	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	rid	rid	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	_
@@ -14158,7 +14158,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	treatment	treatment	NOUN	NN	Number=Sing	2	obl	2:obl:to|7:obj	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
-7	receive	receive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+7	receive	receive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 8	,	,	PUNCT	,	_	12	punct	12:punct	_
 9	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
@@ -14194,7 +14194,7 @@
 5	people	people	NOUN	NNS	Number=Plur	3	obl	3:obl:for|8:nsubj|10:nsubj:xsubj|16:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	like	like	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
+8	like	like	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	play	play	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	D	D	PROPN	NNP	Number=Sing	10	obj	10:obj	SpaceAfter=No
@@ -14652,7 +14652,7 @@
 28	Rahu	Rahu	PROPN	NNP	Number=Sing	26	nmod	26:nmod:of	_
 29	which	which	PRON	WDT	PronType=Rel	31	nsubj	26:ref	_
 30	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
-31	resulted	result	VERB	VBN	Tense=Past|VerbForm=Part	26	acl:relcl	26:acl:relcl	_
+31	resulted	result	VERB	VBN	Tense=Past|VerbForm=Part	26	acl:relcl	26:acl:relcl	Cxn=rc-wh-nsubj
 32	into	into	ADP	IN	_	33	case	33:case	_
 33	floods	flood	NOUN	NNS	Number=Plur	31	obl	31:obl:into	_
 34	in	in	ADP	IN	_	36	case	36:case	_
@@ -14952,7 +14952,7 @@
 1	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	12	obl:unmarked	4:obl|12:obl:unmarked	TemporalNPAdjunct=Yes
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|5:nsubj:xsubj	_
-4	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
 5	wearing	wear	VERB	VBG	VerbForm=Ger	4	xcomp	4:xcomp	_
 6-7	woman's	_	_	_	_	_	_	_	_
 6	woman	woman	NOUN	NN	Number=Sing	8	nmod:poss	8:nmod:poss	_
@@ -15108,7 +15108,7 @@
 17	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	18	amod	18:amod	_
 18	thing	thing	NOUN	NN	Number=Sing	22	nsubj:outer	20:obj|22:nsubj:outer	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+20	do	do	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj
 21	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	cop	18:cop	_
 22	change	change	VERB	VB	VerbForm=Inf	2	parataxis	2:parataxis	_
 23	into	into	ADP	IN	_	27	case	27:case	_
@@ -15155,7 +15155,7 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	masses	mass	NOUN	NNS	Number=Plur	0	root	0:root|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	lot	lot	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	of	of	ADP	IN	_	14	case	14:case	_
@@ -15223,7 +15223,7 @@
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
 28	services	service	NOUN	NNS	Number=Plur	26	conj	12:obl:on|26:conj:and	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	_
+30	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl:relcl	26:acl:relcl	Cxn=rc-red-obj
 31	from	from	ADP	IN	_	33	case	33:case	_
 32	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 33	airlines	airline	NOUN	NNS	Number=Plur	30	obl	30:obl:from	SpaceAfter=No
@@ -15322,7 +15322,7 @@
 20	which	which	PRON	WDT	PronType=Rel	23	nsubj	18:ref	_
 21	may	may	AUX	MD	VerbForm=Fin	23	aux	23:aux	_
 22	even	even	ADV	RB	_	23	advmod	23:advmod	_
-23	surprise	surprise	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	_
+23	surprise	surprise	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-nsubj
 24	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	23	obj	23:obj	SpaceAfter=No
 25	.	.	PUNCT	.	_	15	punct	15:punct	_
 
@@ -15358,7 +15358,7 @@
 18	pilot	pilot	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	study	study	NOUN	NN	Number=Sing	21	obl	21:obl:in	SpaceAfter=No
 20	,	,	PUNCT	,	_	19	punct	19:punct	_
-21	discriminated	discriminate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+21	discriminated	discriminate	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
 22	between	between	ADP	IN	_	23	case	23:case	_
 23	ADHD	adhd	NOUN	NN	Number=Sing	21	obl	21:obl:between	SpaceAfter=No
 24	,	,	PUNCT	,	_	25	punct	25:punct	_
@@ -15401,7 +15401,7 @@
 28	any	anyone	PRON	GW	Number=Sing|PronType=Ind|Typo=Yes	26	obl	26:obl:to|31:nsubj	_
 29	one	_	X	NN	_	28	goeswith	28:goeswith	_
 30	who	who	PRON	WP	PronType=Rel	31	nsubj	28:ref	_
-31	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
+31	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-wh-nsubj
 32	access	access	NOUN	NN	Number=Sing	31	obj	31:obj	_
 33	to	to	ADP	IN	_	35	case	35:case	_
 34	a	a	DET	DT	Definite=Ind|PronType=Art	35	det	35:det	_
@@ -15419,7 +15419,7 @@
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 5	what	what	PRON	WP	PronType=Rel	0	root	0:root|7:nsubj:pass|10:nsubj:xsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	_
+7	called	call	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	5	acl:relcl	5:acl:relcl	Cxn=rc-free-nsubj:pass
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	substitution	substitution	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	test	test	NOUN	NN	Number=Sing	7	xcomp	7:xcomp	SpaceAfter=No
@@ -15436,7 +15436,7 @@
 7	of	of	ADP	IN	_	8	case	8:case	_
 8	which	which	PRON	WDT	PronType=Rel	6	nmod	4:ref	_
 9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	timed	time	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	_
+10	timed	time	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nmod_nsubj:pass-pfront
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	90	90	NUM	CD	NumForm=Digit|NumType=Card	13	nummod	13:nummod	_
 13	seconds	second	NOUN	NNS	Number=Plur	10	obl	10:obl:for	_
@@ -15574,7 +15574,7 @@
 5	out	out	ADV	RB	_	6	advmod	6:advmod	_
 6	there	there	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 7	who	who	PRON	WP	PronType=Rel	8	nsubj	4:ref	_
-8	share	share	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+8	share	share	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	same	same	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	tastes	taste	NOUN	NNS	Number=Plur	8	obj	8:obj	_
@@ -15694,7 +15694,7 @@
 4	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	2	nmod	2:nmod:to|7:nsubj:pass	_
 5	who	who	PRON	WP	PronType=Rel	7	nsubj:pass	4:ref	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux:pass	7:aux:pass	_
-7	offended	offend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	_
+7	offended	offend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj:pass
 8	by	by	ADP	IN	_	10	case	10:case	_
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	request	request	NOUN	NN	Number=Sing	7	obl:agent	7:obl:agent	_
@@ -15959,7 +15959,7 @@
 13	dieters	dieter	NOUN	NNS	Number=Plur	3	obl	3:obl:from|16:nsubj	_
 14	who	who	PRON	WP	PronType=Rel	16	nsubj	13:ref	_
 15	successfully	successfully	ADV	RB	_	16	advmod	16:advmod	_
-16	used	use	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	used	use	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	natural	natural	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	supplement	supplement	NOUN	NN	Number=Sing	16	obj	16:obj	_
@@ -16221,7 +16221,7 @@
 16	people	people	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	suddenly	suddenly	ADV	RB	_	19	advmod	19:advmod	_
-19	discovered	discover	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	_
+19	discovered	discover	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obl:unmarked
 20	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 21	fertilizer	fertilizer	NOUN	NN	Number=Sing	29	nsubj	29:nsubj|32:nsubj	_
 22	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
@@ -16513,7 +16513,7 @@
 13	for	for	ADP	IN	_	14	case	14:case	_
 14	which	which	PRON	WDT	PronType=Rel	16	obl	12:ref	_
 15	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
-16	qualified	qualify	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+16	qualified	qualify	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obl-pfront
 17	prior	prior	ADJ	JJ	Degree=Pos|ExtPos=ADP	20	case	20:case	_
 18	to	to	ADP	IN	_	17	fixed	17:fixed	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
@@ -16743,7 +16743,7 @@
 18	oil	oil	NOUN	NN	Number=Sing	19	compound	19:compound	_
 19	operations	operation	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+21	based	base	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = newsgroup-groups.google.com_marketplace_e019a6deff0a1c7f_ENG_20050922_024300-0007
@@ -16860,7 +16860,7 @@
 5	bellow	bellow	ADV	RB	_	4	advmod	4:advmod	_
 6	which	which	PRON	WDT	PronType=Rel	8	nsubj	4:ref	_
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
-8	excelnt	excellent	ADJ	JJ	Degree=Pos|Typo=Yes	4	acl:relcl	4:acl:relcl	CorrectForm=excellent
+8	excelnt	excellent	ADJ	JJ	Degree=Pos|Typo=Yes	4	acl:relcl	4:acl:relcl	CorrectForm=excellent|Cxn=rc-wh-nsubj
 9	,	,	PUNCT	,	_	10	punct	10:punct	SpaceAfter=No
 10	thank	thanks	NOUN	NN	Number=Sing	2	parataxis	2:parataxis	_
 11	for	for	ADP	IN	_	13	case	13:case	_
@@ -16982,7 +16982,7 @@
 10	,	,	PUNCT	,	_	13	punct	13:punct	_
 11	which	which	PRON	WDT	PronType=Rel	13	nsubj	4:ref	_
 12	only	only	ADV	RB	_	13	advmod	13:advmod	_
-13	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
+13	leaves	leave	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-wh-csubj
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	with	with	ADP	IN	_	17	case	17:case	_
 16	18	18	NUM	CD	NumForm=Digit|NumType=Card	17	nummod	17:nummod	_
@@ -17290,14 +17290,14 @@
 31	land	land	NOUN	NN	Number=Sing	28	obj	28:obj|34:obj|41:nsubj	_
 32	that	that	PRON	WDT	PronType=Rel	34	obj	31:ref	_
 33	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	34	nsubj	34:nsubj	_
-34	occupies	occupy	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	_
+34	occupies	occupy	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	Cxn=rc-that-obj
 35	before	before	ADP	IN	_	38	case	38:case	_
 36	the	the	DET	DT	Definite=Def|PronType=Art	38	det	38:det	_
 37	1967	1967	NUM	CD	NumForm=Digit|NumType=Card	38	nummod	38:nummod	_
 38	border	border	NOUN	NN	Number=Sing	34	obl	34:obl:before	_
 39	(	(	PUNCT	-LRB-	_	41	punct	41:punct	SpaceAfter=No
 40	which	which	PRON	WDT	PronType=Rel	41	nsubj	31:ref	_
-41	includes	include	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	_
+41	includes	include	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	acl:relcl	31:acl:relcl	Cxn=rc-wh-nsubj
 42	East	East	PROPN	NNP	Number=Sing	43	compound	43:compound	_
 43	Jerusalem	Jerusalem	PROPN	NNP	Number=Sing	41	obj	41:obj	_
 44	by	by	ADP	IN	_	46	case	46:case	_
@@ -17343,7 +17343,7 @@
 23	which	which	PRON	WDT	PronType=Rel	26	nsubj	21:ref	_
 24	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
 25	probably	probably	ADV	RB	_	26	advmod	26:advmod	_
-26	done	do	VERB	VBN	Tense=Past|VerbForm=Part	21	acl:relcl	21:acl:relcl	_
+26	done	do	VERB	VBN	Tense=Past|VerbForm=Part	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-nsubj
 27	a	a	DET	DT	Definite=Ind|PronType=Art	29	det	29:det	_
 28	better	good	ADJ	JJR	Degree=Cmp	29	amod	29:amod	_
 29	job	job	NOUN	NN	Number=Sing	26	obj	26:obj	_
@@ -17549,7 +17549,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 11	northern	northern	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 12	Israeli	Israeli	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	city	city	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	_
+13	city	city	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	Cxn=rc-free-nsubj
 14	of	of	ADP	IN	_	15	case	15:case	_
 15	Safed	Safed	PROPN	NNP	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
 16	,	,	PUNCT	,	_	1	punct	1:punct	_
@@ -17801,7 +17801,7 @@
 22	Defense	Defense	PROPN	NNP	Number=Sing	23	compound	23:compound	_
 23	Forces	Force	PROPN	NNPS	Number=Plur	25	nsubj	25:nsubj	_
 24	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
-25	unleashed	unleash	VERB	VBN	Tense=Past|VerbForm=Part	19	acl:relcl	19:acl:relcl	_
+25	unleashed	unleash	VERB	VBN	Tense=Past|VerbForm=Part	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj
 26	upon	upon	ADP	IN	_	29	case	29:case	_
 27	this	this	DET	DT	Number=Sing|PronType=Dem	29	det	29:det	_
 28	terrorist	terrorist	NOUN	NN	Number=Sing	29	compound	29:compound	_
@@ -18082,7 +18082,7 @@
 18	time	time	NOUN	NN	Number=Sing	11	obl	11:obl:by|21:obl	_
 19	Israel	Israel	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 20	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	cop	21:cop	_
-21	done	done	ADJ	JJ	Degree=Pos	18	acl:relcl	18:acl:relcl	_
+21	done	done	ADJ	JJ	Degree=Pos	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl
 22	reminding	remind	VERB	VBG	Tense=Pres|VerbForm=Part	21	advcl	21:advcl	_
 23	Hamas	Hamas	PROPN	NNP	Number=Sing	22	iobj	22:iobj	_
 24	of	of	ADP	IN	_	27	case	27:case	_
@@ -18097,7 +18097,7 @@
 33	thing	thing	NOUN	NN	Number=Sing	38	nsubj:outer	36:obj|38:nsubj:outer|41:nsubj:outer	_
 34	Abbas	Abbas	PROPN	NNP	Number=Sing	36	nsubj	36:nsubj	_
 35	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	36	aux	36:aux	_
-36	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	33	acl:relcl	33:acl:relcl	_
+36	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	33	acl:relcl	33:acl:relcl	Cxn=rc-red-obj
 37	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	38	cop	38:cop	_
 38	lashing	lash	VERB	VBG	Tense=Pres|VerbForm=Part	11	advcl	11:advcl:although	_
 39	out	out	ADP	RP	_	38	compound:prt	38:compound:prt	_
@@ -18446,7 +18446,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	stuff	stuff	NOUN	NN	Number=Sing	1	nmod	1:nmod:like|6:obj	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	eat	eat	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	Spanish	Spanish	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	countries	country	NOUN	NNS	Number=Plur	6	obl	6:obl:in	_
@@ -18561,7 +18561,7 @@
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 8	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 9	easily	easily	ADV	RB	_	10	advmod	10:advmod	_
-10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
+10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obj
 11	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	10	advcl	10:advcl	_
 12	any	any	DET	DT	PronType=Ind	14	det	14:det	_
 13	search	search	NOUN	NN	Number=Sing	14	compound	14:compound	_
@@ -18606,7 +18606,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	company	company	NOUN	NN	Number=Sing	5	nmod	5:nmod:from|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
 11	mold	mold	NOUN	NN	Number=Sing	12	compound	12:compound	_
 12	making	making	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	materials	material	NOUN	NNS	Number=Plur	10	obj	10:obj	_
@@ -18773,7 +18773,7 @@
 8	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	9	amod	9:amod	_
 9	person	person	NOUN	NN	Number=Sing	3	obl	3:obl:for|11:nsubj	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	9:ref	_
-11	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj|13:nsubj:xsubj	_
 13	right	right	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 14	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -18949,7 +18949,7 @@
 8	any	anywhere	ADV	GW	PronType=Ind|Typo=Yes	7	advmod	7:advmod|11:obl	CorrectForm=anywhere
 9	were	_	X	RB	_	8	goeswith	8:goeswith	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl:relcl	8:advcl:relcl	_
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	advcl:relcl	8:advcl:relcl	Cxn=rc-red-obl
 
 # newdoc id = answers-20100605133330AAeW6nm_ans
 # sent_id = answers-20100605133330AAeW6nm_ans-0001
@@ -19085,7 +19085,7 @@
 8	and	any	DET	DT	PronType=Ind|Typo=Yes	9	det	9:det	CorrectForm=any
 9	name	name	NOUN	NN	Number=Sing	7	obj	7:obj|11:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
 
 # sent_id = answers-20111108102900AA9qsc8_ans-0005
 # newpar id = answers-20111108102900AA9qsc8_ans-p0005
@@ -19259,7 +19259,7 @@
 1	the	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	one	one	NOUN	NN	Number=Sing	9	nsubj	4:obj|9:nsubj	_
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	most	most	ADV	RBS	Degree=Sup	4	advmod	4:advmod	_
 7	would	would	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
@@ -19601,7 +19601,7 @@
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	link	link	NOUN	NN	Number=Sing	3	obj	3:obj|7:nsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
 8	all	all	DET	PDT	PronType=Tot	11	det:predet	11:det:predet	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 10	art	art	NOUN	NN	Number=Sing	11	compound	11:compound	_
@@ -19609,7 +19609,7 @@
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj:pass	11:ref	_
 13	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
 14	never	never	ADV	RB	PronType=Neg	15	advmod	15:advmod	_
-15	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	_
+15	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj:pass
 16	after	after	SCONJ	IN	_	19	mark	19:mark	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	Natzi	Natzi	PROPN	NNP	Number=Sing	19	nsubj	19:nsubj	_
@@ -19660,7 +19660,7 @@
 28	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	31	aux	31:aux	_
 29	n't	not	PART	RB	Polarity=Neg	31	advmod	31:advmod	_
 30	been	be	AUX	VBN	Tense=Past|VerbForm=Part	31	aux:pass	31:aux:pass	_
-31	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	acl:relcl	24:acl:relcl	_
+31	returned	return	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	24	acl:relcl	24:acl:relcl	Cxn=rc-that-nsubj:pass
 32	to	to	ADP	IN	_	36	case	36:case	_
 33	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	36	nmod:poss	36:nmod:poss	_
 34	right	rightful	ADJ	GW	Degree=Pos|Typo=Yes	36	amod	36:amod	CorrectForm=rightful
@@ -19733,7 +19733,7 @@
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 10	lot	lot	NOUN	NN	Number=Sing	8	nsubj	8:nsubj|12:nsubj	CxnElt=8:Existential-CopPred-ThereExpl.Pivot
 11	that	that	PRON	WDT	PronType=Rel	12	nsubj	10:ref	_
-12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+12	make	make	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
 13	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	12	obj	12:obj|14:nsubj:xsubj	_
 14	wonder	wonder	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -20063,7 +20063,7 @@
 23	(	(	PUNCT	-LRB-	_	26	punct	26:punct	SpaceAfter=No
 24	who	who	PRON	WP	PronType=Rel	26	nsubj	22:ref	_
 25	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
-26	become	become	VERB	VBN	Tense=Past|VerbForm=Part	22	acl:relcl	22:acl:relcl	_
+26	become	become	VERB	VBN	Tense=Past|VerbForm=Part	22	acl:relcl	22:acl:relcl	Cxn=rc-wh-nsubj
 27	her	her	PRON	PRP$	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	30	nmod:poss	30:nmod:poss	_
 28	new	new	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
 29	best	good	ADJ	JJS	Degree=Sup	30	amod	30:amod	_
@@ -20303,7 +20303,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	way	way	NOUN	NN	Number=Sing	4	obj	4:obj|8:obl	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	think	think	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl
 9	of	of	ADP	IN	_	12	case	12:case	_
 10	as	as	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -20614,7 +20614,7 @@
 # text = Anyone who looks like a druggy or dodgy.
 1	Anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	0	root	0:root|3:nsubj	_
 2	who	who	PRON	WP	PronType=Rel	3	nsubj	1:ref	_
-3	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	_
+3	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-wh-nsubj
 4	like	like	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	druggy	druggy	NOUN	NN	Number=Sing	3	obl	3:obl:like	_
@@ -20711,7 +20711,7 @@
 11	only	only	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	line	line	NOUN	NN	Number=Sing	16	nsubj	14:obj|16:nsubj|21:nsubj	_
 13	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	remember	remember	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 16	de	de	X	FW	Foreign=Yes	4	parataxis	4:parataxis	_
 17	lunde	lunde	X	FW	Foreign=Yes	16	flat	16:flat	_
@@ -21111,7 +21111,7 @@
 14	vote	vote	NOUN	NN	Number=Sing	5	obl	5:obl:in|17:nsubj	_
 15	on	on	ADP	IN	_	16	reparandum	16:reparandum	_
 16	that	that	PRON	WDT	PronType=Rel	17	nsubj	14:ref	_
-17	opens	open	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+17	opens	open	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
 18	on	on	ADP	IN	_	19	case	19:case	_
 19	Wednesday	Wednesday	PROPN	NNP	Number=Sing	17	obl	17:obl:on	_
 20	on	on	ADP	IN	_	22	case	22:case	_
@@ -21439,7 +21439,7 @@
 6	reasons	reason	NOUN	NNS	Number=Plur	4	nmod	4:nmod:of|9:obl	_
 7	why	why	ADV	WRB	PronType=Rel	9	advmod	6:ref	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+9	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	job	job	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
@@ -21614,7 +21614,7 @@
 13-14	can't	_	_	_	_	_	_	_	_
 13	ca	can	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	n't	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
-15	get	get	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	_
+15	get	get	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-obl
 16	lost	lost	ADJ	JJ	Degree=Pos	15	xcomp	15:xcomp	SpaceAfter=No
 17	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -21766,7 +21766,7 @@
 34	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	37	nsubj	37:nsubj	_
 35	can	can	AUX	MD	VerbForm=Fin	37	aux	37:aux	_
 36	really	really	ADV	RB	_	37	advmod	37:advmod	_
-37	say	say	VERB	VB	VerbForm=Inf	33	acl:relcl	33:acl:relcl	_
+37	say	say	VERB	VB	VerbForm=Inf	33	acl:relcl	33:acl:relcl	Cxn=rc-red-obj
 38	if	if	SCONJ	IN	_	39	mark	39:mark	_
 39	so	so	ADV	RB	_	41	advcl	41:advcl:if	CxnElt=41:Conditional-UnspecifiedEpistemic-Reduced.Protasis
 40	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	41	nsubj	41:nsubj	_
@@ -22134,7 +22134,7 @@
 24-25	you're	_	_	_	_	_	_	_	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
 25	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	26	aux	26:aux	_
-26	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	23	acl:relcl	23:acl:relcl	_
+26	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obl-pstrand
 27	for	for	ADP	IN	_	28	case	28:case	_
 28	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	obl	26:obl:for	_
 29	in	in	ADP	IN	_	26	obl	26:obl	Promoted=Yes|SpaceAfter=No
@@ -22245,7 +22245,7 @@
 31	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	CorrectSpaceAfter=Yes|SpaceAfter=No
 32	guys	guy	NOUN	NNS	Number=Plur	29	nmod	29:nmod:of|34:obj	_
 33	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	34	nsubj	34:nsubj	_
-34	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	_
+34	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	32	acl:relcl	32:acl:relcl	Cxn=rc-red-obj
 35	and	and	CCONJ	CC	_	38	cc	38:cc	_
 36	one	one	NUM	CD	NumForm=Word|NumType=Card	37	nummod	37:nummod	_
 37	guy	guy	NOUN	NN	Number=Sing	38	nsubj	38:nsubj	_
@@ -22392,7 +22392,7 @@
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 10	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	12	cop	12:cop	CorrectForm='s
 11	not	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
-12	available	available	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+12	available	available	ADJ	JJ	Degree=Pos	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
 13	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108024148AAO8oFI_ans-0004
@@ -22479,7 +22479,7 @@
 23	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj|28:nsubj:xsubj	_
 24	'll	will	AUX	MD	VerbForm=Fin	26	aux	26:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	26	cop	26:cop	_
-26	able	able	ADJ	JJ	Degree=Pos	21	acl:relcl	21:acl:relcl	_
+26	able	able	ADJ	JJ	Degree=Pos	21	acl:relcl	21:acl:relcl	Cxn=rc-wh-obl_xcomp
 27	to	to	PART	TO	_	28	mark	28:mark	_
 28	pay	pay	VERB	VB	VerbForm=Inf	26	xcomp	26:xcomp	_
 29	with	with	ADP	IN	_	31	case	31:case	_
@@ -22739,7 +22739,7 @@
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	not	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
 14	TOO	too	ADV	RB	_	15	advmod	15:advmod	_
-15	far	far	ADV	RB	_	10	acl:relcl	10:acl:relcl	_
+15	far	far	ADV	RB	_	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
 16	from	from	ADP	IN	_	19	case	19:case	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
 18	main	main	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -22754,7 +22754,7 @@
 2	way	way	NOUN	NN	Number=Sing	0	root	0:root|5:obl	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
 4	could	could	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
-5	get	get	VERB	VB	VerbForm=Inf	2	acl:relcl	2:acl:relcl	_
+5	get	get	VERB	VB	VerbForm=Inf	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
 6	there	there	ADV	RB	PronType=Dem	5	advmod	5:advmod	_
 7	by	by	ADP	IN	_	8	case	8:case	_
 8	boat	boat	NOUN	NN	Number=Sing	5	obl	5:obl:by	_
@@ -22806,7 +22806,7 @@
 7	where	where	ADV	WRB	PronType=Rel	10	advmod	6:ref	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	can	can	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	do	do	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
+10	do	do	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
 11	fun	fun	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	activities	activity	NOUN	NNS	Number=Plur	10	obj	10:obj	SpaceAfter=No
 13	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -22893,7 +22893,7 @@
 16	Tampa	Tampa	PROPN	NNP	Number=Sing	17	compound	17:compound	_
 17	Bay	Bay	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	14:ref	_
-19	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+19	sells	sell	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
 20	morcillas	morcilla	NOUN	NNS	Number=Plur	19	obj	19:obj	SpaceAfter=No
 21	,	,	PUNCT	,	_	23	punct	23:punct	_
 22	also	also	ADV	RB	_	23	advmod	23:advmod	_
@@ -22941,7 +22941,7 @@
 9	,	,	PUNCT	,	_	12	punct	12:punct	_
 10	where	where	ADV	WRB	PronType=Rel	12	advmod	6:ref	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+12	sell	sell	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl
 13	all	all	DET	DT	PronType=Tot	14	det	14:det	_
 14	types	type	NOUN	NNS	Number=Plur	12	obj	12:obj	_
 15	of	of	ADP	IN	_	16	case	16:case	_
@@ -23069,7 +23069,7 @@
 6	numerous	numerous	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	cabs	cab	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj|9:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	ferry	ferry	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	ferry	ferry	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
 10	passengers	passenger	NOUN	NNS	Number=Plur	9	obj	9:obj	_
 11	between	between	ADP	IN	_	15	case	15:case	_
 12	Sector	Sector	PROPN	NNP	Number=Sing	15	compound	15:compound	SpaceAfter=No
@@ -23233,7 +23233,7 @@
 19	way	way	NOUN	NN	Number=Sing	16	nsubj	16:nsubj|22:obl	CxnElt=16:Existential-CopPred-ThereExpl.Pivot
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	buy	buy	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	_
+22	buy	buy	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obl
 23	some	some	DET	DT	PronType=Ind	24	det	24:det	_
 24	card	card	NOUN	NN	Number=Sing	22	obj	22:obj	_
 25	to	to	PART	TO	_	26	mark	26:mark	_
@@ -23329,11 +23329,11 @@
 17	thing	thing	NOUN	NN	Number=Sing	15	nsubj	15:nsubj|20:obl|24:nsubj	CxnElt=15:Existential-CopPred-ThereExpl.Pivot
 18	that	that	PRON	WDT	PronType=Rel	20	obl	17:ref	_
 19	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	20	nsubj	20:nsubj	_
-20	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+20	pay	pay	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-obl-pstrand
 21	for	for	ADP	IN	_	18	case	18:case	_
 22	monthly	monthly	ADV	RB	_	20	advmod	20:advmod	_
 23	that	that	PRON	WDT	PronType=Rel	24	nsubj	17:ref	_
-24	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+24	gets	get	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
 25	wifi	wifi	NOUN	NN	Number=Sing	24	obj	24:obj	_
 26	from	from	ADP	IN	_	27	case	27:case	_
 27	satellite	satellite	NOUN	NN	Number=Sing	24	obl	24:obl:from	_
@@ -23696,7 +23696,7 @@
 6	Cat	cat	NOUN	NN	Number=Sing	2	obj	2:obj|9:nsubj:pass|10:nsubj:xsubj	_
 7	that	that	PRON	WDT	PronType=Rel	9	nsubj:pass	6:ref	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux:pass	9:aux:pass	_
-9	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	_
+9	named	name	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj:pass
 10	Achilles	Achilles	PROPN	NNP	Number=Sing	9	xcomp	9:xcomp	_
 11	bc	because	SCONJ	IN	Abbr=Yes	17	mark	17:mark	_
 12	as	as	ADP	IN	_	14	case	14:case	_
@@ -23726,14 +23726,14 @@
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	year	year	NOUN	NN	Number=Sing	14	nsubj	10:obl|14:nsubj	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	got	get	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl
 11	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	obj	10:obj	_
 12	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	cop	14:cop	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 14	year	year	NOUN	NN	Number=Sing	4	advcl	4:advcl:because|17:obl	_
 15	Frank	Frank	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj	_
 16	Sinatra	Sinatra	PROPN	NNP	Number=Sing	15	flat	15:flat	_
-17	died	die	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+17	died	die	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obl
 
 # sent_id = answers-20111108105146AAtiEx7_ans-0011
 # text = He also had bright blue eyes like Frank Sinatra did :)
@@ -24001,7 +24001,7 @@
 7	airport	airport	NOUN	NN	Number=Sing	4	obl	4:obl:to|10:nsubj:pass	_
 8	which	which	PRON	WDT	PronType=Rel	10	nsubj:pass	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
+10	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj:pass
 11	next	next	ADV	RB	_	10	advmod	10:advmod	_
 12	to	to	ADP	IN	_	13	case	13:case	_
 13	BARTrail	BARTrail	PROPN	NNP	Number=Sing	11	obl	11:obl:to	SpaceAfter=No
@@ -24089,7 +24089,7 @@
 24	off	off	ADV	RB	_	23	advmod	23:advmod	_
 25	anyplace	anyplace	ADV	RB	PronType=Ind	23	advmod	23:advmod|29:obl:at	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
-27	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	advcl:relcl	25:advcl:relcl	_
+27	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	advcl:relcl	25:advcl:relcl	Cxn=rc-red-obl_xcomp-pstrand
 28	to	to	PART	TO	_	29	mark	29:mark	_
 29	spend	spend	VERB	VB	VerbForm=Inf	27	xcomp	27:xcomp	_
 30	more	more	ADJ	JJR	Degree=Cmp	31	amod	31:amod	_
@@ -24238,12 +24238,12 @@
 10	hype	hype	NOUN	NN	Number=Sing	7	nmod	7:nmod:but|13:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	13	nsubj:pass	13:nsubj:pass	_
 12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux:pass	13:aux:pass	_
-13	told	tell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	_
+13	told	tell	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj
 14	and	and	CCONJ	CC	_	16	cc	16:cc	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 16	packages	package	NOUN	NNS	Number=Plur	10	conj	10:conj:and|18:obj	_
 17	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	18	nsubj	18:nsubj|19:nsubj:xsubj	_
-18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
+18	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obj
 19	available	available	ADJ	JJ	Degree=Pos	18	xcomp	18:xcomp	_
 20	to	to	ADP	IN	_	21	case	21:case	_
 21	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	19	obl	19:obl:to	SpaceAfter=No
@@ -24256,7 +24256,7 @@
 3	time	time	NOUN	NN	Number=Sing	14	obl:unmarked	6:obl|14:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	actually	actually	ADV	RB	_	6	advmod	6:advmod	_
-6	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+6	booked	book	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
 7	through	through	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	travel	travel	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -24271,7 +24271,7 @@
 18	amenities	amenity	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of|21:obl	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 20	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	21	aux	21:aux	_
-21	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part	18	acl:relcl	18:acl:relcl	_
+21	paid	pay	VERB	VBN	Tense=Past|VerbForm=Part	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl-pstrand
 22	for	for	ADP	IN	_	21	obl	21:obl	Promoted=Yes|SpaceAfter=No
 23	.	.	PUNCT	.	_	14	punct	14:punct	_
 
@@ -24282,7 +24282,7 @@
 3	times	time	NOUN	NNS	Number=Plur	13	obl:unmarked	6:obl|13:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	consulted	consult	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
+6	consulted	consult	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
 7	with	with	ADP	IN	_	10	case	10:case	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 9	travel	travel	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -24307,7 +24307,7 @@
 28	what	what	PRON	WP	PronType=Rel	25	obl	25:obl:than|31:obj	_
 29	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	31	nsubj	31:nsubj	_
 30	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	31	aux	31:aux	_
-31	selling	sell	VERB	VBG	Tense=Pres|VerbForm=Part	28	acl:relcl	28:acl:relcl	SpaceAfter=No
+31	selling	sell	VERB	VBG	Tense=Pres|VerbForm=Part	28	acl:relcl	28:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 32	.	.	PUNCT	.	_	13	punct	13:punct	_
 
 # sent_id = answers-20111107201700AAKdymq_ans-0008
@@ -24577,7 +24577,7 @@
 8	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 9	mother	mother	NOUN	NN	Number=Sing	11	nsubj	11:nsubj	_
 10	will	will	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	let	let	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
+11	let	let	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj_xcomp
 12	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	11	obj	11:obj|13:nsubj:xsubj	_
 13	have	have	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	please	please	INTJ	UH	_	15	discourse	15:discourse	_
@@ -24745,7 +24745,7 @@
 21	something	something	PRON	NN	Number=Sing|PronType=Ind	20	obj	20:obj|24:obj	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	24	nsubj	24:nsubj|26:nsubj	_
 23	can	can	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	handle	handle	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	_
+24	handle	handle	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	Cxn=rc-red-obj
 25	and	and	CCONJ	CC	_	26	cc	26:cc	_
 26	hold	hold	VERB	VB	VerbForm=Inf	24	conj	21:acl:relcl|24:conj:and	SpaceAfter=No
 27	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -24913,7 +24913,7 @@
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	way	way	NOUN	NN	Number=Sing	19	nsubj	13:obl|19:nsubj	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl
 14	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	obj	13:obj	_
 15	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	cop	19:cop	_
 16	not	not	PART	RB	Polarity=Neg	19	advmod	19:advmod	_
@@ -25231,7 +25231,7 @@
 # text = Whatever you order, you will LOVE!
 1	Whatever	whatever	PRON	WP	PronType=Rel	7	obj	3:obj|7:obj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	order	order	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	SpaceAfter=No
+3	order	order	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	acl:relcl	1:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 4	,	,	PUNCT	,	_	1	punct	1:punct	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	will	will	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
@@ -26156,7 +26156,7 @@
 1	A	a	DET	DT	Definite=Ind|PronType=Art	2	det	2:det	_
 2	company	company	NOUN	NN	Number=Sing	0	root	0:root|4:nsubj	_
 3	which	which	PRON	WDT	PronType=Rel	4	nsubj	2:ref	_
-4	provide	provide	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	2	acl:relcl	2:acl:relcl	CorrectForm=provides|CorrectNumber=Sing
+4	provide	provide	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	2	acl:relcl	2:acl:relcl	CorrectForm=provides|CorrectNumber=Sing|Cxn=rc-wh-nsubj
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	quality	quality	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	portals	portal	NOUN	NNS	Number=Plur	4	obj	4:obj	SpaceAfter=No
@@ -26665,7 +26665,7 @@
 8	Toyota	Toyota	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	Venza	Venza	PROPN	NNP	Number=Sing	5	nmod	5:nmod:for	_
 10	that	that	PRON	WDT	PronType=Rel	11	nsubj	5:ref	_
-11	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+11	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
 12	amazing	amazing	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -26701,7 +26701,7 @@
 13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
 14	friend	friend	NOUN	NN	Number=Sing	13	obj	13:obj|16:nsubj	_
 15	who	who	PRON	WP	PronType=Rel	16	nsubj	14:ref	_
-16	drive	drive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	14	acl:relcl	14:acl:relcl	CorrectForm=drives|CorrectNumber=Sing
+16	drive	drive	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	14	acl:relcl	14:acl:relcl	CorrectForm=drives|CorrectNumber=Sing|Cxn=rc-wh-nsubj
 17	from	from	ADP	IN	_	19	case	19:case	_
 18	central	central	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	Phx	Phoenix	PROPN	NNP	Abbr=Yes|Number=Sing	16	obl	16:obl:from	_
@@ -26898,7 +26898,7 @@
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 6	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	PronType=Ind	8	advmod	8:advmod	_
-8	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
+8	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-363633-0003
@@ -27372,7 +27372,7 @@
 9	Mrs.	Mrs.	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	Lynda	Lynda	PROPN	NNP	Number=Sing	9	flat	9:flat	_
 11	Mcmanus	Mcmanus	PROPN	NNP	Number=Sing	9	flat	9:flat	_
-12	taught	teach	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+12	taught	teach	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	iobj	12:iobj	SpaceAfter=No
 14	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -27410,7 +27410,7 @@
 5	pizza	pizza	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	place	place	NOUN	NN	Number=Sing	0	root	0:root|8:obj	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	recommend	recommend	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 9	in	in	ADP	IN	_	11	case	11:case	_
 10	Woodland	Woodland	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	Hills	Hill	PROPN	NNPS	Number=Plur	6	obl	6:obl:in	SpaceAfter=No
@@ -27591,7 +27591,7 @@
 7	about	about	ADV	RB	_	8	advmod	8:advmod	_
 8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	6	obj	6:obj|10:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+10	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 11	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-262422-0004
@@ -27708,7 +27708,7 @@
 3	and	and	CCONJ	CC	_	4	cc	4:cc	_
 4	hairstyles	hairstyle	NOUN	NNS	Number=Plur	2	conj	2:conj:and|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	last	last	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+6	last	last	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-162992-0002
@@ -27722,7 +27722,7 @@
 6	service	service	NOUN	NN	Number=Sing	3	obl	3:obl:with|9:obj	_
 7	that	that	PRON	WDT	PronType=Rel	9	obj	6:ref	_
 8	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+9	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj
 10	at	at	ADP	IN	_	11	case	11:case	_
 11	Luxe	Luxe	PROPN	NNP	Number=Sing	9	obl	9:obl:at	SpaceAfter=No
 12	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -28060,7 +28060,7 @@
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	what	what	PRON	WP	PronType=Rel	0	root	0:root|5:obj	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	call	call	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obj
 6	customer	customer	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	service	service	NOUN	NN	Number=Sing	5	xcomp	5:xcomp	SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	_
@@ -28390,7 +28390,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
 12	fast	fast	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	food	food	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+13	food	food	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-058274-0002
@@ -28490,7 +28490,7 @@
 9	Duty	Duty	PROPN	NNP	Number=Sing	10	compound	10:compound	_
 10	Free	Free	PROPN	NNP	Number=Sing	12	nsubj:pass	12:nsubj:pass	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
-12	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl:relcl	4:advcl:relcl	SpaceAfter=No
+12	located	locate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	advcl:relcl	4:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
 13	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = reviews-090390-0003
@@ -28558,7 +28558,7 @@
 9	experience	experience	NOUN	NN	Number=Sing	0	root	0:root|12:obj	_
 10	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+12	had	have	VERB	VBN	Tense=Past|VerbForm=Part	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 13	.	.	PUNCT	.	_	9	punct	9:punct	_
 
 # newdoc id = reviews-188461
@@ -28776,7 +28776,7 @@
 12-13	I've	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
-14	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
+14	found	find	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 15	in	in	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 17	Tampa	Tampa	PROPN	NNP	Number=Sing	18	compound	18:compound	_
@@ -28910,7 +28910,7 @@
 8	for	for	ADP	IN	_	9	case	9:case	_
 9	what	what	PRON	WP	PronType=Rel	6	obl	6:obl:for|11:obj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+11	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-148012-0005
@@ -29166,7 +29166,7 @@
 11	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	ever	ever	ADV	RB	PronType=Ind	14	advmod	14:advmod	_
-14	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
+14	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 15	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-173944-0004
@@ -29209,7 +29209,7 @@
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	12	aux	12:aux	_
-12	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
+12	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
 13	on	on	ADP	IN	_	15	case	15:case	_
 14	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	dog	dog	NOUN	NN	Number=Sing	12	obl	12:obl:on	_
@@ -29219,7 +29219,7 @@
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	boy	boy	NOUN	NN	Number=Sing	30	nsubj	22:nsubj|30:nsubj	_
 21	who	who	PRON	WP	PronType=Rel	22	nsubj	20:ref	_
-22	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
+22	answered	answer	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	acl:relcl	20:acl:relcl	Cxn=rc-wh-nsubj
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	phone	phone	NOUN	NN	Number=Sing	22	obj	22:obj	_
 25-26	couldn't	_	_	_	_	_	_	_	_
@@ -29368,7 +29368,7 @@
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 7	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	ever	ever	ADV	RB	PronType=Ind	9	advmod	9:advmod	_
-9	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
+9	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl-pstrand
 10	with	with	ADP	IN	_	9	obl	9:obl	Promoted=Yes|SpaceAfter=No
 11	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -29551,7 +29551,7 @@
 4	excellent	excellent	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	host	host	NOUN	NN	Number=Sing	0	root	0:root|7:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	5:ref	_
-7	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 8	yummy	yummy	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	breakfasts	breakfast	NOUN	NNS	Number=Plur	7	obj	7:obj	SpaceAfter=No
 10	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -29857,7 +29857,7 @@
 2	recommended	recommend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
 3	for	for	ADP	IN	_	4	case	4:case	_
 4	who	whoever	PRON	WP	PronType=Rel|Typo=Yes	2	obl	2:obl:for|5:nsubj	CorrectForm=whoever
-5	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+5	wants	want	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-free-nsubj
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	have	have	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	website	website	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
@@ -30318,7 +30318,7 @@
 10	on	on	ADP	IN	_	13	case	13:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 12	next	next	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	block	block	NOUN	NN	Number=Sing	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+13	block	block	NOUN	NN	Number=Sing	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
 14	)	)	PUNCT	-RRB-	_	13	punct	13:punct	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -30369,7 +30369,7 @@
 12	other	other	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	services	service	NOUN	NNS	Number=Plur	7	obj	7:obj|9:obj|15:obj	_
 14	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
-15	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
+15	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 16	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-323248-0004
@@ -30433,7 +30433,7 @@
 5	attorney	attorney	NOUN	NN	Number=Sing	3	obj	3:obj|8:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	will	will	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	defend	defend	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
+8	defend	defend	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 9	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	right	right	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
 11	,	,	PUNCT	,	_	3	punct	3:punct	_
@@ -30670,7 +30670,7 @@
 12-13	wouldn't	_	_	_	_	_	_	_	_
 12	would	would	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	Polarity=Neg	14	advmod	14:advmod	_
-14	expect	expect	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
+14	expect	expect	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
 15	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	obj	14:obj	SpaceAfter=No
 16	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -30744,7 +30744,7 @@
 11	Your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	Boys	boy	NOUN	NNS	Number=Plur	9	conj	9:conj:and|14:nsubj	_
 13	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
-14	Done	do	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
+14	Done	do	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj
 15	On	on	ADP	IN	_	19	case	19:case	_
 16	Our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 17	New	new	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -30763,7 +30763,7 @@
 30	Power	power	NOUN	NN	Number=Sing	40	nsubj	33:obj|40:nsubj	_
 31	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	33	nsubj	33:nsubj	_
 32	Are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	33	aux	33:aux	_
-33	Putting	put	VERB	VBG	Tense=Pres|VerbForm=Part	30	acl:relcl	30:acl:relcl	_
+33	Putting	put	VERB	VBG	Tense=Pres|VerbForm=Part	30	acl:relcl	30:acl:relcl	Cxn=rc-red-obj
 34	Back	back	ADV	RB	_	33	advmod	33:advmod	_
 35	In	into	ADP	GW	Typo=Yes	38	case	38:case	_
 36	To	_	X	IN	_	35	goeswith	35:goeswith	_
@@ -30791,7 +30791,7 @@
 2	First	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	3	amod	3:amod	_
 3	time	time	NOUN	NN	Number=Sing	14	obl:unmarked	5:obl|14:obl:unmarked	TemporalNPAdjunct=Yes
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	walked	walk	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
 6	in	in	ADP	IN	_	7	case	7:case	_
 7	there	there	ADV	RB	PronType=Dem	5	obl	5:obl:in	_
 8	with	with	ADP	IN	_	12	case	12:case	_
@@ -30826,7 +30826,7 @@
 12	and	and	CCONJ	CC	_	13	cc	13:cc	_
 13	everything	everything	PRON	NN	Number=Sing|PronType=Tot	5	conj	3:obj|5:conj:and|15:obj	_
 14	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj|17:nsubj:xsubj	_
-15	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+15	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	keep	keep	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
@@ -31024,7 +31024,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	reason	reason	NOUN	NN	Number=Sing	12	nsubj:outer	4:obl|12:nsubj:outer	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	go	go	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
 5	back	back	ADV	RB	_	4	advmod	4:advmod	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 7	because	because	SCONJ	IN	_	12	mark	12:mark	_
@@ -31067,7 +31067,7 @@
 3	guy	guy	NOUN	NN	Number=Sing	20	nsubj	6:nsubj|20:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	6	nsubj	3:ref	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
-6	there	there	ADV	RB	PronType=Dem	3	acl:relcl	3:acl:relcl	SpaceAfter=No
+6	there	there	ADV	RB	PronType=Dem	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj|SpaceAfter=No
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
 8-9	I'm	_	_	_	_	_	_	_	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
@@ -31087,7 +31087,7 @@
 21	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 22	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
 23	ever	ever	ADV	RB	PronType=Ind	24	advmod	24:advmod	_
-24	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	20	acl:relcl	20:acl:relcl	SpaceAfter=No
+24	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	20	acl:relcl	20:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 25	.	.	PUNCT	.	_	20	punct	20:punct	_
 
 # sent_id = reviews-061768-0004
@@ -31406,7 +31406,7 @@
 33-34	wouldn't	_	_	_	_	_	_	_	_
 33	would	would	AUX	MD	VerbForm=Fin	35	aux	35:aux	_
 34	n't	not	PART	RB	Polarity=Neg	35	advmod	35:advmod	_
-35	do	do	VERB	VB	VerbForm=Inf	29	acl:relcl	29:acl:relcl	SpaceAfter=No
+35	do	do	VERB	VB	VerbForm=Inf	29	acl:relcl	29:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 36	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = reviews-063754-0002
@@ -31745,7 +31745,7 @@
 12	decide	decide	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:if|15:csubj	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	(	(	PUNCT	-LRB-	_	15	punct	15:punct	SpaceAfter=No
 14	which	which	PRON	WDT	PronType=Rel	15	nsubj	12:ref	_
-15	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl:relcl	12:advcl:relcl	_
+15	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-csubj
 16	every	every	DET	DT	PronType=Tot	17	det	17:det	_
 17	time	time	NOUN	NN	Number=Sing	15	obl:unmarked	15:obl:unmarked	TemporalNPAdjunct=Yes
 18	for	for	ADP	IN	_	19	case	19:case	_
@@ -31867,7 +31867,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	been	be	AUX	VBN	Tense=Past|VerbForm=Part	11	cop	11:cop	_
-11	to	to	ADP	IN	_	7	acl:relcl	7:acl:relcl	Promoted=Yes|SpaceAfter=No
+11	to	to	ADP	IN	_	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes|SpaceAfter=No
 12	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # sent_id = reviews-228944-0003
@@ -31880,7 +31880,7 @@
 6	which	which	PRON	WDT	PronType=Rel	9	obl	4:ref	_
 7	everything	everything	PRON	NN	Number=Sing|PronType=Tot	9	nsubj	9:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
-9	expensive	expensive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	_
+9	expensive	expensive	ADJ	JJ	Degree=Pos	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pstrand
 10	on	on	ADP	IN	_	6	case	6:case	_
 11	and	and	CCONJ	CC	_	16	cc	16:cc	_
 12	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
@@ -31898,7 +31898,7 @@
 24	other	other	ADJ	JJ	Degree=Pos	25	amod	25:amod	_
 25	shop	shop	NOUN	NN	Number=Sing	21	obl	21:obl:than|27:obj	_
 26	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	27	nsubj	27:nsubj	_
-27	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	SpaceAfter=No
+27	called	call	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 28	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-228944-0004
@@ -31910,7 +31910,7 @@
 5	place	place	NOUN	NN	Number=Sing	0	root	0:root|8:obl	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	take	take	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
+8	take	take	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	car	car	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	peiod	period	NOUN	NN	Number=Sing|Typo=Yes	8	obl:unmarked	8:obl:unmarked	CorrectForm=period|SpaceAfter=No
@@ -32227,7 +32227,7 @@
 1	Dentist	dentist	NOUN	NN	Number=Sing	0	root	0:root|4:obj	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	trust	trust	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
+4	trust	trust	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 
 # sent_id = reviews-313558-0002
 # newpar id = reviews-313558-p0002
@@ -32456,7 +32456,7 @@
 1	All	all	DET	DT	PronType=Tot	11	nsubj:outer	4:obj|11:nsubj:outer	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	say	say	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
+4	say	say	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 6	that	that	SCONJ	IN	_	11	mark	11:mark	_
 7	Elmira	Elmira	PROPN	NNP	Number=Sing	11	vocative	11:vocative	_
@@ -32467,7 +32467,7 @@
 12-13	Ive	_	_	_	_	_	_	_	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	14	aux	14:aux	CorrectForm='ve
-14	experienced	experience	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+14	experienced	experience	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
 16	never	never	ADV	RB	PronType=Neg	17	advmod	17:advmod	_
 17	before	before	ADV	RB	_	21	advmod	21:advmod	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -74,7 +74,7 @@
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	cop	23:cop	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 22	good	good	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
-23	thing	thing	NOUN	NN	Number=Sing	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+23	thing	thing	NOUN	NN	Number=Sing	17	acl:relcl	17:acl:relcl	Cxn=rc-wh-obl:unmarked|SpaceAfter=No
 24	?	?	PUNCT	.	_	14	punct	14:punct	SpaceAfter=No
 25	)	)	PUNCT	-RRB-	_	14	punct	14:punct	_
 
@@ -99,7 +99,7 @@
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
 16	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 17	all	all	ADV	RB	_	18	advmod	18:advmod	_
-18	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl:relcl	12:advcl:relcl	_
+18	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-ccomp
 19	before	before	ADV	RB	_	18	advmod	18:advmod	SpaceAfter=No
 20	,	,	PUNCT	,	_	27	punct	27:punct	_
 21	but	but	CCONJ	CC	_	27	cc	27:cc	_
@@ -179,7 +179,7 @@
 5	few	few	ADJ	JJ	Degree=Pos	13	nsubj	8:nsubj|13:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	actually	actually	ADV	RB	_	8	advmod	8:advmod	_
-8	read	read	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+8	read	read	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	blog	blog	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
@@ -262,7 +262,7 @@
 7	flag	flag	NOUN	NN	Number=Sing	5	obj	5:obj|10:nsubj:pass	_
 8	that	that	PRON	WDT	PronType=Rel	10	nsubj:pass	7:ref	_
 9	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
+10	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj:pass
 11	in	in	ADP	IN	_	12	case	12:case	_
 12	Fallujah	Fallujah	PROPN	NNP	Number=Sing	10	obl	10:obl:in	SpaceAfter=No
 13	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -363,7 +363,7 @@
 20	linked	link	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	21	amod	21:amod	_
 21	article	article	NOUN	NN	Number=Sing	17	obl	17:obl:in	SpaceAfter=No
 22	,	,	PUNCT	,	_	17	punct	17:punct	_
-23	commits	commit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+23	commits	commit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
 24	just	just	ADV	RB	_	25	advmod	25:advmod	_
 25	about	about	ADV	RB	_	27	advmod	27:advmod	_
 26	every	every	DET	DT	PronType=Tot	27	det	27:det	_
@@ -372,7 +372,7 @@
 29	online	online	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
 30	marketer	marketer	NOUN	NN	Number=Sing	32	nsubj	32:nsubj	_
 31	could	could	AUX	MD	VerbForm=Fin	32	aux	32:aux	_
-32	commit	commit	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	SpaceAfter=No
+32	commit	commit	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 33	,	,	PUNCT	,	_	35	punct	35:punct	_
 34	and	and	CCONJ	CC	_	35	cc	35:cc	_
 35	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	conj	12:acl:relcl|23:conj:and	_
@@ -458,7 +458,7 @@
 51	someone	someone	PRON	NN	Number=Sing|PronType=Ind	48	obl	48:obl:to|54:nsubj	_
 52	who	who	PRON	WP	PronType=Rel	54	nsubj	51:ref	_
 53	would	would	AUX	MD	VerbForm=Fin	54	aux	54:aux	_
-54	forward	forward	VERB	VB	VerbForm=Inf	51	acl:relcl	51:acl:relcl	_
+54	forward	forward	VERB	VB	VerbForm=Inf	51	acl:relcl	51:acl:relcl	Cxn=rc-wh-nsubj
 55	an	a	DET	DT	Definite=Ind|PronType=Art	56	det	56:det	_
 56	excerpt	excerpt	NOUN	NN	Number=Sing	54	obj	54:obj	_
 57	to	to	ADP	IN	_	58	case	58:case	_
@@ -466,7 +466,7 @@
 59	who	who	PRON	WP	PronType=Rel	62	nsubj	58:ref	_
 60	would	would	AUX	MD	VerbForm=Fin	62	aux	62:aux	_
 61	then	then	ADV	RB	PronType=Dem	62	advmod	62:advmod	_
-62	store	store	VERB	VB	VerbForm=Inf	58	acl:relcl	58:acl:relcl	_
+62	store	store	VERB	VB	VerbForm=Inf	58	acl:relcl	58:acl:relcl	Cxn=rc-wh-nsubj
 63	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	62	obj	62:obj	_
 64	on	on	ADP	IN	_	67	case	67:case	_
 65	a	a	DET	DT	Definite=Ind|PronType=Art	67	det	67:det	_
@@ -635,7 +635,7 @@
 18	could	could	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 19	n't	not	PART	RB	Polarity=Neg	21	advmod	21:advmod	_
 20	even	even	ADV	RB	_	21	advmod	21:advmod	_
-21	begin	begin	VERB	VB	VerbForm=Inf	12	advcl:relcl	12:advcl:relcl	_
+21	begin	begin	VERB	VB	VerbForm=Inf	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-xcomp_xcomp
 22	to	to	PART	TO	_	23	mark	23:mark	_
 23	try	try	VERB	VB	VerbForm=Inf	21	xcomp	21:xcomp	_
 24	without	without	ADP	IN	_	26	case	26:case	_
@@ -867,7 +867,7 @@
 11	massacre	massacre	NOUN	NN	Number=Sing	9	obj	9:obj|14:nsubj:pass	_
 12	which	which	PRON	WDT	PronType=Rel	14	nsubj:pass	11:ref	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux:pass	14:aux:pass	_
-14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	_
+14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-nsubj:pass
 15	on	on	ADP	IN	_	16	case	16:case	_
 16	Friday	Friday	PROPN	NNP	Number=Sing	14	obl	14:obl:on	_
 17	against	against	ADP	IN	_	18	case	18:case	_
@@ -1075,7 +1075,7 @@
 42	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	cop	45:cop	_
 43	185	185	NUM	CD	NumForm=Digit|NumType=Card	44	nummod	44:nummod	_
 44	pages	page	NOUN	NNS	Number=Plur	45	obl:unmarked	45:obl:unmarked	_
-45	long	long	ADJ	JJ	Degree=Pos	40	acl:relcl	40:acl:relcl	SpaceAfter=No
+45	long	long	ADJ	JJ	Degree=Pos	40	acl:relcl	40:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 46	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0002
@@ -1140,7 +1140,7 @@
 47	,	,	PUNCT	,	_	49	punct	49:punct	_
 48	and	and	CCONJ	CC	_	49	cc	49:cc	_
 49	BREYER	Breyer	PROPN	NNP	Number=Sing	42	conj	42:conj:and|50:nsubj	_
-50	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+50	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 51	,	,	PUNCT	,	_	54	punct	54:punct	_
 52	and	and	CCONJ	CC	_	54	cc	54:cc	_
 53	an	a	DET	DT	Definite=Ind|PronType=Art	54	det	54:det	_
@@ -1165,7 +1165,7 @@
 72	,	,	PUNCT	,	_	74	punct	74:punct	_
 73	and	and	CCONJ	CC	_	74	cc	74:cc	_
 74	BREYER	Breyer	PROPN	NNP	Number=Sing	69	conj	69:conj:and|75:nsubj	_
-75	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	SpaceAfter=No
+75	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 76	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0004
@@ -1184,7 +1184,7 @@
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	GINSBURG	Ginsburg	PROPN	NNP	Number=Sing	9	conj	9:conj:and|15:nsubj	_
-15	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+15	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0005
@@ -1205,7 +1205,7 @@
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	BREYER	Breyer	PROPN	NNP	Number=Sing	11	conj	11:conj:and|17:nsubj	_
-17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pfront
 18	as	as	ADP	IN	ExtPos=ADP	20	case	20:case	_
 19	to	to	ADP	IN	_	18	fixed	18:fixed	_
 20	Parts	part	NOUN	NNS	Number=Plur	17	obl	17:obl:as_to	_
@@ -1227,7 +1227,7 @@
 9	THOMAS	Thomas	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	ALITO	Alito	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0007
@@ -1241,7 +1241,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	which	which	PRON	WDT	PronType=Rel	10	obl	5:ref	_
 9	SCALIA	Scalia	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
-10	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+10	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 11	,	,	PUNCT	,	_	16	punct	16:punct	_
 12	and	and	CCONJ	CC	_	16	cc	16:cc	_
 13	in	in	ADP	IN	_	14	case	14:case	_
@@ -1282,7 +1282,7 @@
 9	SCALIA	Scalia	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	THOMAS	Thomas	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront
 13	as	as	ADP	IN	ExtPos=ADP	15	case	15:case	_
 14	to	to	ADP	IN	_	13	fixed	13:fixed	_
 15	Parts	part	NOUN	NNS	Number=Plur	12	obl	12:obl:as_to	_
@@ -1384,7 +1384,7 @@
 39	not	not	PART	RB	Polarity=Neg	42	advmod	42:advmod	_
 40	only	only	ADV	RB	_	42	advmod	42:advmod	_
 41	be	be	AUX	VB	VerbForm=Inf	42	aux:pass	42:aux:pass	_
-42	frowned	frown	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	_
+42	frowned	frown	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	Cxn=rc-wh-obl-pstrand
 43	upon	upon	ADP	IN	_	42	obl	42:obl	Promoted=Yes
 44	but	but	CCONJ	CC	_	48	cc	48:cc	_
 45	should	should	AUX	MD	VerbForm=Fin	48	aux	48:aux	_
@@ -1592,7 +1592,7 @@
 21	area	area	NOUN	NN	Number=Sing	16	obl	16:obl:to|24:nsubj	_
 22	that	that	PRON	WDT	PronType=Rel	24	nsubj	21:ref	_
 23	will	will	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	need	need	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	_
+24	need	need	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	Cxn=rc-that-nsubj
 25	15,000	15000	NUM	CD	NumForm=Digit|NumType=Card	24	obj	24:obj	SpaceAfter=No
 26	,	,	PUNCT	,	_	29	punct	29:punct	_
 27	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	29	case	29:case	_
@@ -1615,7 +1615,7 @@
 11	aid	aid	NOUN	NN	Number=Sing	7	nmod	7:nmod:of|14:obj	_
 12	that	that	PRON	WDT	PronType=Rel	14	obj	11:ref	_
 13	Darfur	Darfur	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
-14	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+14	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
 16	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	21	case	21:case	_
 17	to	to	ADP	IN	_	16	fixed	16:fixed	_
@@ -1696,7 +1696,7 @@
 4	move	move	NOUN	NN	Number=Sing	0	root	0:root|7:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	7	nsubj	4:ref	_
 6	really	really	ADV	RB	_	7	advmod	7:advmod	_
-7	worries	worry	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+7	worries	worry	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 8	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	;	;	PUNCT	,	_	25	punct	25:punct	_
 10-11	Buffett's	_	_	_	_	_	_	_	_
@@ -1909,7 +1909,7 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	guy	guy	NOUN	NN	Number=Sing	10	nmod	10:nmod:from|20:nsubj|25:nsubj|30:nsubj:xsubj	_
 19	who	who	PRON	WP	PronType=Rel	20	nsubj	18:ref	_
-20	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+20	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-nsubj
 21	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	obj	20:obj	_
 22	best	well	ADV	RBS	Degree=Sup	20	advmod	20:advmod	_
 23	--	--	PUNCT	,	_	25	punct	25:punct	_
@@ -2002,7 +2002,7 @@
 16	each	each	DET	DT	PronType=Tot	17	det	17:det	_
 17	year	year	NOUN	NN	Number=Sing	11	obl:unmarked	11:obl:unmarked	TemporalNPAdjunct=Yes
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
-19	decrease	decrease	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+19	decrease	decrease	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
 20	in	in	ADP	IN	_	21	case	21:case	_
 21	number	number	NOUN	NN	Number=Sing	19	obl	19:obl:in	_
 22	at	at	ADP	IN	_	24	case	24:case	_
@@ -2083,7 +2083,7 @@
 42	where	where	ADV	WRB	PronType=Rel	45	advmod	41:ref	_
 43	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	45	nsubj	45:nsubj	_
 44	will	will	AUX	MD	VerbForm=Fin	45	aux	45:aux	_
-45	compound	compound	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	SpaceAfter=No
+45	compound	compound	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
 46	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = weblog-blogspot.com_floppingaces_20050313182621_ENG_20050313_182621
@@ -2136,7 +2136,7 @@
 3	same	same	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	day	day	NOUN	NN	Number=Sing	19	obl	6:obl|19:obl:on	_
 5	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	6	nsubj	6:nsubj	_
-6	protest	protest	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	protest	protest	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	support	support	NOUN	NN	Number=Sing	6	obl	6:obl:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
@@ -2211,7 +2211,7 @@
 16	which	which	PRON	WDT	PronType=Rel	19	nsubj	13:ref	_
 17	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	already	already	ADV	RB	_	19	advmod	19:advmod	_
-19	begun	begin	VERB	VBN	Tense=Past|VerbForm=Part	13	acl:relcl	13:acl:relcl	_
+19	begun	begin	VERB	VBN	Tense=Past|VerbForm=Part	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj
 20	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-blogspot.com_floppingaces_20050313182621_ENG_20050313_182621-0005
@@ -2245,7 +2245,7 @@
 27	placards	placard	NOUN	NNS	Number=Plur	24	nmod	24:nmod:on|30:obj	_
 28	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
 29	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	aux	30:aux	_
-30	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	27	acl:relcl	27:acl:relcl	SpaceAfter=No
+30	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	27	acl:relcl	27:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 31	"	"	PUNCT	''	_	24	punct	24:punct	SpaceAfter=No
 32	.	.	PUNCT	.	_	8	punct	8:punct	_
 
@@ -2468,7 +2468,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	organization	organization	NOUN	NN	Number=Sing	0	root	0:root|6:nsubj|13:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	bombed	bomb	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	bombed	bomb	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 7	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 8	Marine	Marine	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	barracks	barracks	NOUN	NNS	Number=Ptan	6	obj	6:obj	_
@@ -2701,7 +2701,7 @@
 28	of	of	ADP	IN	_	29	case	29:case	_
 29	which	which	PRON	WDT	PronType=Rel	27	nmod	24:ref	_
 30	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	cop	31:cop	_
-31	Muslim	Muslim	ADJ	JJ	Degree=Pos	24	acl:relcl	24:acl:relcl	_
+31	Muslim	Muslim	ADJ	JJ	Degree=Pos	24	acl:relcl	24:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
 32	(	(	PUNCT	-LRB-	_	35	punct	35:punct	SpaceAfter=No
 33	such	such	ADJ	JJ	Degree=Pos|ExtPos=ADP	35	case	35:case	_
 34	as	as	ADP	IN	_	33	fixed	33:fixed	_
@@ -2821,7 +2821,7 @@
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	whom	whom	PRON	WP	PronType=Rel	25	nmod	12:ref	_
 28	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	Muslim	Muslim	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	SpaceAfter=No
+29	Muslim	Muslim	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
 30	,	,	PUNCT	,	_	12	punct	12:punct	_
 31	calling	call	VERB	VBG	VerbForm=Ger	9	acl	9:acl	_
 32	upon	upon	ADP	IN	_	33	case	33:case	_
@@ -2841,7 +2841,7 @@
 46	that	that	PRON	WDT	PronType=Rel	49	nsubj	45:ref	_
 47	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	49	aux	49:aux	_
 48	not	not	PART	RB	Polarity=Neg	49	advmod	49:advmod	_
-49	respect	respect	VERB	VB	VerbForm=Inf	45	acl:relcl	45:acl:relcl	_
+49	respect	respect	VERB	VB	VerbForm=Inf	45	acl:relcl	45:acl:relcl	Cxn=rc-that-nsubj
 50	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	51	nmod:poss	51:nmod:poss	_
 51	religion	religion	NOUN	NN	Number=Sing	49	obj	49:obj	_
 52	or	or	CCONJ	CC	_	54	cc	54:cc	_
@@ -2961,7 +2961,7 @@
 21	of	of	ADP	IN	_	22	case	22:case	_
 22	whom	whom	PRON	WP	PronType=Rel	20	nmod	16:ref	_
 23	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	aux	24:aux	_
-24	supported	support	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	_
+24	supported	support	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
 25	Saddam	Saddam	PROPN	NNP	Number=Sing	24	obj	24:obj	_
 26	and	and	CCONJ	CC	_	29	cc	29:cc	_
 27	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	29	nmod:poss	29:nmod:poss	_
@@ -3119,7 +3119,7 @@
 5-6	didn't	_	_	_	_	_	_	_	_
 5	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
-7	say	say	VERB	VB	VerbForm=Inf	3	advcl:relcl	3:advcl:relcl	_
+7	say	say	VERB	VB	VerbForm=Inf	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod
 8-9	we're	_	_	_	_	_	_	_	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
@@ -3595,7 +3595,7 @@
 11-12	didn't	_	_	_	_	_	_	_	_
 11	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	crash	crash	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
+13	crash	crash	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-that-nsubj
 14	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
 15	spell	spell	NOUN	NN	Number=Sing	17	compound	17:compound	SpaceAfter=No
 16	-	-	PUNCT	HYPH	_	15	punct	15:punct	SpaceAfter=No
@@ -3894,7 +3894,7 @@
 16	Arabs	Arab	PROPN	NNPS	Number=Plur	8	nmod	8:nmod:of|19:nsubj	SpaceAfter=No
 17	"	"	PUNCT	''	_	16	punct	16:punct	_
 18	who	who	PRON	WP	PronType=Rel	19	nsubj	16:ref	_
-19	pledged	pledge	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
+19	pledged	pledge	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nsubj
 20	personal	personal	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	loyalty	loyalty	NOUN	NN	Number=Sing	19	obj	19:obj	_
 22	to	to	ADP	IN	_	23	case	23:case	_
@@ -3960,7 +3960,7 @@
 22	of	of	ADP	IN	_	23	case	23:case	_
 23	Islam	Islam	PROPN	NNP	Number=Sing	21	nmod	21:nmod:of	_
 24	that	that	PRON	WDT	PronType=Rel	25	nsubj	21:ref	_
-25	predominates	predominate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
+25	predominates	predominate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-that-nsubj
 26	among	among	ADP	IN	_	32	case	32:case	_
 27-28	Saudia's	_	_	_	_	_	_	_	_
 27	Saudia	Saudia	PROPN	NNP	Number=Sing	32	nmod:poss	32:nmod:poss	_
@@ -4040,7 +4040,7 @@
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	whom	whom	PRON	WP	PronType=Rel	25	nmod	19:ref	_
 28	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	29	cop	29:cop	_
-29	Saudi	Saudi	ADJ	JJ	Degree=Pos	19	acl:relcl	19:acl:relcl	SpaceAfter=No
+29	Saudi	Saudi	ADJ	JJ	Degree=Pos	19	acl:relcl	19:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
 30	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041018060600_ENG_20041018_060600-0013
@@ -4107,7 +4107,7 @@
 13	thought	thought	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	which	which	PRON	WDT	PronType=Rel	16	nsubj	9:ref	_
-16	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+16	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
 17	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 18	Protestant	Protestant	PROPN	NNP	Number=Sing	20	compound	20:compound	SpaceAfter=No
 19	-	-	PUNCT	HYPH	_	18	punct	18:punct	SpaceAfter=No
@@ -4269,7 +4269,7 @@
 13	where	where	ADV	WRB	PronType=Rel	16	advmod	12:ref	_
 14	there	there	PRON	EX	_	16	expl	16:expl	_
 15	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
-16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=Existential-CopPred-ThereExpl
+16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=Existential-CopPred-ThereExpl,rc-wh-obl
 17	none	none	PRON	NN	PronType=Neg	16	nsubj	16:nsubj	CxnElt=16:Existential-CopPred-ThereExpl.Pivot
 18	before	before	ADV	RB	_	16	advmod	16:advmod	SpaceAfter=No
 19	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -4302,7 +4302,7 @@
 24	in	in	ADP	IN	_	25	case	25:case	_
 25	Tangiers	tangier	NOUN	NNS	Number=Plur	16	obl	16:obl:in|27:nsubj	_
 26	that	that	PRON	WDT	PronType=Rel	27	nsubj	25:ref	_
-27	morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
+27	morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	Cxn=rc-that-nsubj
 28	into	into	SCONJ	IN	_	35	mark	35:mark	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 30	Moroccan	Moroccan	PROPN	NNP	Number=Sing	33	compound	33:compound	_
@@ -4313,7 +4313,7 @@
 35	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	27	advcl	27:advcl:into	_
 36	members	member	NOUN	NNS	Number=Plur	35	obj	35:obj|38:nsubj|51:nsubj	_
 37	who	who	PRON	WP	PronType=Rel	38	nsubj	36:ref	_
-38	met	meet	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
+38	met	meet	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	Cxn=rc-wh-nsubj
 39	with	with	ADP	IN	_	42	case	42:case	_
 40	September	September	PROPN	NNP	Number=Sing	42	compound	42:compound	_
 41	11	11	NUM	CD	NumForm=Digit|NumType=Card	40	nummod	40:nummod	_
@@ -4360,13 +4360,13 @@
 6	which	which	PRON	WDT	PronType=Rel	9	obl	4:ref	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	US	US	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
-9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pfront
 10	key	key	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	mistakes	mistake	NOUN	NNS	Number=Plur	9	obj	9:obj|15:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj	11:ref	_
 13	might	might	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	have	have	AUX	VB	VerbForm=Inf	15	aux	15:aux	_
-15	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
+15	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
 16	Bin	Bin	PROPN	NNP	Number=Sing	19	nmod:poss	19:nmod:poss	_
 17-18	Laden's	_	_	_	_	_	_	_	_
 17	Laden	Laden	PROPN	NNP	Number=Sing	16	flat	16:flat	_
@@ -4763,7 +4763,7 @@
 8	bases	basis	NOUN	NNS	Number=Plur	2	nmod	2:nmod:about|11:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	11	nsubj	8:ref	_
 10	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
-11	trained	train	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
+11	trained	train	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	9/11	9/11	NUM	CD	NumForm=Digit|NumType=Card	14	compound	14:compound	_
 14	hijackers	hijacker	NOUN	NNS	Number=Plur	11	obj	11:obj	_
@@ -4799,7 +4799,7 @@
 17	that	that	PRON	WDT	PronType=Rel	20	obj	8:ref	_
 18	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
 19	could	could	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	pull	pull	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	_
+20	pull	pull	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	Cxn=rc-that-obj
 21	off	off	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	shelf	shelf	NOUN	NN	Number=Sing	20	obl	20:obl:off	SpaceAfter=No
@@ -4882,7 +4882,7 @@
 27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
 28	threat	threat	NOUN	NN	Number=Sing	24	conj	21:obl:about|24:conj:and|30:obj	_
 29	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	posed	pose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	SpaceAfter=No
+30	posed	pose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 31	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0024
@@ -4940,7 +4940,7 @@
 12	officers	officer	NOUN	NNS	Number=Plur	8	nmod	8:nmod:from|15:nsubj	SpaceAfter=No
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
 14	who	who	PRON	WP	PronType=Rel	15	nsubj	12:ref	_
-15	outranked	outrank	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+15	outranked	outrank	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
 16	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obj	15:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	22	punct	22:punct	_
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
@@ -4977,7 +4977,7 @@
 48	the	the	DET	DT	Definite=Def|PronType=Art	49	det	49:det	_
 49	CIA	CIA	PROPN	NNP	Number=Sing	51	nsubj	51:nsubj	_
 50	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	51	aux	51:aux	_
-51	picking	pick	VERB	VBG	Tense=Pres|VerbForm=Part	47	acl:relcl	47:acl:relcl	_
+51	picking	pick	VERB	VBG	Tense=Pres|VerbForm=Part	47	acl:relcl	47:acl:relcl	Cxn=rc-red-obj
 52	up	up	ADP	RP	_	51	compound:prt	51:compound:prt	_
 53	from	from	ADP	IN	_	56	case	56:case	_
 54	radical	radical	ADJ	JJ	Degree=Pos	56	amod	56:amod	_
@@ -5024,7 +5024,7 @@
 17	that	that	PRON	WDT	PronType=Rel	20	nsubj	6:ref	_
 18	would	would	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 19	have	have	AUX	VB	VerbForm=Inf	20	aux	20:aux	_
-20	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+20	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	US	US	PROPN	NNP	Number=Sing	20	iobj	20:iobj|24:nsubj:xsubj	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
@@ -5266,7 +5266,7 @@
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	how	how	ADV	WRB	PronType=Rel	0	root	0:root|8:xcomp	_
 4	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	_
+5	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-xcomp_xcomp
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	obj	5:obj|8:nsubj:xsubj	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	refer	refer	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
@@ -5501,7 +5501,7 @@
 3	thinking	think	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	somewhere	somewhere	ADV	RB	PronType=Ind	3	obj	3:obj|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	requires	require	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
+6	requires	require	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-that-nsubj
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	jacket	jacket	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
@@ -5517,7 +5517,7 @@
 2	that	that	PRON	WDT	PronType=Rel	5	nsubj	1:ref	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	like	like	ADP	IN	_	5	case	5:case	_
-5	$	$	SYM	$	_	1	advcl:relcl	1:advcl:relcl	SpaceAfter=No
+5	$	$	SYM	$	_	1	advcl:relcl	1:advcl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 6	30	30	NUM	CD	NumForm=Digit|NumType=Card	5	nummod	5:nummod	_
 7	an	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	entree	entree	NOUN	NN	Number=Sing	5	nmod:unmarked	5:nmod:unmarked	SpaceAfter=No
@@ -5599,7 +5599,7 @@
 10	other	other	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	girl	girl	NOUN	NN	Number=Sing	6	obl	6:obl:with|13:obl	_
 12	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl-pstrand
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	bet	bet	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	with	with	ADP	IN	_	13	obl	13:obl	Promoted=Yes|SpaceAfter=No
@@ -5991,7 +5991,7 @@
 4	risk	risk	NOUN	NN	Number=Sing	0	root	0:root|7:obj	_
 5	that	that	PRON	WDT	PronType=Rel	7	obj	4:ref	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-obj
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
@@ -6103,7 +6103,7 @@
 8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	7	nsubj	7:nsubj|11:obj	CxnElt=7:Existential-CopPred-ThereExpl.Pivot
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	can	can	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	do	do	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	_
+11	do	do	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
 12	but	but	CCONJ	CC	_	16	cc	16:cc	_
 13-14	I'm	_	_	_	_	_	_	_	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
@@ -6325,7 +6325,7 @@
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	time	time	NOUN	NN	Number=Sing	2	obl	2:obl:at	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	5:ref	_
-10	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+10	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 11	overdue	overdue	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	margin	margin	NOUN	NN	Number=Sing	10	obj	10:obj	SpaceAfter=No
 13	:	:	PUNCT	:	_	2	punct	2:punct	_
@@ -6501,7 +6501,7 @@
 9	conference	conference	NOUN	NN	Number=Sing	5	nmod	5:nmod:from|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+12	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-obj
 13	today	today	NOUN	NN	Number=Sing	12	obl:unmarked	12:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 14	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -6814,7 +6814,7 @@
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	lesson	lesson	NOUN	NN	Number=Sing	0	root	0:root|17:obj	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-17	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj
 18	following	follow	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	Ark	Ark	PROPN	NNP	Number=Sing	21	compound	21:compound	_
@@ -7079,7 +7079,7 @@
 6	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj|9:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 7	who	who	PRON	WP	PronType=Rel	9	nsubj	6:ref	_
 8	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	consider	consider	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
+9	consider	consider	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	correlation	correlation	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	between	between	ADP	IN	_	14	case	14:case	_
@@ -7132,7 +7132,7 @@
 6	suggestions	suggestion	NOUN	NNS	Number=Plur	4	conj	1:obl:for|4:conj:or	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	provide	provide	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+9	provide	provide	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent18_01-0011
@@ -7590,7 +7590,7 @@
 12	CASH	cash	NOUN	NN	Number=Sing	9	obj	9:obj|15:nsubj:pass	_
 13	that	that	PRON	WDT	PronType=Rel	15	nsubj:pass	12:ref	_
 14	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
-15	drawn	draw	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
+15	drawn	draw	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass
 16	down	down	ADV	RB	_	15	advmod	15:advmod	SpaceAfter=No
 17	...	...	PUNCT	,	_	19	punct	19:punct	SpaceAfter=No
 18	please	please	INTJ	UH	_	19	discourse	19:discourse	_
@@ -7784,7 +7784,7 @@
 15	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 16	]	]	PUNCT	-RRB-	_	7	punct	7:punct	_
 17	who	who	PRON	WP	PronType=Rel	18	nsubj	4:ref	_
-18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	18	obl	18:obl:to	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_
@@ -7915,7 +7915,7 @@
 12	13s	13	NOUN	NNS	Number=Plur	7	nmod	7:nmod:for|15:nsubj:pass	_
 13	which	which	PRON	WDT	PronType=Rel	15	nsubj:pass	12:ref	_
 14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	15	aux:pass	15:aux:pass	CorrectForm=is|CorrectNumber=Sing
-15	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
+15	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj:pass
 16	to	to	ADP	IN	_	19	case	19:case	_
 17	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 18	sample	sample	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -8296,7 +8296,7 @@
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	28:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	good	good	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
-28	time	time	NOUN	NN	Number=Sing	23	advcl:relcl	23:advcl:relcl	SpaceAfter=No
+28	time	time	NOUN	NN	Number=Sing	23	advcl:relcl	23:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
 29	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent09_02-0008
@@ -8876,7 +8876,7 @@
 5	Master	master	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	draft	draft	NOUN	NN	Number=Sing	2	nsubj	2:nsubj|8:obj	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+8	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent29_02-0011
@@ -8913,7 +8913,7 @@
 12	standard	standard	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	template	template	NOUN	NN	Number=Sing	9	nmod	9:nmod:of|15:obj	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+15	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
 16	for	for	ADP	IN	_	20	case	20:case	_
 17	Enfolio	Enfolio	PROPN	NNP	Number=Sing	20	compound	20:compound	_
 18	gas	gas	NOUN	NN	Number=Sing	19	compound	19:compound	_
@@ -9646,7 +9646,7 @@
 10	since	since	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	Depression	Depression	PROPN	NNP	Number=Sing	9	nmod	9:nmod:since	_
-13	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+13	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
 14	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	way	way	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	down	down	ADV	RB	_	13	advmod	13:advmod	SpaceAfter=No
@@ -9875,7 +9875,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	spreadsheet	spreadsheet	NOUN	NN	Number=Sing	1	nsubj:pass	1:nsubj:pass|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	contains	contain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	contains	contain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	values	value	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -9927,7 +9927,7 @@
 11	which	which	PRON	WDT	PronType=Rel	14	nsubj	10:ref	_
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-14	difference	difference	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	_
+14	difference	difference	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nsubj
 15	between	between	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 17	SCADA	scada	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -9938,7 +9938,7 @@
 22	)	)	PUNCT	-RRB-	_	21	punct	21:punct	_
 23	that	that	PRON	WDT	PronType=Rel	25	obj	18:ref	_
 24	Anita	Anita	PROPN	NNP	Number=Sing	25	nsubj	25:nsubj	_
-25	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+25	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-that-obj
 26	on	on	ADP	IN	_	31	case	31:case	_
 27	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 28	February	February	PROPN	NNP	Number=Sing	31	compound	31:compound	_
@@ -9956,7 +9956,7 @@
 40	that	that	PRON	WDT	PronType=Rel	43	obj	39:ref	_
 41	Gary	Gary	PROPN	NNP	Number=Sing	43	nsubj	43:nsubj	_
 42	Wilson	Wilson	PROPN	NNP	Number=Sing	41	flat	41:flat	_
-43	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	_
+43	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	Cxn=rc-that-obj
 44	from	from	ADP	IN	_	45	case	45:case	_
 45	MIPS	mips	NOUN	NN	Number=Sing	43	obl	43:obl:from	SpaceAfter=No
 46	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -10279,7 +10279,7 @@
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj	1:ref	_
 11	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 12	not	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	relate	relate	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
+13	relate	relate	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-that-nsubj
 14	to	to	ADP	IN	_	17	case	17:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	official	official	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -10347,7 +10347,7 @@
 7	firm	firm	NOUN	NN	Number=Sing	0	root	0:root|10:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	10	nsubj	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
-10	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
+10	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	an	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	individual	individual	NOUN	NN	Number=Sing	10	obl	10:obl:for	_
@@ -10517,7 +10517,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	people	people	NOUN	NNS	Number=Plur	3	obl	3:obl:from|12:obj	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
+12	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj
 13	at	at	ADP	IN	_	14	case	14:case	_
 14	ENE	ENE	PROPN	NNP	Number=Sing	12	obl	12:obl:at	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -10665,7 +10665,7 @@
 10	gas	gas	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	traders	trader	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|13:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	made	make	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	made	make	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
 14	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 15	now	now	ADV	RB	PronType=Dem	17	advmod	17:advmod	_
 16	almost	almost	ADV	RB	_	17	advmod	17:advmod	_
@@ -10761,7 +10761,7 @@
 28	what	what	PRON	WP	PronType=Rel	26	obl	26:obl:to|31:obj	_
 29	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	31	nsubj	31:nsubj	_
 30	all	all	DET	DT	PronType=Tot	29	det	29:det	_
-31	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
+31	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-free-obj
 32	in	in	ADP	IN	_	33	case	33:case	_
 33	mind	mind	NOUN	NN	Number=Sing	31	obl	31:obl:in	SpaceAfter=No
 34	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -11086,7 +11086,7 @@
 18	banks	bank	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 19	which	which	PRON	WDT	PronType=Rel	21	nsubj:pass	13:ref	_
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	granted	grant	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	acl:relcl	13:acl:relcl	_
+21	granted	grant	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj:pass
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	connection	connection	NOUN	NN	Number=Sing	21	obl	21:obl:in	_
 24	with	with	ADP	IN	_	29	case	29:case	_
@@ -11137,7 +11137,7 @@
 17	form	form	NOUN	NN	Number=Sing	12	xcomp	12:xcomp|20:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	20	nsubj	17:ref	_
 19	will	will	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	acceptable	acceptable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	_
+20	acceptable	acceptable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
 21	to	to	ADP	IN	_	24	case	24:case	_
 22	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	24	nmod:poss	24:nmod:poss	_
 23	project	project	NOUN	NN	Number=Sing	24	compound	24:compound	_
@@ -11157,7 +11157,7 @@
 37	form	form	NOUN	NN	Number=Sing	34	obl	34:obl:with|40:nsubj:pass|48:nsubj:pass	_
 38	that	that	PRON	WDT	PronType=Rel	40	nsubj:pass	37:ref	_
 39	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	40	aux:pass	40:aux:pass	_
-40	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	37	acl:relcl	37:acl:relcl	_
+40	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	37	acl:relcl	37:acl:relcl	Cxn=rc-that-nsubj:pass
 41	in	in	ADP	IN	_	44	case	44:case	_
 42	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	44	nmod:poss	44:nmod:poss	_
 43	last	last	ADJ	JJ	Degree=Pos	44	amod	44:amod	_
@@ -11190,7 +11190,7 @@
 13	that	that	PRON	WDT	PronType=Rel	16	nsubj:pass	12:ref	_
 14	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 15	be	be	AUX	VB	VerbForm=Inf	16	aux:pass	16:aux:pass	_
-16	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
+16	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	favor	favor	NOUN	NN	Number=Sing	16	obl	16:obl:in	_
 19	of	of	ADP	IN	_	20	case	20:case	_
@@ -11683,7 +11683,7 @@
 10	consulting	consulting	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	arrangement	arrangement	NOUN	NN	Number=Sing	5	obl	5:obl:regarding|13:obj	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	couple	couple	NOUN	NN	Number=Sing	18	obl:unmarked	18:obl:unmarked	_
 16	of	of	ADP	IN	_	17	case	17:case	_
@@ -11708,7 +11708,7 @@
 13	contract	contract	NOUN	NN	Number=Sing	5	obl	5:obl:with|16:obl|28:obl	_
 14	where	where	ADV	WRB	PronType=Rel	16	advmod	13:ref	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|28:nsubj	_
-16	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+16	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-obl
 17	some	some	DET	DT	PronType=Ind	18	det	18:det	_
 18	thoughts	thought	NOUN	NNS	Number=Plur	16	obj	16:obj	_
 19	to	to	ADP	IN	_	21	case	21:case	_
@@ -11718,7 +11718,7 @@
 23	issues	issue	NOUN	NNS	Number=Plur	21	nmod	21:nmod:of	_
 24	that	that	PRON	WDT	PronType=Rel	26	obj	21:ref	_
 25	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
+26	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-that-obj
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
 28	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	16	conj	13:acl:relcl|16:conj:and	_
 29	to	to	ADP	IN	_	30	case	30:case	_
@@ -11795,7 +11795,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	resume	resume	NOUN	NN	Number=Sing	9	nmod	9:nmod:at|14:obj	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
+14	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
 15	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	14	iobj	14:iobj	SpaceAfter=No
 16	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -11913,7 +11913,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	presentation	presentation	NOUN	NN	Number=Sing	5	nsubj:pass	5:nsubj:pass|10:obj	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
 11	at	at	ADP	IN	_	16	case	16:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 13	Canadian	Canadian	ADJ	NNP	Degree=Pos	16	amod	16:amod	_
@@ -12380,7 +12380,7 @@
 16	could	could	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
 17	be	be	AUX	VB	VerbForm=Inf	19	aux:pass	19:aux:pass	_
 18	successfully	successfully	ADV	RB	_	19	advmod	19:advmod	_
-19	accomplished	accomplish	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+19	accomplished	accomplish	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent18_02-0070
@@ -12418,7 +12418,7 @@
 11	elsewhere	elsewhere	ADV	RB	_	6	conj	5:advmod|6:conj:or|14:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	14	nsubj	11:ref	_
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
-14	appropriate	appropriate	ADJ	JJ	Degree=Pos	11	advcl:relcl	11:advcl:relcl	SpaceAfter=No
+14	appropriate	appropriate	ADJ	JJ	Degree=Pos	11	advcl:relcl	11:advcl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent18_02-0072
@@ -12587,7 +12587,7 @@
 7	books	book	NOUN	NNS	Number=Plur	5	conj	3:obj|5:conj:and|10:obj	_
 8	that	that	PRON	WDT	PronType=Rel	10	obj	5:ref	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+10	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-obj
 11	last	last	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	week	week	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -12707,7 +12707,7 @@
 8	other	other	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	possibilities	possibility	NOUN	NNS	Number=Plur	12	nsubj	11:obj|12:nsubj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
 12	better	good	ADJ	JJR	Degree=Cmp	3	conj	3:conj:or	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -12795,7 +12795,7 @@
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	nmod	2:nmod:of	_
 5	who	who	PRON	WP	PronType=Rel	7	nsubj	2:ref	_
 6	already	already	ADV	RB	_	7	advmod	7:advmod	_
-7	sent	send	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+7	sent	send	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-nsubj
 8	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	7	iobj	7:iobj	_
 9	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	RSVP	rsvp	NOUN	NN	Number=Sing	11	compound	11:compound	_
@@ -13071,7 +13071,7 @@
 8	few	few	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	times	time	NOUN	NNS	Number=Plur	4	obl:unmarked	4:obl:unmarked|11:obl	TemporalNPAdjunct=Yes
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+11	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obl
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -13318,7 +13318,7 @@
 11	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 12	with	with	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-14	estate	estate	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+14	estate	estate	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent21_02-0064
@@ -13818,7 +13818,7 @@
 34	coupled	coupled	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	friends	friend	NOUN	NNS	Number=Plur	32	nmod	32:nmod:with|37:nsubj|40:nsubj:xsubj	_
 36	who	who	PRON	WP	PronType=Rel	37	nsubj	35:ref	_
-37	happen	happen	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	_
+37	happen	happen	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	Cxn=rc-wh-nsubj
 38	to	to	PART	TO	_	40	mark	40:mark	_
 39	be	be	AUX	VB	VerbForm=Inf	40	cop	40:cop	_
 40	gay	gay	ADJ	JJ	Degree=Pos	37	xcomp	37:xcomp	SpaceAfter=No
@@ -14401,7 +14401,7 @@
 18	'	'	PUNCT	''	_	10	punct	10:punct	SpaceAfter=No
 19	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 20	aptly	aptly	ADV	RB	_	21	advmod	21:advmod	_
-21	summarised	summarise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+21	summarised	summarise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	nature	nature	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	of	of	ADP	IN	_	26	case	26:case	_
@@ -14641,7 +14641,7 @@
 14	cortex	cortex	NOUN	NN	Number=Sing	9	nmod	9:nmod:in	SpaceAfter=No
 15	,	,	PUNCT	,	_	17	punct	17:punct	_
 16	which	which	PRON	WDT	PronType=Rel	17	nsubj	9:ref	_
-17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
+17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
 18	important	important	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	implications	implication	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	for	for	ADP	IN	_	22	case	22:case	_
@@ -14993,7 +14993,7 @@
 5	sport	sport	NOUN	NN	Number=Sing	3	conj	3:conj:and|6:compound	_
 6	headlines	headline	NOUN	NNS	Number=Plur	1	obj	1:obj|8:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 9	-	-	PUNCT	,	_	12	punct	12:punct	_
 10	when	when	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
@@ -15270,7 +15270,7 @@
 9	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 10	not	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
 11	only	only	ADV	RB	_	12	advmod	12:advmod	_
-12	help	help	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	_
+12	help	help	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 13	strengthen	strengthen	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 15	Chinese	Chinese	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -15669,7 +15669,7 @@
 10	Professional	professional	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	Vendor	vendor	NOUN	NN	Number=Sing	3	conj	3:conj:or|13:nsubj|31:advcl:if	_
 12	who	who	PRON	WP	PronType=Rel	13	nsubj	11:ref	_
-13	exhibits	exhibit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	exhibits	exhibit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-nsubj
 14	at	at	ADP	IN	_	21	case	21:case	_
 15	Sport	sport	NOUN	NN	Number=Sing	21	compound	21:compound	SpaceAfter=No
 16	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -16270,7 +16270,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	who	who	PRON	WP	PronType=Rel	20	nsubj	16:ref	_
 19	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
-20	known	know	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	_
+20	known	know	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nsubj
 21	no	no	DET	DT	PronType=Neg	23	det	23:det	_
 22	major	major	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	defeat	defeat	NOUN	NN	Number=Sing	20	obj	20:obj	_
@@ -16337,12 +16337,12 @@
 8	people	people	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|11:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
-11	taking	take	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
+11	taking	take	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
 12	action	action	NOUN	NN	Number=Sing	11	obj	11:obj	_
 13	on	on	ADP	IN	_	14	case	14:case	_
 14	issues	issue	NOUN	NNS	Number=Plur	11	obl	11:obl:on|16:nsubj	_
 15	that	that	PRON	WDT	PronType=Rel	16	nsubj	14:ref	_
-16	concern	concern	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	concern	concern	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
 17	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	obj	16:obj	SpaceAfter=No
 18	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -16428,7 +16428,7 @@
 19	where	where	ADV	WRB	PronType=Rel	22	advmod	18:ref	_
 20	people	people	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	exchange	exchange	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	_
+22	exchange	exchange	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-obl
 23	ideas	idea	NOUN	NNS	Number=Plur	22	obj	22:obj	_
 24	and	and	CCONJ	CC	_	25	cc	25:cc	_
 25	advice	advice	NOUN	NN	Number=Sing	23	conj	22:obj|23:conj:and	SpaceAfter=No
@@ -16446,7 +16446,7 @@
 8	from	from	ADP	IN	_	9	case	9:case	_
 9	CHANT	CHANT	PROPN	NNP	Number=Sing	7	nmod	7:nmod:from	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	7:ref	_
-11	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+11	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 12	this	this	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
 13	page	page	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
@@ -16512,7 +16512,7 @@
 3	attach	attach	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	anything	anything	PRON	NN	Number=Sing|PronType=Ind	3	obj	3:obj|6:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
 7	to	to	ADP	IN	_	8	case	8:case	_
 8	pages	page	NOUN	NNS	Number=Plur	3	obl	3:obl:to	_
 9	for	for	ADP	IN	_	12	case	12:case	_
@@ -16636,7 +16636,7 @@
 13	best	good	ADJ	JJS	Degree=Sup	14	amod	14:amod	_
 14	friend	friend	NOUN	NN	Number=Sing	20	nsubj	16:nsubj|20:nsubj	_
 15	who	who	PRON	WP	PronType=Rel	16	nsubj	14:ref	_
-16	lives	live	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	lives	live	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
 17	next	next	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	door	door	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
@@ -16734,7 +16734,7 @@
 14	what	what	PRON	WP	PronType=Rel	4	parataxis	4:parataxis|17:obj|20:nsubj:xsubj	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	would	would	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	call	call	VERB	VB	VerbForm=Inf	14	acl:relcl	14:acl:relcl	_
+17	call	call	VERB	VB	VerbForm=Inf	14	acl:relcl	14:acl:relcl	Cxn=rc-free-obj
 18	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 19	GREAT	great	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 20	LOSS	loss	NOUN	NN	Number=Sing	17	xcomp	17:xcomp	SpaceAfter=No
@@ -16775,7 +16775,7 @@
 14	here	here	ADV	RB	PronType=Dem	12	advmod	12:advmod	_
 15	who	who	PRON	WP	PronType=Rel	17	nsubj	12:ref	_
 16	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	give	give	VERB	VB	VerbForm=Inf	12	acl:relcl	12:acl:relcl	_
+17	give	give	VERB	VB	VerbForm=Inf	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	iobj	17:iobj	_
 19	an	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 20	example	example	NOUN	NN	Number=Sing	17	obj	17:obj	_
@@ -16962,7 +16962,7 @@
 10	architecture	architecture	NOUN	NN	Number=Sing	7	obj	7:obj|13:nsubj	_
 11	that	that	PRON	WDT	PronType=Rel	13	nsubj	10:ref	_
 12	will	will	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	establish	establish	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
+13	establish	establish	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	equivalent	equivalent	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	of	of	ADP	IN	_	21	case	21:case	_
@@ -17297,7 +17297,7 @@
 24	this	this	DET	DT	Number=Sing|PronType=Dem	25	det	25:det	_
 25	country	country	NOUN	NN	Number=Sing	27	nsubj	27:nsubj	_
 26	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	aux	27:aux	_
-27	developed	develop	VERB	VBN	Tense=Past|VerbForm=Part	23	acl:relcl	23:acl:relcl	_
+27	developed	develop	VERB	VBN	Tense=Past|VerbForm=Part	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obj
 28	in	in	ADP	IN	_	32	case	32:case	_
 29	more	more	ADJ	JJR	Degree=Cmp|ExtPos=ADV	32	advmod	32:advmod	_
 30	than	than	ADP	IN	_	29	fixed	29:fixed	_
@@ -18223,7 +18223,7 @@
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	man	man	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
-7	wise	wise	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	_
+7	wise	wise	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
 8	enough	enough	ADV	RB	_	7	advmod	7:advmod	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	watch	watch	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:to	_
@@ -18735,7 +18735,7 @@
 3	shop	shop	NOUN	NN	Number=Sing	0	root	0:root|6:obl	_
 4	that	that	PRON	WDT	PronType=Rel	6	obl	3:ref	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+6	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-that-obl-pstrand
 7	of	of	ADP	IN	_	4	case	4:case	_
 8	AND	and	CCONJ	CC	_	10	cc	10:cc	_
 9	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -18893,7 +18893,7 @@
 8	sports	sport	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	6:ref	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-11	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+11	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj
 12	like	like	ADP	IN	_	13	case	13:case	_
 13	basketball	basketball	NOUN	NN	Number=Sing	6	nmod	6:nmod:like	SpaceAfter=No
 14	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -18931,7 +18931,7 @@
 2	Hank	Hank	PROPN	NNP	Number=Sing	8	nsubj	5:obj|8:nsubj	_
 3	Green	Green	PROPN	NNP	Number=Sing	2	flat	2:flat	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+5	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	hardly	hardly	ADV	RB	_	8	advmod	8:advmod	_
 8	awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -19117,7 +19117,7 @@
 14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
 15	n't	not	PART	RB	Polarity=Neg	17	advmod	17:advmod	_
 16	very	very	ADV	RB	_	17	advmod	17:advmod	_
-17	common	common	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	_
+17	common	common	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	conj	12:acl:relcl|17:conj:and	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
@@ -19417,7 +19417,7 @@
 7-8	Ive	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	9	aux	9:aux	CorrectForm='ve
-9	read	read	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+9	read	read	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 10	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 11	so	so	ADV	RB	_	10	advmod	10:advmod	_
 12	and	and	CCONJ	CC	_	15	cc	15:cc	_
@@ -19472,7 +19472,7 @@
 18	dinner	dinner	NOUN	NN	Number=Sing	13	obl	13:obl:for	_
 19	where	where	ADV	WRB	PronType=Rel	21	advmod	11:ref	_
 20	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+21	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
 22	music	music	NOUN	NN	Number=Sing	21	obj	21:obj	_
 23	and	and	CCONJ	CC	_	25	cc	25:cc	_
 24	there	there	PRON	EX	_	25	expl	25:expl	_
@@ -19597,12 +19597,12 @@
 1	Name	name	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	something	something	PRON	NN	Number=Sing|PronType=Ind	1	obj	1:obj|4:obj|9:nsubj	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 5	at	at	ADP	IN	_	7	case	7:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	carnival	carnival	NOUN	NN	Number=Sing	4	obl	4:obl:at	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	2:ref	_
-9	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+9	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
 10	on	on	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	stick	stick	NOUN	NN	Number=Sing	9	obl	9:obl:on	SpaceAfter=No
@@ -19928,7 +19928,7 @@
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	breeds	breed	NOUN	NNS	Number=Plur	2	obj	2:obj|7:nsubj|10:nsubj:xsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	lot	lot	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	_
 10	alike	alike	ADJ	JJ	Degree=Pos	7	xcomp	7:xcomp	SpaceAfter=No
@@ -20108,7 +20108,7 @@
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	people	people	NOUN	NNS	Number=Plur	9	nmod	9:nmod:of	_
 12	who	who	PRON	WP	PronType=Rel	13	nsubj	9:ref	_
-13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Promoted=Yes|SpaceAfter=No
+13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj-auxstrand|Promoted=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111107214231AA68BMD_ans-0005
@@ -20148,7 +20148,7 @@
 6	system	system	NOUN	NN	Number=Sing	0	root	0:root|9:obj	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	can	can	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	buy	buy	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
+9	buy	buy	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	philadelphia	Philadelphia	PROPN	NNP	Number=Sing	9	obl	9:obl:in	_
 12	pa	PA	PROPN	NNP	Number=Sing	11	appos	11:appos	SpaceAfter=No
@@ -20897,7 +20897,7 @@
 5	whatever	whatever	DET	WDT	PronType=Int	6	det	6:det	_
 6	age	age	NOUN	NN	Number=Sing	3	obl:unmarked	3:obl:unmarked|8:obl	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Promoted=Yes|SpaceAfter=No
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl-auxstrand|Promoted=Yes|SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = answers-20111108074555AAFT8Aj_ans
@@ -20911,7 +20911,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	device	device	NOUN	NN	Number=Sing	4	obj	4:obj|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	hold	hold	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	6	acl:relcl	6:acl:relcl	CorrectForm=holds|CorrectNumber=Sing
+8	hold	hold	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	6	acl:relcl	6:acl:relcl	CorrectForm=holds|CorrectNumber=Sing|Cxn=rc-that-nsubj
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 11	photography	photography	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -21155,7 +21155,7 @@
 16	computer	computer	NOUN	NN	Number=Sing	12	obl	12:obl:to|19:nsubj:pass	_
 17	that	that	PRON	WDT	PronType=Rel	19	nsubj:pass	16:ref	_
 18	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux:pass	19:aux:pass	_
-19	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	_
+19	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	Cxn=rc-that-nsubj:pass
 20	off	off	ADP	RP	_	19	compound:prt	19:compound:prt	SpaceAfter=No
 21	?	?	PUNCT	.	_	7	punct	7:punct	_
 
@@ -21222,7 +21222,7 @@
 7	now	now	ADV	RB	PronType=Dem	3	advmod	3:advmod	SpaceAfter=No
 8	,	,	PUNCT	,	_	10	punct	10:punct	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	4:ref	_
-10	allow	allow	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+10	allow	allow	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	PC	pc	NOUN	NN	Number=Sing	10	iobj	10:iobj|14:nsubj:xsubj|21:nsubj:xsubj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -21304,7 +21304,7 @@
 3	some	some	DET	DT	PronType=Ind	4	det	4:det	_
 4	articles	article	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	discuss	discuss	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	discuss	discuss	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	details	detail	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -21398,7 +21398,7 @@
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	camera	camera	NOUN	NN	Number=Sing	3	obl	3:obl:for|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
 9	really	really	ADV	RB	_	10	advmod	10:advmod	_
 10	good	good	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	zoom	zoom	NOUN	NN	Number=Sing	8	obj	8:obj	_
@@ -21441,7 +21441,7 @@
 21	)	)	PUNCT	-RRB-	_	20	punct	20:punct	_
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 23	should	should	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	purchase	purchase	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	SpaceAfter=No
+24	purchase	purchase	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108083559AAp6Jfq_ans-0004
@@ -21700,7 +21700,7 @@
 3	what	what	PRON	WP	PronType=Rel	0	root	0:root|6:obl:to	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause,3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	referring	refer	VERB	VBG	Tense=Pres|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
+6	referring	refer	VERB	VBG	Tense=Pres|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obl-pstrand
 7	to	to	ADP	IN	_	6	obl	3:case	Promoted=Yes|SpaceAfter=No
 8	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -21817,7 +21817,7 @@
 7	heat	heat	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	source	source	NOUN	NN	Number=Sing	5	obj	5:obj|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	creates	create	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	creates	create	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	basking	basking	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	temp	temp	NOUN	NN	Number=Sing	10	obj	10:obj	_
@@ -22180,7 +22180,7 @@
 19	girl	girl	NOUN	NN	Number=Sing	8	conj	7:obj|8:conj:and|22:obj	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	really	really	ADV	RB	_	22	advmod	22:advmod	_
-22	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	_
+22	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj
 23	out	out	ADP	RP	_	7	compound:prt	7:compound:prt	_
 24	to	to	ADP	IN	_	25	case	25:case	_
 25	dinner	dinner	NOUN	NN	Number=Sing	7	obl	7:obl:to	_
@@ -22527,7 +22527,7 @@
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	canada	Canada	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
 17	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	grew	grow	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+18	grew	grow	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obl-pstrand
 19	up	up	ADP	RP	_	18	compound:prt	18:compound:prt	_
 20	in	in	ADP	IN	_	18	obl	18:obl	Promoted=Yes
 21	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
@@ -22718,7 +22718,7 @@
 9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 10	from	from	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
-12	UK	UK	PROPN	NNP	Number=Sing	5	acl:relcl	5:acl:relcl	_
+12	UK	UK	PROPN	NNP	Number=Sing	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	US	US	PROPN	NNP	Number=Sing	12	conj	5:acl:relcl|12:conj:and	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -22811,7 +22811,7 @@
 10	last	last	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	one	one	NOUN	NN	Number=Sing	14	nsubj	13:obj|14:nsubj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	bought	buy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
+13	bought	buy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 14	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 15	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	14	obj	14:obj|16:nsubj:xsubj	_
 16	soaked	soaked	ADJ	JJ	Degree=Pos	14	xcomp	14:xcomp	_
@@ -22972,7 +22972,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	buffer	buffer	NOUN	NN	Number=Sing	0	root	0:root|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	holds	hold	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
+8	holds	hold	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	data	data	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	until	until	SCONJ	IN	_	14	mark	14:mark	_
@@ -23020,7 +23020,7 @@
 1	All	all	DET	DT	PronType=Tot	6	nsubj:outer	4:obj|6:nsubj:outer|14:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	do	do	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
+4	do	do	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	each	each	DET	DT	PronType=Tot	8	det	8:det	_
@@ -23479,7 +23479,7 @@
 6	burger	burger	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	formula	formula	NOUN	NN	Number=Sing	3	obj	3:obj|9:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+9	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
 10	about	about	ADV	RB	_	11	advmod	11:advmod	_
 11	80	80	NUM	CD	NumForm=Digit|NumType=Card	12	nummod	12:nummod	_
 12	years	year	NOUN	NNS	Number=Plur	13	obl:unmarked	13:obl:unmarked	_
@@ -23737,7 +23737,7 @@
 55	to	_	X	IN	_	54	goeswith	54:goeswith	_
 56	something	something	PRON	NN	Number=Sing|PronType=Ind	53	obl	53:obl:to|58:nsubj|61:nsubj:xsubj	_
 57	that	that	PRON	WDT	PronType=Rel	58	nsubj	56:ref	_
-58	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	56	acl:relcl	56:acl:relcl	_
+58	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	56	acl:relcl	56:acl:relcl	Cxn=rc-that-nsubj-pstrand
 59	to	to	PART	TO	_	61	mark	61:mark	_
 60	be	be	AUX	VB	VerbForm=Inf	61	aux:pass	61:aux:pass	_
 61	attended	attend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	58	xcomp	58:xcomp	_
@@ -23930,7 +23930,7 @@
 33	could	could	AUX	MD	VerbForm=Fin	36	aux	36:aux	_
 34	have	have	AUX	VB	VerbForm=Inf	36	aux	36:aux	_
 35	been	be	AUX	VBN	Tense=Past|VerbForm=Part	36	aux:pass	36:aux:pass	_
-36	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	_
+36	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	Cxn=rc-that-nsubj:pass
 37	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	36	advcl	36:advcl	_
 38	a	a	DET	DT	Definite=Ind|PronType=Art	39	det	39:det	_
 39	statue	statue	NOUN	NN	Number=Sing	37	obj	37:obj	_
@@ -23980,7 +23980,7 @@
 23	style	style	NOUN	NN	Number=Sing	24	compound	24:compound	_
 24	restaurant	restaurant	NOUN	NN	Number=Sing	18	nmod	18:nmod:of|26:obj	_
 25	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	_
+26	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	Cxn=rc-red-obj
 27	while	while	SCONJ	IN	_	29	mark	29:mark	_
 28	out	out	ADV	RB	_	29	advmod	29:advmod	_
 29	there	there	ADV	RB	PronType=Dem	26	advcl	26:advcl:while	_
@@ -24082,7 +24082,7 @@
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	SpaceAfter=No
 5	-	-	PUNCT	HYPH	_	4	punct	4:punct	SpaceAfter=No
-6	eat	eat	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
+6	eat	eat	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
 7	style	style	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	deal	deal	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 9	.	.	PUNCT	.	_	8	punct	8:punct	_
@@ -24488,7 +24488,7 @@
 13	just	just	ADV	RB	_	15	advmod	15:advmod	_
 14	like	like	ADP	IN	_	15	case	15:case	_
 15	what	what	PRON	WP	PronType=Rel	10	obl	10:obl:like|16:nsubj	_
-16	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+16	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-free-nsubj
 17	in	in	ADP	IN	_	19	case	19:case	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 19	computer	computer	NOUN	NN	Number=Sing	16	obl	16:obl:in	_
@@ -24720,7 +24720,7 @@
 7	rates	rate	NOUN	NNS	Number=Plur	5	conj	2:obj|5:conj	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	could	could	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	SpaceAfter=No
+10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = answers-20111103205154AAOod9K_ans
@@ -24764,7 +24764,7 @@
 16	place	place	NOUN	NN	Number=Sing	14	nsubj	14:nsubj|19:obl	CxnElt=14:Existential-CopPred-ThereExpl.Pivot
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 18	can	can	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
-19	get	get	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	_
+19	get	get	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obl
 20	good	good	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	deals	deal	NOUN	NNS	Number=Plur	19	obj	19:obj	_
 22	on	on	ADP	IN	_	23	case	23:case	_
@@ -24812,11 +24812,11 @@
 13	whatever	whatever	DET	WDT	PronType=Rel	14	det	14:det	_
 14	Restaurant	restaurant	NOUN	NN	Number=Sing	11	nmod	11:nmod:to|16:obj	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
+16	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 17	,	,	PUNCT	,	_	18	punct	18:punct	_
 18	whenever	whenever	ADV	WRB	PronType=Rel	8	advmod	8:advmod|20:advmod	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	advcl:relcl	18:advcl:relcl	SpaceAfter=No
+20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	advcl:relcl	18:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111103205154AAOod9K_ans-0005
@@ -24872,7 +24872,7 @@
 7	whatever	whatever	DET	WDT	PronType=Int	8	det	8:det	_
 8	deal	deal	NOUN	NN	Number=Sing	6	obj	6:obj|10:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
 11	anytime	anytime	ADV	RB	PronType=Ind	6	advmod	6:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -25032,7 +25032,7 @@
 25	exhibits	exhibit	NOUN	NNS	Number=Plur	22	obj	22:obj|28:obj	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	28	nsubj	28:nsubj	_
 27	might	might	AUX	MD	VerbForm=Fin	28	aux	28:aux	_
-28	enjoy	enjoy	VERB	VB	VerbForm=Inf	25	acl:relcl	25:acl:relcl	SpaceAfter=No
+28	enjoy	enjoy	VERB	VB	VerbForm=Inf	25	acl:relcl	25:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 29	,	,	PUNCT	,	_	33	punct	33:punct	_
 30	food	food	NOUN	NN	Number=Sing	33	nsubj	33:nsubj	_
 31	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	cop	33:cop	_
@@ -25224,7 +25224,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	one	one	NOUN	NN	Number=Sing	3	obj	3:obj|7:nsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	best	well	ADV	RBS	Degree=Sup	7	advmod	7:advmod	_
 10	after	after	SCONJ	IN	_	11	mark	11:mark	_
@@ -25475,7 +25475,7 @@
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	ever	ever	ADV	RB	PronType=Ind	6	advmod	6:advmod	_
-6	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	SpaceAfter=No
+6	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
 7	!	!	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-314938
@@ -25639,7 +25639,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	pics	pic	NOUN	NNS	Number=Plur	2	obj	2:obj|6:obj	_
 5	geeksquad	geeksquad	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	deleted	delete	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
+6	deleted	delete	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-255757-0002
@@ -25693,7 +25693,7 @@
 4-5	I'd	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	'd	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
-6	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	_
+6	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-that-obj
 7	so	so	ADV	RB	_	8	advmod	8:advmod	_
 8	far	far	ADV	RB	Degree=Pos	6	advmod	6:advmod	SpaceAfter=No
 9	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -25747,7 +25747,7 @@
 4	some	some	DET	DT	PronType=Ind	5	det	5:det	_
 5	shirts	shirt	NOUN	NNS	Number=Plur	3	obj	3:obj|7:obj	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj
 8	too	too	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -25851,7 +25851,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	PronType=Ind	11	advmod	11:advmod	_
-11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
+11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obl-pstrand
 12	to	to	ADP	IN	_	11	obl	11:obl	Promoted=Yes
 
 # newdoc id = reviews-343336
@@ -26022,7 +26022,7 @@
 9	what	what	PRON	WP	PronType=Rel	12	obj	8:ref	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	customer	customer	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
-12	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
+12	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
 13	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # newdoc id = reviews-086914
@@ -26285,7 +26285,7 @@
 12	area	area	NOUN	NN	Number=Sing	9	nmod	9:nmod:in	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	count	count	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
+15	count	count	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obl-pstrand
 16	on	on	ADP	IN	_	15	obl	15:obl	Promoted=Yes|SpaceAfter=No
 17	.	.	PUNCT	.	_	9	punct	9:punct	_
 
@@ -26454,7 +26454,7 @@
 10	reason	reason	NOUN	NN	Number=Sing	1	parataxis	1:parataxis|13:obl	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 12	would	would	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	go	go	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
+13	go	go	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
 14	to	to	ADP	IN	_	17	case	17:case	_
 15	this	this	DET	DT	Number=Sing|PronType=Dem	17	det	17:det	_
 16	particular	particular	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -26532,7 +26532,7 @@
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 5	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	7	aux	7:aux	CorrectForm='ve
 6	ever	ever	ADV	RB	PronType=Ind	7	advmod	7:advmod	_
-7	had	have	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
+7	had	have	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-104703-0003
@@ -26576,7 +26576,7 @@
 11-12	didn't	_	_	_	_	_	_	_	_
 11	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	like	like	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	SpaceAfter=No
+13	like	like	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 14	!	!	PUNCT	.	_	5	punct	5:punct	_
 
 # newdoc id = reviews-200668
@@ -26722,7 +26722,7 @@
 1	Did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	services	service	NOUN	NNS	Number=Plur	1	obj	1:obj|8:obj	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|8:obj	_
-4	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj_xcomp
 5	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	iobj	4:iobj|8:nsubj:xsubj	_
 6	NOT	not	PART	RB	Polarity=Neg	8	advmod	8:advmod	CorrectSpaceAfter=Yes|SpaceAfter=No
 7	to	to	PART	TO	_	8	mark	8:mark	_
@@ -27018,7 +27018,7 @@
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	ever	ever	ADV	RB	PronType=Ind	19	advmod	19:advmod	_
-19	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	15	acl:relcl	15:acl:relcl	SpaceAfter=No
+19	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-396046-0002
@@ -27147,7 +27147,7 @@
 7-8	I've	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
-9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Seattle	Seattle	PROPN	NNP	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -27159,7 +27159,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	place	place	NOUN	NN	Number=Sing	0	root	0:root|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	specializes	specialize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	specializes	specialize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
 7	in	in	ADP	IN	_	10	case	10:case	_
 8	high	high	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	quality	quality	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -27181,7 +27181,7 @@
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 8	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	PronType=Ind	10	advmod	10:advmod	_
-10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	SpaceAfter=No
+10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 11	!	!	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-314024-0002
@@ -27191,7 +27191,7 @@
 3	that	that	PRON	WDT	PronType=Rel	6	nsubj:pass	2:ref	_
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 5	already	already	ADV	RB	_	6	advmod	6:advmod	_
-6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	acl:relcl	2:acl:relcl	SpaceAfter=No
+6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj:pass|SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
 8	easy	easy	ADJ	JJ	Degree=Pos	6	conj	2:acl:relcl|6:conj	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -27259,7 +27259,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	best	good	ADJ	JJS	Degree=Sup	0	root	0:root|4:obj	_
 3	darlington	darlington	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	offer	offer	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:to	_
 7	in	in	ADP	IN	_	9	case	9:case	_
@@ -27499,7 +27499,7 @@
 9	bagh	Bagh	PROPN	NNP	Number=Sing	8	flat	8:flat	_
 10	which	which	PRON	WDT	PronType=Rel	12	nsubj:pass	8:ref	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
-12	done	do	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	_
+12	done	do	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj:pass
 13	under	under	ADP	IN	_	16	case	16:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	wooden	wooden	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -27723,7 +27723,7 @@
 7	last	last	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	time	time	NOUN	NN	Number=Sing	6	obl:unmarked	6:obl:unmarked|10:obl	TemporalNPAdjunct=Yes
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
+10	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl
 11	there	there	ADV	RB	PronType=Dem	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -27757,7 +27757,7 @@
 4	Sam	Sam	PROPN	NNP	Number=Sing	2	obl	2:obl:with|7:nsubj	_
 5	Mones	Mones	PROPN	NNP	Number=Sing	4	flat	4:flat	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	4:ref	_
-7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
 8	great	great	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	care	care	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
@@ -27836,7 +27836,7 @@
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	Ever	ever	ADV	RB	PronType=Ind	14	advmod	14:advmod	_
-14	Met	meet	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
+14	Met	meet	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 15	.	.	PUNCT	.	_	10	punct	10:punct	_
 
 # sent_id = reviews-181696-0003
@@ -28093,7 +28093,7 @@
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	service	service	NOUN	NN	Number=Sing	4	nmod	4:nmod:about|9:obj	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	SpaceAfter=No
+9	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
 # sent_id = reviews-101864-0003
@@ -28162,7 +28162,7 @@
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 7	VE	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	9	aux	9:aux	CorrectForm='VE
 8	BEEN	be	AUX	VBN	Tense=Past|VerbForm=Part	9	cop	9:cop	_
-9	TO	to	ADP	IN	_	5	acl:relcl	5:acl:relcl	Promoted=Yes|SpaceAfter=No
+9	TO	to	ADP	IN	_	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes|SpaceAfter=No
 10	!!!!!!	!!!!!!	PUNCT	.	_	5	punct	5:punct	_
 
 # newdoc id = reviews-270889
@@ -28462,7 +28462,7 @@
 7	emergency	emergency	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	plumbers	plumber	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	8:ref	_
-10	visted	visit	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited
+10	visted	visit	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited|Cxn=rc-wh-nsubj
 11	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	shop	shop	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	in	in	ADP	IN	_	15	case	15:case	_
@@ -28506,7 +28506,7 @@
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	PronType=Ind	8	advmod	8:advmod	_
-8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
+8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
 9	in	in	ADP	IN	_	10	case	10:case	_
 10	Australia	Australia	PROPN	NNP	Number=Sing	8	obl	8:obl:in	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
@@ -28665,7 +28665,7 @@
 11	anything	anything	PRON	NN	Number=Sing|PronType=Ind	9	obj	9:obj|14:obj	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	want	want	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
+14	want	want	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	terms	term	NOUN	NNS	Number=Plur	14	obl	14:obl:in	_
 17	of	of	ADP	IN	_	21	case	21:case	_
@@ -28828,7 +28828,7 @@
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	utilities	utility	NOUN	NNS	Number=Plur	11	nsubj	9:obj|11:nsubj	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj_xcomp
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	set	set	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	up	up	ADP	RP	_	9	compound:prt	9:compound:prt	_
@@ -28943,7 +28943,7 @@
 18	every	every	DET	DT	PronType=Tot	19	det	19:det	_
 19	step	step	NOUN	NN	Number=Sing	16	obl	16:obl:for|21:obj	_
 20	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	take	take	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	19	acl:relcl	19:acl:relcl	CorrectForm=takes
+21	take	take	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	19	acl:relcl	19:acl:relcl	CorrectForm=takes|Cxn=rc-red-obj
 22	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # newdoc id = reviews-307170
@@ -29099,7 +29099,7 @@
 3	fresh	fresh	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	flowers	flower	NOUN	NNS	Number=Plur	2	obj	2:obj|6:nsubj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
-6	lasted	last	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
+6	lasted	last	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-nsubj
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	long	long	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	while	while	NOUN	NN	Number=Sing	6	obl:unmarked	6:obl:unmarked	TemporalNPAdjunct=Yes
@@ -29326,7 +29326,7 @@
 17	therapist	therapist	NOUN	NN	Number=Sing	13	obl	13:obl:with|20:obj	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 19	regularly	regularly	ADV	RB	_	20	advmod	20:advmod	_
-20	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+20	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-045972-0003
@@ -29339,13 +29339,13 @@
 5	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	obj	4:obj|8:nsubj|10:nsubj:xsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	can	can	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	manage	manage	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
+8	manage	manage	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	do	do	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	what	what	PRON	WP	PronType=Rel	10	obj	10:obj|14:obj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	really	really	ADV	RB	_	14	advmod	14:advmod	_
-14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
+14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # newdoc id = reviews-024306
@@ -29369,7 +29369,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	PronType=Ind	11	advmod	11:advmod	_
-11	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
+11	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	cop	17:cop	_
 14	possible	possibly	ADV	RB	Typo=Yes	17	advmod	17:advmod	CorrectForm=possibly
@@ -29380,7 +29380,7 @@
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 19	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
 20	ever	ever	ADV	RB	PronType=Ind	21	advmod	21:advmod	_
-21	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	17	acl:relcl	17:acl:relcl	SpaceAfter=No
+21	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-024306-0003
@@ -29838,7 +29838,7 @@
 14	that	that	PRON	WDT	PronType=Rel	17	obj	13:ref	_
 15	Farrell	Farrell	PROPN	NNP	Number=Sing	16	compound	16:compound	_
 16	Electric	Electric	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj	_
-17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
+17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-335490
@@ -29850,7 +29850,7 @@
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
-6	to	to	ADP	IN	_	2	acl:relcl	2:acl:relcl	Promoted=Yes
+6	to	to	ADP	IN	_	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes
 
 # sent_id = reviews-335490-0002
 # newpar id = reviews-335490-p0002
@@ -29989,13 +29989,13 @@
 15	where	where	ADV	WRB	PronType=Rel	18	advmod	11:ref	_
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	delete	delete	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
+18	delete	delete	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
 19	songs	song	NOUN	NNS	Number=Plur	18	obj	18:obj|23:obj	_
 20	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	23:nsubj	_
 21-22	doesn't	_	_	_	_	_	_	_	_
 21	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	n't	not	PART	RB	Polarity=Neg	23	advmod	23:advmod	_
-23	like	like	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	SpaceAfter=No
+23	like	like	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 24	,	,	PUNCT	,	_	27	punct	27:punct	_
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
@@ -30034,7 +30034,7 @@
 8	undergone	undergo	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl	7:acl	_
 9	here	here	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
 10	which	which	PRON	WDT	PronType=Rel	11	nsubj	7:ref	_
-11	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
+11	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 12	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	life	life	NOUN	NN	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	step	step	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
@@ -30244,7 +30244,7 @@
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	PronType=Ind	10	advmod	10:advmod	_
-10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
 11	and	and	CCONJ	CC	_	15	cc	15:cc	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 13	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
@@ -30288,7 +30288,7 @@
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 6	even	even	ADV	RB	_	8	advmod	8:advmod	_
 7	never	never	ADV	RB	PronType=Neg	8	advmod	8:advmod	_
-8	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
+8	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
 9	before	before	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -30620,7 +30620,7 @@
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	lady	lady	NOUN	NN	Number=Sing	0	root	0:root|5:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	5	nsubj	3:ref	_
-5	operates	operate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
+5	operates	operate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	front	front	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	register	register	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
@@ -30803,7 +30803,7 @@
 19	business	business	NOUN	NN	Number=Sing	17	iobj	17:iobj	_
 20	something	something	PRON	NN	Number=Sing|PronType=Ind	17	obj	17:obj|22:nsubj	_
 21	that	that	PRON	WDT	PronType=Rel	22	nsubj	20:ref	_
-22	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
+22	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	acl:relcl	20:acl:relcl	Cxn=rc-that-nsubj
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	initials	initial	NOUN	NNS	Number=Plur	22	obj	22:obj	_
 25	KKK	KKK	PROPN	NNP	Number=Sing	24	appos	24:appos	SpaceAfter=No
@@ -30890,7 +30890,7 @@
 14	exactly	exactly	ADV	RB	_	15	advmod	15:advmod	_
 15	what	what	PRON	WP	PronType=Rel	12	obj	12:obj|17:obj	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
-17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
+17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-free-obj
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
 19	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
 20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
@@ -30955,7 +30955,7 @@
 9	what	what	PRON	WP	PronType=Rel	8	obj	8:obj|12:obj	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	9	acl:relcl	9:acl:relcl	_
+12	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	9	acl:relcl	9:acl:relcl	Cxn=rc-free-obj
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 15	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	SpaceAfter=No
@@ -31051,7 +31051,7 @@
 13	extra	extra	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	mile	mile	NOUN	NN	Number=Sing	10	conj	7:obl:with|10:conj:and|16:obj	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
+16	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obj
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	get	get	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:to	_
 19	out	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs|Typo=Yes	20	nmod:poss	20:nmod:poss	CorrectForm=our
@@ -31265,10 +31265,10 @@
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	what	what	PRON	WP	PronType=Rel	3	obl	3:obl:to|12:obj	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	7:expl	_
-7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Promoted=Yes
+7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
 9	would	would	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	like	like	VERB	VB	VerbForm=Inf	5	advcl:relcl	5:advcl:relcl	_
+10	like	like	VERB	VB	VerbForm=Inf	5	advcl:relcl	5:advcl:relcl	Cxn=rc-free-obj_xcomp
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	achieve	achieve	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	SpaceAfter=No
 13	,	,	PUNCT	,	_	18	punct	18:punct	_
@@ -31342,7 +31342,7 @@
 38	sometimes	sometimes	ADV	RB	PronType=Ind	41	advmod	41:advmod	_
 39	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	41	aux:pass	41:aux:pass	_
 40	not	not	PART	RB	Polarity=Neg	41	advmod	41:advmod	_
-41	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	35	acl:relcl	35:acl:relcl	SpaceAfter=No
+41	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	35	acl:relcl	35:acl:relcl	Cxn=rc-wh-nsubj:pass|SpaceAfter=No
 42	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-309258-0003
@@ -31416,7 +31416,7 @@
 5-6	I've	_	_	_	_	_	_	_	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	come	come	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
+7	come	come	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl-pstrand
 8	across	across	ADP	IN	_	7	obl	7:obl	Promoted=Yes
 9	for	for	ADP	IN	_	11	case	11:case	_
 10	long	long	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -31447,7 +31447,7 @@
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	ever	ever	ADV	RB	PronType=Ind	12	advmod	12:advmod	_
-12	come	come	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
+12	come	come	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl-pstrand
 13	across	across	ADP	IN	_	12	obl	12:obl	Promoted=Yes
 14	in	in	ADP	IN	_	17	case	17:case	_
 15	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
@@ -31480,7 +31480,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	good	good	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	indication	indication	NOUN	NN	Number=Sing	5	advcl:relcl	5:advcl:relcl	_
+13	indication	indication	NOUN	NN	Number=Sing	5	advcl:relcl	5:advcl:relcl	Cxn=rc-wh-csubj
 14	of	of	ADP	IN	_	16	case	16:case	_
 15	her	her	PRON	PRP$	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 16	talent	talent	NOUN	NN	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
@@ -31580,7 +31580,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	price	price	NOUN	NN	Number=Sing	6	nsubj	4:obj|6:nsubj	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 6	good	good	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	so	so	ADV	RB	_	9	mark	9:mark	_
@@ -31960,7 +31960,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	team	team	NOUN	NN	Number=Sing	7	nsubj	4:nsubj|7:nsubj|9:nsubj|12:nsubj|15:nsubj	_
 3	who	who	PRON	WP	PronType=Rel	4	nsubj	2:ref	_
-4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-nsubj
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	helpfull	helpful	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	CorrectForm=helpful|SpaceAfter=No
@@ -32110,7 +32110,7 @@
 11	clueless	clueless	ADJ	JJ	Degree=Pos	3	conj	3:conj:but	_
 12	about	about	ADP	IN	_	13	case	13:case	_
 13	what	what	PRON	WP	PronType=Rel	11	obl	11:obl:about|14:nsubj	_
-14	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
+14	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-free-nsubj
 15	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 16	good	good	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 17	dining	dining	NOUN	NN	Number=Sing	20	compound	20:compound	_
@@ -32192,7 +32192,7 @@
 8	who	who	PRON	WP	PronType=Rel	11	nsubj	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	in	in	ADP	IN	_	11	case	11:case	_
-11	need	need	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	_
+11	need	need	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
 12	of	of	ADP	IN	_	15	case	15:case	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	regular	regular	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
@@ -32234,7 +32234,7 @@
 16	family	family	NOUN	NN	Number=Sing	17	compound	17:compound	_
 17	members	member	NOUN	NNS	Number=Plur	13	obl	13:obl:to|19:nsubj|23:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	17:ref	_
-19	visit	visit	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+19	visit	visit	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
 21-22	don't	_	_	_	_	_	_	_	_
 21	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
@@ -32265,7 +32265,7 @@
 9	find	find	VERB	VB	VerbForm=Inf	3	conj	3:conj:and	_
 10	anything	anything	PRON	NN	Number=Sing|PronType=Ind	9	obj	9:obj|12:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	SpaceAfter=No
+12	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
 13	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-235190-0004
@@ -32314,14 +32314,14 @@
 10	photographers	photographer	NOUN	NNS	Number=Plur	7	obj	7:obj|13:nsubj	_
 11	that	that	PRON	WDT	PronType=Rel	13	nsubj	10:ref	_
 12	would	would	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	represent	represent	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
+13	represent	represent	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj-auxstrand
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	firm	firm	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	in	in	ADP	IN	_	18	case	18:case	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	light	light	NOUN	NN	Number=Sing	13	obl	13:obl:in|20:obl	_
 19	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	wished	wish	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
+20	wished	wish	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl-auxstrand
 21	to	to	PART	TO	_	20	xcomp	20:xcomp	Promoted=Yes
 22	and	and	CCONJ	CC	_	27	cc	27:cc	_
 23	Michael	Michael	PROPN	NNP	Number=Sing	27	nsubj	27:nsubj	_
@@ -32438,7 +32438,7 @@
 1	Last	last	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	10	obl:unmarked	4:obl|10:obl:unmarked	TemporalNPAdjunct=Yes
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
+4	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
 5	however	however	ADV	RB	_	10	advmod	10:advmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
@@ -32546,7 +32546,7 @@
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	service	service	NOUN	NN	Number=Sing	17	conj	14:obl:with|17:conj:and	_
 20	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
+21	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj
 22	at	at	ADP	IN	_	24	case	24:case	_
 23	Family	Family	PROPN	NNP	Number=Sing	24	compound	24:compound	_
 24	Bagels	Bagel	PROPN	NNPS	Number=Plur	21	obl	21:obl:at	_
@@ -32807,7 +32807,7 @@
 6	which	which	PRON	WDT	PronType=Rel	9	nsubj	5:ref	_
 7	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	significantly	significantly	ADV	RB	_	9	advmod	9:advmod	_
-9	reduced	reduce	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
+9	reduced	reduce	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	pain	pain	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	in	in	ADP	IN	_	14	case	14:case	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -2,20 +2,20 @@
 # sent_id = weblog-blogspot.com_zentelligence_20040423000200_ENG_20040423_000200-0001
 # newpar id = weblog-blogspot.com_zentelligence_20040423000200_ENG_20040423_000200-p0001
 # text = What if Google Morphed Into GoogleOS?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Conditional-Interrogative|CxnElt=1:Conditional-Interrogative.Apodosis
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	Morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
+4	Morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	CxnElt=1:Conditional-Interrogative.Protasis
 5	Into	into	ADP	IN	_	6	case	6:case	_
 6	GoogleOS	GoogleOS	PROPN	NNP	Number=Sing	4	obl	4:obl:into	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_zentelligence_20040423000200_ENG_20040423_000200-0002
 # text = What if Google expanded on its search-engine (and now e-mail) wares into a full-fledged operating system?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Conditional-Interrogative|CxnElt=1:Conditional-Interrogative.Apodosis
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	Google	Google	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	expanded	expand	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	_
+4	expanded	expand	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	advcl	1:advcl:if	CxnElt=1:Conditional-Interrogative.Protasis
 5	on	on	ADP	IN	_	15	case	15:case	_
 6	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 7	search	search	NOUN	NN	Number=Sing	9	compound	9:compound	SpaceAfter=No
@@ -65,7 +65,7 @@
 11	just	just	ADV	RB	_	13	advmod	13:advmod	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	little	little	ADJ	JJ	Degree=Pos	14	obl:unmarked	14:obl:unmarked	_
-14	nostalgic	nostalgic	ADJ	JJ	Degree=Pos	0	root	0:root	_
+14	nostalgic	nostalgic	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=14:Interrogative-Polar-Direct.Clause
 15	for	for	ADP	IN	_	17	case	17:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	days	day	NOUN	NNS	Number=Plur	14	obl	14:obl:for|23:obl:unmarked	_
@@ -74,7 +74,7 @@
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	cop	23:cop	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 22	good	good	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
-23	thing	thing	NOUN	NN	Number=Sing	17	acl:relcl	17:acl:relcl	Cxn=rc-wh-obl:unmarked|SpaceAfter=No
+23	thing	thing	NOUN	NN	Number=Sing	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 24	?	?	PUNCT	.	_	14	punct	14:punct	SpaceAfter=No
 25	)	)	PUNCT	-RRB-	_	14	punct	14:punct	_
 
@@ -99,7 +99,7 @@
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
 16	've	have	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	18	aux	18:aux	_
 17	all	all	ADV	RB	_	18	advmod	18:advmod	_
-18	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-ccomp
+18	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	12	advcl:relcl	12:advcl:relcl	_
 19	before	before	ADV	RB	_	18	advmod	18:advmod	SpaceAfter=No
 20	,	,	PUNCT	,	_	27	punct	27:punct	_
 21	but	but	CCONJ	CC	_	27	cc	27:cc	_
@@ -129,7 +129,7 @@
 # text = Does anybody use it for anything else?
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	anybody	anybody	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obj	3:obj	_
 5	for	for	ADP	IN	_	6	case	6:case	_
 6	anything	anything	PRON	NN	Number=Sing|PronType=Ind	3	obl	3:obl:for	_
@@ -152,7 +152,7 @@
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	5	nsubj	5:nsubj	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	money	money	NOUN	NN	Number=Sing	5	compound	5:compound	_
-5	maker	maker	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+5	maker	maker	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 6	?	?	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = weblog-blogspot.com_marketview_20050511222700_ENG_20050511_222700-0007
@@ -179,7 +179,7 @@
 5	few	few	ADJ	JJ	Degree=Pos	13	nsubj	8:nsubj|13:nsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	actually	actually	ADV	RB	_	8	advmod	8:advmod	_
-8	read	read	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+8	read	read	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
 10	blog	blog	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
@@ -262,7 +262,7 @@
 7	flag	flag	NOUN	NN	Number=Sing	5	obj	5:obj|10:nsubj:pass	_
 8	that	that	PRON	WDT	PronType=Rel	10	nsubj:pass	7:ref	_
 9	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	10:aux:pass	_
-10	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj:pass
+10	found	find	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl:relcl	7:acl:relcl	_
 11	in	in	ADP	IN	_	12	case	12:case	_
 12	Fallujah	Fallujah	PROPN	NNP	Number=Sing	10	obl	10:obl:in	SpaceAfter=No
 13	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -363,7 +363,7 @@
 20	linked	link	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	21	amod	21:amod	_
 21	article	article	NOUN	NN	Number=Sing	17	obl	17:obl:in	SpaceAfter=No
 22	,	,	PUNCT	,	_	17	punct	17:punct	_
-23	commits	commit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
+23	commits	commit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 24	just	just	ADV	RB	_	25	advmod	25:advmod	_
 25	about	about	ADV	RB	_	27	advmod	27:advmod	_
 26	every	every	DET	DT	PronType=Tot	27	det	27:det	_
@@ -372,7 +372,7 @@
 29	online	online	ADJ	JJ	Degree=Pos	30	amod	30:amod	_
 30	marketer	marketer	NOUN	NN	Number=Sing	32	nsubj	32:nsubj	_
 31	could	could	AUX	MD	VerbForm=Fin	32	aux	32:aux	_
-32	commit	commit	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+32	commit	commit	VERB	VB	VerbForm=Inf	27	acl:relcl	27:acl:relcl	SpaceAfter=No
 33	,	,	PUNCT	,	_	35	punct	35:punct	_
 34	and	and	CCONJ	CC	_	35	cc	35:cc	_
 35	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	conj	12:acl:relcl|23:conj:and	_
@@ -441,14 +441,14 @@
 35	and	and	CCONJ	CC	_	70	cc	70:cc	_
 36	if	if	SCONJ	IN	_	44	mark	44:mark	_
 37	--	--	PUNCT	,	_	36	punct	36:punct	_
-38	wonder	wonder	NOUN	NN	Number=Sing	44	parataxis	44:parataxis	_
-39	of	of	ADP	IN	_	40	case	40:case	_
-40	wonders	wonder	NOUN	NNS	Number=Plur	38	nmod	38:nmod:of	_
+38	wonder	wonder	NOUN	NN	Number=Sing	44	parataxis	44:parataxis	Cxn=NPN|CxnElt=38:NPN.N1
+39	of	of	ADP	IN	_	40	case	40:case	CxnElt=38:NPN.P
+40	wonders	wonder	NOUN	NNS	Number=Plur	38	nmod	38:nmod:of	CxnElt=38:NPN.N2
 41	--	--	PUNCT	,	_	38	punct	38:punct	_
 42-43	you're	_	_	_	_	_	_	_	_
 42	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	44	nsubj	44:nsubj	_
 43	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	44	cop	44:cop	_
-44	worried	worried	ADJ	JJ	Degree=Pos	70	advcl	70:advcl:if	_
+44	worried	worried	ADJ	JJ	Degree=Pos	70	advcl	70:advcl:if	CxnElt=70:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 45	that	that	SCONJ	IN	_	48	mark	48:mark	_
 46	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	48	nsubj	48:nsubj	_
 47	might	might	AUX	MD	VerbForm=Fin	48	aux	48:aux	_
@@ -458,7 +458,7 @@
 51	someone	someone	PRON	NN	Number=Sing|PronType=Ind	48	obl	48:obl:to|54:nsubj	_
 52	who	who	PRON	WP	PronType=Rel	54	nsubj	51:ref	_
 53	would	would	AUX	MD	VerbForm=Fin	54	aux	54:aux	_
-54	forward	forward	VERB	VB	VerbForm=Inf	51	acl:relcl	51:acl:relcl	Cxn=rc-wh-nsubj
+54	forward	forward	VERB	VB	VerbForm=Inf	51	acl:relcl	51:acl:relcl	_
 55	an	a	DET	DT	Definite=Ind|PronType=Art	56	det	56:det	_
 56	excerpt	excerpt	NOUN	NN	Number=Sing	54	obj	54:obj	_
 57	to	to	ADP	IN	_	58	case	58:case	_
@@ -466,7 +466,7 @@
 59	who	who	PRON	WP	PronType=Rel	62	nsubj	58:ref	_
 60	would	would	AUX	MD	VerbForm=Fin	62	aux	62:aux	_
 61	then	then	ADV	RB	PronType=Dem	62	advmod	62:advmod	_
-62	store	store	VERB	VB	VerbForm=Inf	58	acl:relcl	58:acl:relcl	Cxn=rc-wh-nsubj
+62	store	store	VERB	VB	VerbForm=Inf	58	acl:relcl	58:acl:relcl	_
 63	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	62	obj	62:obj	_
 64	on	on	ADP	IN	_	67	case	67:case	_
 65	a	a	DET	DT	Definite=Ind|PronType=Art	67	det	67:det	_
@@ -474,7 +474,7 @@
 67	account	account	NOUN	NN	Number=Sing	62	obl	62:obl:on	SpaceAfter=No
 68	...	...	PUNCT	,	_	44	punct	44:punct	_
 69	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	70	nsubj	70:nsubj	_
-70	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	_
+70	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	conj	5:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=70:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 71	far	far	ADV	RB	Degree=Pos	75	advmod	75:advmod	SpaceAfter=No
 72	,	,	PUNCT	,	_	71	punct	71:punct	_
 73	far	far	ADV	RB	Degree=Pos	75	advmod	75:advmod	_
@@ -557,9 +557,9 @@
 # text = But there is no proof .
 1	But	but	CCONJ	CC	_	3	cc	3:cc	_
 2	there	there	PRON	EX	_	3	expl	3:expl	_
-3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+3	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	no	no	DET	DT	PronType=Neg	5	det	5:det	_
-5	proof	proof	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+5	proof	proof	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 6	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-blogspot.com_grandpasgripes_20060413051000_ENG_20060413_051000-0005
@@ -635,7 +635,7 @@
 18	could	could	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 19	n't	not	PART	RB	Polarity=Neg	21	advmod	21:advmod	_
 20	even	even	ADV	RB	_	21	advmod	21:advmod	_
-21	begin	begin	VERB	VB	VerbForm=Inf	12	advcl:relcl	12:advcl:relcl	Cxn=rc-wh-xcomp_xcomp
+21	begin	begin	VERB	VB	VerbForm=Inf	12	advcl:relcl	12:advcl:relcl	_
 22	to	to	PART	TO	_	23	mark	23:mark	_
 23	try	try	VERB	VB	VerbForm=Inf	21	xcomp	21:xcomp	_
 24	without	without	ADP	IN	_	26	case	26:case	_
@@ -680,7 +680,7 @@
 1	But	but	CCONJ	CC	_	4	cc	4:cc	_
 2	will	will	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	diplomacy	diplomacy	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
-4	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	work	work	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_grandpasgripes_20060413051000_ENG_20060413_051000-0011
@@ -688,7 +688,7 @@
 1	And	and	CCONJ	CC	_	4	cc	4:cc	_
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj	_
-4	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	military	military	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	pressure	pressure	NOUN	NN	Number=Sing	4	obj	4:obj	_
 7	without	without	ADP	IN	_	8	case	8:case	_
@@ -867,7 +867,7 @@
 11	massacre	massacre	NOUN	NN	Number=Sing	9	obj	9:obj|14:nsubj:pass	_
 12	which	which	PRON	WDT	PronType=Rel	14	nsubj:pass	11:ref	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux:pass	14:aux:pass	_
-14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-nsubj:pass
+14	committed	commit	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	11	acl:relcl	11:acl:relcl	_
 15	on	on	ADP	IN	_	16	case	16:case	_
 16	Friday	Friday	PROPN	NNP	Number=Sing	14	obl	14:obl:on	_
 17	against	against	ADP	IN	_	18	case	18:case	_
@@ -1075,7 +1075,7 @@
 42	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	cop	45:cop	_
 43	185	185	NUM	CD	NumForm=Digit|NumType=Card	44	nummod	44:nummod	_
 44	pages	page	NOUN	NNS	Number=Plur	45	obl:unmarked	45:obl:unmarked	_
-45	long	long	ADJ	JJ	Degree=Pos	40	acl:relcl	40:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+45	long	long	ADJ	JJ	Degree=Pos	40	acl:relcl	40:acl:relcl	SpaceAfter=No
 46	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0002
@@ -1140,7 +1140,7 @@
 47	,	,	PUNCT	,	_	49	punct	49:punct	_
 48	and	and	CCONJ	CC	_	49	cc	49:cc	_
 49	BREYER	Breyer	PROPN	NNP	Number=Sing	42	conj	42:conj:and|50:nsubj	_
-50	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+50	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 51	,	,	PUNCT	,	_	54	punct	54:punct	_
 52	and	and	CCONJ	CC	_	54	cc	54:cc	_
 53	an	a	DET	DT	Definite=Ind|PronType=Art	54	det	54:det	_
@@ -1165,7 +1165,7 @@
 72	,	,	PUNCT	,	_	74	punct	74:punct	_
 73	and	and	CCONJ	CC	_	74	cc	74:cc	_
 74	BREYER	Breyer	PROPN	NNP	Number=Sing	69	conj	69:conj:and|75:nsubj	_
-75	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+75	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	54	acl:relcl	54:acl:relcl	SpaceAfter=No
 76	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0004
@@ -1184,7 +1184,7 @@
 12	,	,	PUNCT	,	_	14	punct	14:punct	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	GINSBURG	Ginsburg	PROPN	NNP	Number=Sing	9	conj	9:conj:and|15:nsubj	_
-15	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+15	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 16	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0005
@@ -1205,7 +1205,7 @@
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	and	and	CCONJ	CC	_	16	cc	16:cc	_
 16	BREYER	Breyer	PROPN	NNP	Number=Sing	11	conj	11:conj:and|17:nsubj	_
-17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pfront
+17	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 18	as	as	ADP	IN	ExtPos=ADP	20	case	20:case	_
 19	to	to	ADP	IN	_	18	fixed	18:fixed	_
 20	Parts	part	NOUN	NNS	Number=Plur	17	obl	17:obl:as_to	_
@@ -1227,7 +1227,7 @@
 9	THOMAS	Thomas	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	ALITO	Alito	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060629164800_ENG_20060629_164800-0007
@@ -1241,7 +1241,7 @@
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	which	which	PRON	WDT	PronType=Rel	10	obl	5:ref	_
 9	SCALIA	Scalia	PROPN	NNP	Number=Sing	10	nsubj	10:nsubj	_
-10	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+10	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 11	,	,	PUNCT	,	_	16	punct	16:punct	_
 12	and	and	CCONJ	CC	_	16	cc	16:cc	_
 13	in	in	ADP	IN	_	14	case	14:case	_
@@ -1282,7 +1282,7 @@
 9	SCALIA	Scalia	PROPN	NNP	Number=Sing	12	nsubj	12:nsubj	_
 10	and	and	CCONJ	CC	_	11	cc	11:cc	_
 11	THOMAS	Thomas	PROPN	NNP	Number=Sing	9	conj	9:conj:and|12:nsubj	_
-12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-obl-pfront
+12	joined	join	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 13	as	as	ADP	IN	ExtPos=ADP	15	case	15:case	_
 14	to	to	ADP	IN	_	13	fixed	13:fixed	_
 15	Parts	part	NOUN	NNS	Number=Plur	12	obl	12:obl:as_to	_
@@ -1384,7 +1384,7 @@
 39	not	not	PART	RB	Polarity=Neg	42	advmod	42:advmod	_
 40	only	only	ADV	RB	_	42	advmod	42:advmod	_
 41	be	be	AUX	VB	VerbForm=Inf	42	aux:pass	42:aux:pass	_
-42	frowned	frown	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	Cxn=rc-wh-obl-pstrand
+42	frowned	frown	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	_
 43	upon	upon	ADP	IN	_	42	obl	42:obl	Promoted=Yes
 44	but	but	CCONJ	CC	_	48	cc	48:cc	_
 45	should	should	AUX	MD	VerbForm=Fin	48	aux	48:aux	_
@@ -1592,7 +1592,7 @@
 21	area	area	NOUN	NN	Number=Sing	16	obl	16:obl:to|24:nsubj	_
 22	that	that	PRON	WDT	PronType=Rel	24	nsubj	21:ref	_
 23	will	will	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	need	need	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	Cxn=rc-that-nsubj
+24	need	need	VERB	VB	VerbForm=Inf	21	acl:relcl	21:acl:relcl	_
 25	15,000	15000	NUM	CD	NumForm=Digit|NumType=Card	24	obj	24:obj	SpaceAfter=No
 26	,	,	PUNCT	,	_	29	punct	29:punct	_
 27	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	29	case	29:case	_
@@ -1615,7 +1615,7 @@
 11	aid	aid	NOUN	NN	Number=Sing	7	nmod	7:nmod:of|14:obj	_
 12	that	that	PRON	WDT	PronType=Rel	14	obj	11:ref	_
 13	Darfur	Darfur	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	_
-14	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+14	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	,	,	PUNCT	,	_	21	punct	21:punct	_
 16	according	accord	VERB	VBG	ExtPos=ADP|Tense=Pres|VerbForm=Part	21	case	21:case	_
 17	to	to	ADP	IN	_	16	fixed	16:fixed	_
@@ -1629,8 +1629,8 @@
 # text = So hear we are, two weeks later, after that dazzling PR display two weeks ago by Powell and Annan, and the situation on the ground in Darfur appears basically unchanged.
 1	So	so	ADV	RB	_	4	advmod	4:advmod	_
 2	hear	here	ADV	RB	PronType=Dem|Typo=Yes	4	advmod	4:advmod	CorrectForm=here
-3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+3	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-HereExpl.Pivot
+4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-HereExpl|SpaceAfter=No
 5	,	,	PUNCT	,	_	8	punct	8:punct	_
 6	two	two	NUM	CD	NumForm=Word|NumType=Card	7	nummod	7:nummod	_
 7	weeks	week	NOUN	NNS	Number=Plur	8	obl:unmarked	8:obl:unmarked	_
@@ -1696,7 +1696,7 @@
 4	move	move	NOUN	NN	Number=Sing	0	root	0:root|7:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	7	nsubj	4:ref	_
 6	really	really	ADV	RB	_	7	advmod	7:advmod	_
-7	worries	worry	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+7	worries	worry	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 8	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	obj	7:obj	SpaceAfter=No
 9	;	;	PUNCT	,	_	25	punct	25:punct	_
 10-11	Buffett's	_	_	_	_	_	_	_	_
@@ -1909,7 +1909,7 @@
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	guy	guy	NOUN	NN	Number=Sing	10	nmod	10:nmod:from|20:nsubj|25:nsubj|30:nsubj:xsubj	_
 19	who	who	PRON	WP	PronType=Rel	20	nsubj	18:ref	_
-20	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-nsubj
+20	knows	know	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 21	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	obj	20:obj	_
 22	best	well	ADV	RBS	Degree=Sup	20	advmod	20:advmod	_
 23	--	--	PUNCT	,	_	25	punct	25:punct	_
@@ -2002,7 +2002,7 @@
 16	each	each	DET	DT	PronType=Tot	17	det	17:det	_
 17	year	year	NOUN	NN	Number=Sing	11	obl:unmarked	11:obl:unmarked	TemporalNPAdjunct=Yes
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	15:ref	_
-19	decrease	decrease	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-that-nsubj
+19	decrease	decrease	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 20	in	in	ADP	IN	_	21	case	21:case	_
 21	number	number	NOUN	NN	Number=Sing	19	obl	19:obl:in	_
 22	at	at	ADP	IN	_	24	case	24:case	_
@@ -2083,7 +2083,7 @@
 42	where	where	ADV	WRB	PronType=Rel	45	advmod	41:ref	_
 43	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	45	nsubj	45:nsubj	_
 44	will	will	AUX	MD	VerbForm=Fin	45	aux	45:aux	_
-45	compound	compound	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	Cxn=rc-wh-obl|SpaceAfter=No
+45	compound	compound	VERB	VB	VerbForm=Inf	41	acl:relcl	41:acl:relcl	SpaceAfter=No
 46	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = weblog-blogspot.com_floppingaces_20050313182621_ENG_20050313_182621
@@ -2136,7 +2136,7 @@
 3	same	same	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	day	day	NOUN	NN	Number=Sing	19	obl	6:obl|19:obl:on	_
 5	Palestinians	Palestinian	PROPN	NNPS	Number=Plur	6	nsubj	6:nsubj	_
-6	protest	protest	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl
+6	protest	protest	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	in	in	ADP	IN	_	8	case	8:case	_
 8	support	support	NOUN	NN	Number=Sing	6	obl	6:obl:in	_
 9	of	of	ADP	IN	_	10	case	10:case	_
@@ -2170,9 +2170,9 @@
 5	Lebanon	Lebanon	PROPN	NNP	Number=Sing	8	obl	8:obl:in	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	there	there	PRON	EX	_	8	expl	8:expl	_
-8	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 9	serious	serious	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
-10	debate	debate	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
+10	debate	debate	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	CxnElt=8:Existential-CopPred-ThereExpl.Pivot
 11	within	within	ADP	IN	_	12	case	12:case	_
 12	Hezbollah	Hezbollah	PROPN	NNP	Number=Sing	10	nmod	10:nmod:within	_
 13	about	about	SCONJ	IN	_	14	mark	14:mark	_
@@ -2211,7 +2211,7 @@
 16	which	which	PRON	WDT	PronType=Rel	19	nsubj	13:ref	_
 17	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	already	already	ADV	RB	_	19	advmod	19:advmod	_
-19	begun	begin	VERB	VBN	Tense=Past|VerbForm=Part	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj
+19	begun	begin	VERB	VBN	Tense=Past|VerbForm=Part	13	acl:relcl	13:acl:relcl	_
 20	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-blogspot.com_floppingaces_20050313182621_ENG_20050313_182621-0005
@@ -2245,7 +2245,7 @@
 27	placards	placard	NOUN	NNS	Number=Plur	24	nmod	24:nmod:on|30:obj	_
 28	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
 29	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	aux	30:aux	_
-30	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	27	acl:relcl	27:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+30	using	use	VERB	VBG	Tense=Pres|VerbForm=Part	27	acl:relcl	27:acl:relcl	SpaceAfter=No
 31	"	"	PUNCT	''	_	24	punct	24:punct	SpaceAfter=No
 32	.	.	PUNCT	.	_	8	punct	8:punct	_
 
@@ -2468,7 +2468,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	organization	organization	NOUN	NN	Number=Sing	0	root	0:root|6:nsubj|13:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	bombed	bomb	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+6	bombed	bomb	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	9	nmod:poss	9:nmod:poss	_
 8	Marine	Marine	PROPN	NNP	Number=Sing	9	compound	9:compound	_
 9	barracks	barracks	NOUN	NNS	Number=Ptan	6	obj	6:obj	_
@@ -2701,7 +2701,7 @@
 28	of	of	ADP	IN	_	29	case	29:case	_
 29	which	which	PRON	WDT	PronType=Rel	27	nmod	24:ref	_
 30	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	cop	31:cop	_
-31	Muslim	Muslim	ADJ	JJ	Degree=Pos	24	acl:relcl	24:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
+31	Muslim	Muslim	ADJ	JJ	Degree=Pos	24	acl:relcl	24:acl:relcl	_
 32	(	(	PUNCT	-LRB-	_	35	punct	35:punct	SpaceAfter=No
 33	such	such	ADJ	JJ	Degree=Pos|ExtPos=ADP	35	case	35:case	_
 34	as	as	ADP	IN	_	33	fixed	33:fixed	_
@@ -2821,7 +2821,7 @@
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	whom	whom	PRON	WP	PronType=Rel	25	nmod	12:ref	_
 28	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	29	cop	29:cop	_
-29	Muslim	Muslim	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
+29	Muslim	Muslim	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	SpaceAfter=No
 30	,	,	PUNCT	,	_	12	punct	12:punct	_
 31	calling	call	VERB	VBG	VerbForm=Ger	9	acl	9:acl	_
 32	upon	upon	ADP	IN	_	33	case	33:case	_
@@ -2841,7 +2841,7 @@
 46	that	that	PRON	WDT	PronType=Rel	49	nsubj	45:ref	_
 47	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	49	aux	49:aux	_
 48	not	not	PART	RB	Polarity=Neg	49	advmod	49:advmod	_
-49	respect	respect	VERB	VB	VerbForm=Inf	45	acl:relcl	45:acl:relcl	Cxn=rc-that-nsubj
+49	respect	respect	VERB	VB	VerbForm=Inf	45	acl:relcl	45:acl:relcl	_
 50	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	51	nmod:poss	51:nmod:poss	_
 51	religion	religion	NOUN	NN	Number=Sing	49	obj	49:obj	_
 52	or	or	CCONJ	CC	_	54	cc	54:cc	_
@@ -2961,7 +2961,7 @@
 21	of	of	ADP	IN	_	22	case	22:case	_
 22	whom	whom	PRON	WP	PronType=Rel	20	nmod	16:ref	_
 23	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	aux	24:aux	_
-24	supported	support	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront
+24	supported	support	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	_
 25	Saddam	Saddam	PROPN	NNP	Number=Sing	24	obj	24:obj	_
 26	and	and	CCONJ	CC	_	29	cc	29:cc	_
 27	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	29	nmod:poss	29:nmod:poss	_
@@ -3119,7 +3119,7 @@
 5-6	didn't	_	_	_	_	_	_	_	_
 5	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
-7	say	say	VERB	VB	VerbForm=Inf	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-advmod
+7	say	say	VERB	VB	VerbForm=Inf	3	advcl:relcl	3:advcl:relcl	_
 8-9	we're	_	_	_	_	_	_	_	_
 8	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
@@ -3176,7 +3176,7 @@
 4-5	haven't	_	_	_	_	_	_	_	_
 4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	n't	not	PART	RB	Polarity=Neg	6	advmod	6:advmod	_
-6	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	_
+6	heard	hear	VERB	VBN	Tense=Past|VerbForm=Part	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	by	by	ADP	IN	_	8	case	8:case	_
 8	now	now	ADV	RB	PronType=Dem	6	obl	6:obl:by	SpaceAfter=No
 9	,	,	PUNCT	,	_	6	punct	6:punct	_
@@ -3185,7 +3185,7 @@
 12	of	of	ADP	IN	_	14	case	14:case	_
 13	suspected	suspect	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	amod	14:amod	_
 14	terrorists	terrorist	NOUN	NNS	Number=Plur	11	nmod	11:nmod:of	_
-15	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+15	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	not	not	PART	RB	Polarity=Neg	15	advmod	15:advmod	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 18	Tom	Tom	PROPN	NNP	Number=Sing	15	obj	15:obj	SpaceAfter=No
@@ -3595,7 +3595,7 @@
 11-12	didn't	_	_	_	_	_	_	_	_
 11	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	crash	crash	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-that-nsubj
+13	crash	crash	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
 14	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
 15	spell	spell	NOUN	NN	Number=Sing	17	compound	17:compound	SpaceAfter=No
 16	-	-	PUNCT	HYPH	_	15	punct	15:punct	SpaceAfter=No
@@ -3621,7 +3621,7 @@
 4-5	it's	_	_	_	_	_	_	_	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	6:nsubj|9:nsubj	_
 5	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
-6	Islamic	Islamic	ADJ	JJ	Degree=Pos	15	advcl	15:advcl:if	SpaceAfter=No
+6	Islamic	Islamic	ADJ	JJ	Degree=Pos	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	fascist	fascist	ADJ	JJ	Degree=Pos	6	conj	6:conj:and|15:advcl:if	SpaceAfter=No
@@ -3631,7 +3631,7 @@
 12	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	15:cop	_
 13	an	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	Islamic	Islamic	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
-15	fascist	fascist	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+15	fascist	fascist	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 16	.	.	PUNCT	.	_	15	punct	15:punct	_
 
 # sent_id = weblog-blogspot.com_aggressivevoicedaily_20060811122000_ENG_20060811_122000-0042
@@ -3808,13 +3808,13 @@
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	statement	statement	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
-5	true	true	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	SpaceAfter=No
+5	true	true	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 9	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	worrying	worrying	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
-11	sign	sign	NOUN	NN	Number=Sing	0	root	0:root	_
+11	sign	sign	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 12	that	that	SCONJ	IN	_	23	mark	23:mark	_
 13	even	even	ADV	RB	_	19	advmod	19:advmod	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	19	det	19:det	_
@@ -3894,7 +3894,7 @@
 16	Arabs	Arab	PROPN	NNPS	Number=Plur	8	nmod	8:nmod:of|19:nsubj	SpaceAfter=No
 17	"	"	PUNCT	''	_	16	punct	16:punct	_
 18	who	who	PRON	WP	PronType=Rel	19	nsubj	16:ref	_
-19	pledged	pledge	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nsubj
+19	pledged	pledge	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	acl:relcl	16:acl:relcl	_
 20	personal	personal	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	loyalty	loyalty	NOUN	NN	Number=Sing	19	obj	19:obj	_
 22	to	to	ADP	IN	_	23	case	23:case	_
@@ -3960,7 +3960,7 @@
 22	of	of	ADP	IN	_	23	case	23:case	_
 23	Islam	Islam	PROPN	NNP	Number=Sing	21	nmod	21:nmod:of	_
 24	that	that	PRON	WDT	PronType=Rel	25	nsubj	21:ref	_
-25	predominates	predominate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-that-nsubj
+25	predominates	predominate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
 26	among	among	ADP	IN	_	32	case	32:case	_
 27-28	Saudia's	_	_	_	_	_	_	_	_
 27	Saudia	Saudia	PROPN	NNP	Number=Sing	32	nmod:poss	32:nmod:poss	_
@@ -4040,7 +4040,7 @@
 26	of	of	ADP	IN	_	27	case	27:case	_
 27	whom	whom	PRON	WP	PronType=Rel	25	nmod	19:ref	_
 28	were	be	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	29	cop	29:cop	_
-29	Saudi	Saudi	ADJ	JJ	Degree=Pos	19	acl:relcl	19:acl:relcl	Cxn=rc-wh-nmod_nsubj-pfront|SpaceAfter=No
+29	Saudi	Saudi	ADJ	JJ	Degree=Pos	19	acl:relcl	19:acl:relcl	SpaceAfter=No
 30	.	.	PUNCT	.	_	11	punct	11:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20041018060600_ENG_20041018_060600-0013
@@ -4107,7 +4107,7 @@
 13	thought	thought	NOUN	NN	Number=Sing	9	nmod	9:nmod:of	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
 15	which	which	PRON	WDT	PronType=Rel	16	nsubj	9:ref	_
-16	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
+16	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
 18	Protestant	Protestant	PROPN	NNP	Number=Sing	20	compound	20:compound	SpaceAfter=No
 19	-	-	PUNCT	HYPH	_	18	punct	18:punct	SpaceAfter=No
@@ -4257,8 +4257,8 @@
 1	So	so	ADV	RB	_	4	advmod	4:advmod	_
 2	now	now	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-5	hundreds	hundred	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
+4	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+5	hundreds	hundred	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 6	of	of	ADP	IN	_	10	case	10:case	_
 7	al	al	PROPN	NNP	Number=Sing	10	compound	10:compound	SpaceAfter=No
 8	-	-	PUNCT	HYPH	_	7	punct	7:punct	SpaceAfter=No
@@ -4269,8 +4269,8 @@
 13	where	where	ADV	WRB	PronType=Rel	16	advmod	12:ref	_
 14	there	there	PRON	EX	_	16	expl	16:expl	_
 15	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
-16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-obl
-17	none	none	PRON	NN	PronType=Neg	16	nsubj	16:nsubj	_
+16	been	be	VERB	VBN	Tense=Past|VerbForm=Part	12	acl:relcl	12:acl:relcl	Cxn=Existential-CopPred-ThereExpl
+17	none	none	PRON	NN	PronType=Neg	16	nsubj	16:nsubj	CxnElt=16:Existential-CopPred-ThereExpl.Pivot
 18	before	before	ADV	RB	_	16	advmod	16:advmod	SpaceAfter=No
 19	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -4302,7 +4302,7 @@
 24	in	in	ADP	IN	_	25	case	25:case	_
 25	Tangiers	tangier	NOUN	NNS	Number=Plur	16	obl	16:obl:in|27:nsubj	_
 26	that	that	PRON	WDT	PronType=Rel	27	nsubj	25:ref	_
-27	morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	Cxn=rc-that-nsubj
+27	morphed	morph	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl:relcl	25:acl:relcl	_
 28	into	into	SCONJ	IN	_	35	mark	35:mark	_
 29	the	the	DET	DT	Definite=Def|PronType=Art	33	det	33:det	_
 30	Moroccan	Moroccan	PROPN	NNP	Number=Sing	33	compound	33:compound	_
@@ -4313,7 +4313,7 @@
 35	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	27	advcl	27:advcl:into	_
 36	members	member	NOUN	NNS	Number=Plur	35	obj	35:obj|38:nsubj|51:nsubj	_
 37	who	who	PRON	WP	PronType=Rel	38	nsubj	36:ref	_
-38	met	meet	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	Cxn=rc-wh-nsubj
+38	met	meet	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	acl:relcl	36:acl:relcl	_
 39	with	with	ADP	IN	_	42	case	42:case	_
 40	September	September	PROPN	NNP	Number=Sing	42	compound	42:compound	_
 41	11	11	NUM	CD	NumForm=Digit|NumType=Card	40	nummod	40:nummod	_
@@ -4360,13 +4360,13 @@
 6	which	which	PRON	WDT	PronType=Rel	9	obl	4:ref	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	US	US	PROPN	NNP	Number=Sing	9	nsubj	9:nsubj	_
-9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-obl-pfront
+9	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 10	key	key	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	mistakes	mistake	NOUN	NNS	Number=Plur	9	obj	9:obj|15:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	15	nsubj	11:ref	_
 13	might	might	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	have	have	AUX	VB	VerbForm=Inf	15	aux	15:aux	_
-15	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
+15	stopped	stop	VERB	VBN	Tense=Past|VerbForm=Part	11	acl:relcl	11:acl:relcl	_
 16	Bin	Bin	PROPN	NNP	Number=Sing	19	nmod:poss	19:nmod:poss	_
 17-18	Laden's	_	_	_	_	_	_	_	_
 17	Laden	Laden	PROPN	NNP	Number=Sing	16	flat	16:flat	_
@@ -4401,15 +4401,15 @@
 8	if	if	SCONJ	IN	_	11	mark	11:mark	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 10	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
-11	known	know	VERB	VBN	Tense=Past|VerbForm=Part	19	advcl	19:advcl:if	_
-12	what	what	PRON	WP	PronType=Int	14	nsubj	14:nsubj	_
+11	known	know	VERB	VBN	Tense=Past|VerbForm=Part	19	advcl	19:advcl:if	CxnElt=19:Conditional-NegativeEpistemic-NoInversion.Protasis
+12	what	what	PRON	WP	PronType=Int	14	nsubj	14:nsubj	CxnElt=14:Interrogative-WHInfo-Indirect.WHWord
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	14:aux	_
-14	coming	come	VERB	VBG	Tense=Pres|VerbForm=Part	11	ccomp	11:ccomp	SpaceAfter=No
+14	coming	come	VERB	VBG	Tense=Pres|VerbForm=Part	11	ccomp	11:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=14:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 15	,	,	PUNCT	,	_	11	punct	11:punct	_
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	19	nsubj	19:nsubj	_
 17	would	would	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
 18	have	have	AUX	VB	VerbForm=Inf	19	aux	19:aux	_
-19	expended	expend	VERB	VBN	Tense=Past|VerbForm=Part	6	ccomp	6:ccomp	_
+19	expended	expend	VERB	VBN	Tense=Past|VerbForm=Part	6	ccomp	6:ccomp	Cxn=Conditional-NegativeEpistemic-NoInversion|CxnElt=19:Conditional-NegativeEpistemic-NoInversion.Apodosis
 20	every	every	DET	DT	PronType=Tot	21	det	21:det	_
 21	effort	effort	NOUN	NN	Number=Sing	19	obj	19:obj	_
 22	to	to	PART	TO	_	23	mark	23:mark	_
@@ -4451,14 +4451,14 @@
 3	Bush	Bush	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj|8:nsubj:xsubj	_
 4	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	have	have	AUX	VB	VerbForm=Inf	6	aux	6:aux	_
-6	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+6	tried	try	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Conditional-NegativeEpistemic-NoInversion|CxnElt=6:Conditional-NegativeEpistemic-NoInversion.Apodosis
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	stop	stop	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	9/11	9/11	NUM	CD	NumForm=Digit|NumType=Card	8	obj	8:obj	_
 10	if	if	SCONJ	IN	_	13	mark	13:mark	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	13:nsubj	_
 12	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
-13	known	know	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:if	_
+13	known	know	VERB	VBN	Tense=Past|VerbForm=Part	6	advcl	6:advcl:if	CxnElt=6:Conditional-NegativeEpistemic-NoInversion.Protasis
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	16:nsubj	_
 15	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 16	coming	come	VERB	VBG	Tense=Pres|VerbForm=Part	13	ccomp	13:ccomp	SpaceAfter=No
@@ -4474,7 +4474,7 @@
 6	Should	should	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
 7	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	have	have	AUX	VB	VerbForm=Inf	9	aux	9:aux	_
-9	known	know	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+9	known	know	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=9:Interrogative-Polar-Direct.Clause
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	aux	12:aux	_
 12	coming	come	VERB	VBG	Tense=Pres|VerbForm=Part	9	ccomp	9:ccomp	SpaceAfter=No
@@ -4601,7 +4601,7 @@
 # text = If you believe crackpot theories instead of focusing on the reality--that was an al-Qaeda operation mainly carried out by al-Gamaa al-Islamiyyah, an Egyptian terrorist component allied with Bin Laden-- then you will concentrate on the wrong threat.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	believe	believe	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	43	advcl	43:advcl:if	_
+3	believe	believe	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	43	advcl	43:advcl:if	CxnElt=43:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	crackpot	crackpot	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	theories	theory	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	instead	instead	ADV	RB	ExtPos=SCONJ	8	mark	8:mark	_
@@ -4641,7 +4641,7 @@
 40	then	then	ADV	RB	PronType=Dem	43	advmod	43:advmod	_
 41	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	43	nsubj	43:nsubj	_
 42	will	will	AUX	MD	VerbForm=Fin	43	aux	43:aux	_
-43	concentrate	concentrate	VERB	VB	VerbForm=Inf	0	root	0:root	_
+43	concentrate	concentrate	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=43:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 44	on	on	ADP	IN	_	47	case	47:case	_
 45	the	the	DET	DT	Definite=Def|PronType=Art	47	det	47:det	_
 46	wrong	wrong	ADJ	JJ	Degree=Pos	47	amod	47:amod	_
@@ -4675,13 +4675,13 @@
 6	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	2:conj:and	_
 7	that	that	SCONJ	IN	_	9	mark	9:mark	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
+9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	Cxn=Existential-CopPred-ThereExpl
 10	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 11	10	10	NUM	CD	NumForm=Digit|NumType=Card	14	nummod	14:nummod	_
 12	to	to	ADP	IN	_	13	case	13:case	_
 13	50	50	NUM	CD	NumForm=Digit|NumType=Card	11	nmod	11:nmod:to	SpaceAfter=No
 14	%	%	SYM	NN	Number=Sing	15	compound	15:compound	_
-15	chance	chance	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
+15	chance	chance	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 16	that	that	SCONJ	IN	_	20	mark	20:mark	_
 17	Iraq	Iraq	PROPN	NNP	Number=Sing	20	nsubj	20:nsubj	_
 18	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	cop	20:cop	_
@@ -4693,8 +4693,8 @@
 # text = (On what evidence?
 1	(	(	PUNCT	-LRB-	_	4	punct	4:punct	SpaceAfter=No
 2	On	on	ADP	IN	_	4	case	4:case	_
-3	what	what	DET	WDT	PronType=Int	4	det	4:det	_
-4	evidence	evidence	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+3	what	what	DET	WDT	PronType=Int	4	det	4:det	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
+4	evidence	evidence	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0016
@@ -4741,11 +4741,11 @@
 13	,	,	PUNCT	,	_	14	punct	14:punct	_
 14	saying	say	VERB	VBG	Tense=Pres|VerbForm=Part	3	advcl	3:advcl	_
 15	there	there	PRON	EX	_	16	expl	16:expl	_
-16	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	_
+16	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	ccomp	14:ccomp	Cxn=Existential-CopPred-ThereExpl
 17	"	"	PUNCT	``	_	20	punct	20:punct	SpaceAfter=No
 18	no	no	DET	DT	PronType=Neg	20	det	20:det	_
 19	good	good	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
-20	targets	target	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	SpaceAfter=No
+20	targets	target	NOUN	NNS	Number=Plur	16	nsubj	16:nsubj	CxnElt=16:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 21	"	"	PUNCT	''	_	20	punct	20:punct	_
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	Afghanistan	Afghanistan	PROPN	NNP	Number=Sing	16	obl	16:obl:in	SpaceAfter=No
@@ -4754,7 +4754,7 @@
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0018
 # text = (What about 40 al-Qaeda bases that had trained the 9/11 hijackers and other terrorists gunning for the United States??)
 1	(	(	PUNCT	-LRB-	_	2	punct	2:punct	SpaceAfter=No
-2	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+2	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause,2:Interrogative-WHInfo-Direct.WHWord
 3	about	about	ADP	IN	_	8	case	8:case	_
 4	40	40	NUM	CD	NumForm=Digit|NumType=Card	8	nummod	8:nummod	_
 5	al	al	PROPN	NNP	Number=Sing	8	compound	8:compound	SpaceAfter=No
@@ -4763,7 +4763,7 @@
 8	bases	basis	NOUN	NNS	Number=Plur	2	nmod	2:nmod:about|11:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	11	nsubj	8:ref	_
 10	had	have	AUX	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
-11	trained	train	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
+11	trained	train	VERB	VBN	Tense=Past|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
 13	9/11	9/11	NUM	CD	NumForm=Digit|NumType=Card	14	compound	14:compound	_
 14	hijackers	hijacker	NOUN	NNS	Number=Plur	11	obj	11:obj	_
@@ -4799,7 +4799,7 @@
 17	that	that	PRON	WDT	PronType=Rel	20	obj	8:ref	_
 18	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	20:nsubj	_
 19	could	could	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	pull	pull	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	Cxn=rc-that-obj
+20	pull	pull	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	_
 21	off	off	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	shelf	shelf	NOUN	NN	Number=Sing	20	obl	20:obl:off	SpaceAfter=No
@@ -4882,7 +4882,7 @@
 27	the	the	DET	DT	Definite=Def|PronType=Art	28	det	28:det	_
 28	threat	threat	NOUN	NN	Number=Sing	24	conj	21:obl:about|24:conj:and|30:obj	_
 29	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	30	nsubj	30:nsubj	_
-30	posed	pose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+30	posed	pose	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	SpaceAfter=No
 31	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = weblog-juancole.com_juancole_20040722101300_ENG_20040722_101300-0024
@@ -4940,7 +4940,7 @@
 12	officers	officer	NOUN	NNS	Number=Plur	8	nmod	8:nmod:from|15:nsubj	SpaceAfter=No
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
 14	who	who	PRON	WP	PronType=Rel	15	nsubj	12:ref	_
-15	outranked	outrank	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
+15	outranked	outrank	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 16	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	obj	15:obj	SpaceAfter=No
 17	,	,	PUNCT	,	_	22	punct	22:punct	_
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
@@ -4977,7 +4977,7 @@
 48	the	the	DET	DT	Definite=Def|PronType=Art	49	det	49:det	_
 49	CIA	CIA	PROPN	NNP	Number=Sing	51	nsubj	51:nsubj	_
 50	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	51	aux	51:aux	_
-51	picking	pick	VERB	VBG	Tense=Pres|VerbForm=Part	47	acl:relcl	47:acl:relcl	Cxn=rc-red-obj
+51	picking	pick	VERB	VBG	Tense=Pres|VerbForm=Part	47	acl:relcl	47:acl:relcl	_
 52	up	up	ADP	RP	_	51	compound:prt	51:compound:prt	_
 53	from	from	ADP	IN	_	56	case	56:case	_
 54	radical	radical	ADJ	JJ	Degree=Pos	56	amod	56:amod	_
@@ -5024,7 +5024,7 @@
 17	that	that	PRON	WDT	PronType=Rel	20	nsubj	6:ref	_
 18	would	would	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
 19	have	have	AUX	VB	VerbForm=Inf	20	aux	20:aux	_
-20	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
+20	allowed	allow	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 21	the	the	DET	DT	Definite=Def|PronType=Art	22	det	22:det	_
 22	US	US	PROPN	NNP	Number=Sing	20	iobj	20:iobj|24:nsubj:xsubj	_
 23	to	to	PART	TO	_	24	mark	24:mark	_
@@ -5168,7 +5168,7 @@
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	figure	figure	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	out	out	ADP	RP	_	9	compound:prt	9:compound:prt	_
-11	how	how	ADV	WRB	PronType=Int	21	advmod	21:advmod	SpaceAfter=No
+11	how	how	ADV	WRB	PronType=Int	21	advmod	21:advmod	CxnElt=21:Interrogative-WHInfo-Indirect.WHWord|SpaceAfter=No
 12	,	,	PUNCT	,	_	11	punct	11:punct	_
 13	in	in	ADP	IN	_	14	case	14:case	_
 14	fall	fall	NOUN	NN	Number=Sing	21	obl	21:obl:in	_
@@ -5178,7 +5178,7 @@
 18	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	21	nsubj	21:nsubj	_
 19	could	could	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 20	possibly	possibly	ADV	RB	_	21	advmod	21:advmod	_
-21	pull	pull	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	_
+21	pull	pull	VERB	VB	VerbForm=Inf	9	ccomp	9:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=21:Interrogative-WHInfo-Indirect.Clause
 22	off	off	ADP	RP	_	21	compound:prt	21:compound:prt	_
 23	such	such	DET	PDT	PronType=Ind	25	det:predet	25:det:predet	_
 24	an	a	DET	DT	Definite=Ind|PronType=Art	25	det	25:det	_
@@ -5266,7 +5266,7 @@
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 3	how	how	ADV	WRB	PronType=Rel	0	root	0:root|8:xcomp	_
 4	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	Cxn=rc-free-xcomp_xcomp
+5	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl:relcl	3:advcl:relcl	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	obj	5:obj|8:nsubj:xsubj	_
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	refer	refer	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
@@ -5362,10 +5362,10 @@
 
 # sent_id = email-enronsent23_01-0003
 # text = what are you doing tonight.
-1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	tonight	tonight	NOUN	NN	Number=Sing	4	obl:unmarked	4:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 6	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -5373,7 +5373,7 @@
 # newpar id = email-enronsent23_01-p0002
 # text = like what?
 1	like	like	ADP	IN	_	2	case	2:case	_
-2	what	what	PRON	WP	PronType=Int	0	root	0:root	SpaceAfter=No
+2	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause,2:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 3	?	?	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent23_01-0005
@@ -5425,10 +5425,10 @@
 
 # sent_id = email-enronsent23_05-0005
 # text = why do you think i should get one of those?
-1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	should	should	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
 7	get	get	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
@@ -5501,7 +5501,7 @@
 3	thinking	think	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 4	somewhere	somewhere	ADV	RB	PronType=Ind	3	obj	3:obj|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	requires	require	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	Cxn=rc-that-nsubj
+6	requires	require	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	advcl:relcl	4:advcl:relcl	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	jacket	jacket	NOUN	NN	Number=Sing	6	obj	6:obj	SpaceAfter=No
 9	,	,	PUNCT	,	_	11	punct	11:punct	_
@@ -5517,7 +5517,7 @@
 2	that	that	PRON	WDT	PronType=Rel	5	nsubj	1:ref	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 4	like	like	ADP	IN	_	5	case	5:case	_
-5	$	$	SYM	$	_	1	advcl:relcl	1:advcl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+5	$	$	SYM	$	_	1	advcl:relcl	1:advcl:relcl	SpaceAfter=No
 6	30	30	NUM	CD	NumForm=Digit|NumType=Card	5	nummod	5:nummod	_
 7	an	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	entree	entree	NOUN	NN	Number=Sing	5	nmod:unmarked	5:nmod:unmarked	SpaceAfter=No
@@ -5550,10 +5550,10 @@
 
 # sent_id = email-enronsent23_02-0005
 # text = what do you think?
-1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	what	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent23_02-0006
@@ -5599,7 +5599,7 @@
 10	other	other	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	girl	girl	NOUN	NN	Number=Sing	6	obl	6:obl:with|13:obl	_
 12	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obl-pstrand
+13	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	bet	bet	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	with	with	ADP	IN	_	13	obl	13:obl	Promoted=Yes|SpaceAfter=No
@@ -5618,11 +5618,11 @@
 4	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 5	no	no	DET	DT	PronType=Neg	6	det	6:det	_
 6	idea	idea	NOUN	NN	Number=Sing	4	obj	4:obj	_
-7	what	what	PRON	WP	PronType=Int	10	obl	10:obl:about	_
+7	what	what	PRON	WP	PronType=Int	10	obl	10:obl:about	CxnElt=10:Interrogative-WHInfo-Indirect.WHWord
 8-9	you're	_	_	_	_	_	_	_	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 9	're	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
-10	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	4	ccomp	4:ccomp	_
+10	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=10:Interrogative-WHInfo-Indirect.Clause
 11	about	about	ADP	IN	_	7	case	7:case	SpaceAfter=No
 12	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -5711,8 +5711,8 @@
 
 # sent_id = email-enronsent23_07-0004
 # text = what happened to you?
-1	what	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	happened	happen	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+1	what	what	PRON	WP	PronType=Int	2	nsubj	2:nsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	happened	happen	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	to	to	ADP	IN	_	4	case	4:case	_
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	obl	2:obl:to	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -5732,7 +5732,7 @@
 # text = did you hook up with that blonde chick saturday night?
 1	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	hook	hook	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	hook	hook	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	with	with	ADP	IN	_	8	case	8:case	_
 6	that	that	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
@@ -5765,7 +5765,7 @@
 # text = are you lying?
 1	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	lying	lie	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	SpaceAfter=No
+3	lying	lie	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent23_07-0010
@@ -5923,7 +5923,7 @@
 6	if	if	SCONJ	IN	_	9	mark	9:mark	_
 7	she	she	PRON	PRP	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	can	can	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	get	get	VERB	VB	VerbForm=Inf	5	ccomp	5:ccomp	_
+9	get	get	VERB	VB	VerbForm=Inf	5	ccomp	5:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=9:Interrogative-Polar-Indirect.Clause
 10	financing	financing	NOUN	NN	Number=Sing	9	obj	9:obj	SpaceAfter=No
 11	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -5991,7 +5991,7 @@
 4	risk	risk	NOUN	NN	Number=Sing	0	root	0:root|7:obj	_
 5	that	that	PRON	WDT	PronType=Rel	7	obj	4:ref	_
 6	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-obj
+7	had	have	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 8	but	but	CCONJ	CC	_	11	cc	11:cc	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	aux	11:aux	_
@@ -6010,11 +6010,11 @@
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	n't	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=9:Interrogative-WHInfo-Indirect.WHWord
 6	much	much	ADV	RB	_	9	advmod	9:advmod	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 8	will	will	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	help	help	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+9	help	help	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=9:Interrogative-WHInfo-Indirect.Clause
 10	however	however	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 11	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -6099,11 +6099,11 @@
 4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	there	there	PRON	EX	_	7	expl	7:expl	_
-7	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
-8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	7	nsubj	7:nsubj|11:obj	_
+7	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
+8	anything	anything	PRON	NN	Number=Sing|PronType=Ind	7	nsubj	7:nsubj|11:obj	CxnElt=7:Existential-CopPred-ThereExpl.Pivot
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	can	can	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
-11	do	do	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
+11	do	do	VERB	VB	VerbForm=Inf	8	acl:relcl	8:acl:relcl	_
 12	but	but	CCONJ	CC	_	16	cc	16:cc	_
 13-14	I'm	_	_	_	_	_	_	_	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|18:nsubj:xsubj	_
@@ -6288,11 +6288,11 @@
 
 # sent_id = email-enronsent21_01-0011
 # text = Call me if you have time.
-1	Call	call	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+1	Call	call	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=1:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	CxnElt=1:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	time	time	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -6317,15 +6317,15 @@
 # sent_id = email-enronsent21_01-0015
 # text = There are only two counterparties at this time who have overdue margin:
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	only	only	ADV	RB	_	5	advmod	5:advmod	_
 4	two	two	NUM	CD	NumForm=Word|NumType=Card	5	nummod	5:nummod	_
-5	counterparties	counterparty	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|10:nsubj	_
+5	counterparties	counterparty	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj|10:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 6	at	at	ADP	IN	_	8	case	8:case	_
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	time	time	NOUN	NN	Number=Sing	2	obl	2:obl:at	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	5:ref	_
-10	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+10	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 11	overdue	overdue	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	margin	margin	NOUN	NN	Number=Sing	10	obj	10:obj	SpaceAfter=No
 13	:	:	PUNCT	:	_	2	punct	2:punct	_
@@ -6377,7 +6377,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
 8	any	any	DET	DT	PronType=Ind	10	det	10:det	_
 9	additional	additional	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
 10	information	information	NOUN	NN	Number=Sing	7	obj	7:obj	SpaceAfter=No
@@ -6410,7 +6410,7 @@
 1	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 2	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 3	for	for	ADP	IN	_	4	case	4:case	_
-4	guitar	guitar	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+4	guitar	guitar	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent04_02-0003
@@ -6492,7 +6492,7 @@
 # text = Have you seen the materials from the press conference that he launched today?
 1	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	materials	material	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	from	from	ADP	IN	_	9	case	9:case	_
@@ -6501,7 +6501,7 @@
 9	conference	conference	NOUN	NN	Number=Sing	5	nmod	5:nmod:from|12:obj	_
 10	that	that	PRON	WDT	PronType=Rel	12	obj	9:ref	_
 11	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-that-obj
+12	launched	launch	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 13	today	today	NOUN	NN	Number=Sing	12	obl:unmarked	12:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 14	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -6644,7 +6644,7 @@
 14	if	if	SCONJ	IN	_	17	mark	17:mark	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	set	set	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	_
+17	set	set	VERB	VB	VerbForm=Inf	13	ccomp	13:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=17:Interrogative-Polar-Indirect.Clause
 18	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	obj	17:obj	_
 19	up	up	ADP	RP	_	17	compound:prt	17:compound:prt	SpaceAfter=No
 20	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -6774,7 +6774,7 @@
 18	that	that	SCONJ	IN	_	21	mark	21:mark	_
 19	LSU	LSU	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 20	may	may	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
-21	play	play	VERB	VB	VerbForm=Inf	17	acl	17:acl:that	_
+21	play	play	VERB	VB	VerbForm=Inf	17	acl	17:acl:that	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 22	in	in	ADP	IN	_	25	case	25:case	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 24	Cotton	Cotton	PROPN	NNP	Number=Sing	25	compound	25:compound	_
@@ -6786,7 +6786,7 @@
 30	Alabama	Alabama	PROPN	NNP	Number=Sing	28	flat	28:flat	SpaceAfter=No
 31	"	"	PUNCT	''	_	30	punct	30:punct	_
 32	Davey	Davey	PROPN	NNP	Number=Sing	28	flat	28:flat	_
-33	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	_
+33	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 34	up	up	ADP	RP	_	33	compound:prt	33:compound:prt	_
 35	for	for	ADP	IN	_	39	case	39:case	_
 36	the	the	DET	DT	Definite=Def|PronType=Art	39	det	39:det	_
@@ -6814,7 +6814,7 @@
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	lesson	lesson	NOUN	NN	Number=Sing	0	root	0:root|17:obj	_
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
-17	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj
+17	learned	learn	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	following	follow	VERB	VBG	Tense=Pres|VerbForm=Part	21	case	21:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	21	det	21:det	_
 20	Ark	Ark	PROPN	NNP	Number=Sing	21	compound	21:compound	_
@@ -6886,10 +6886,10 @@
 
 # sent_id = email-enronsent23_04-0017
 # text = why is enron blowing up?
-1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	enron	enron	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	blowing	blow	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+4	blowing	blow	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	up	up	ADP	RP	_	4	compound:prt	4:compound:prt	SpaceAfter=No
 6	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -7074,12 +7074,12 @@
 1	In	in	ADP	IN	_	2	case	2:case	_
 2	addition	addition	NOUN	NN	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
-4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	there	there	PRON	EX	_	4	expl	4:expl	_
-6	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj|9:nsubj	_
+6	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj|9:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 7	who	who	PRON	WP	PronType=Rel	9	nsubj	6:ref	_
 8	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	consider	consider	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-nsubj
+9	consider	consider	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	correlation	correlation	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	between	between	ADP	IN	_	14	case	14:case	_
@@ -7104,9 +7104,9 @@
 6	assuming	assume	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 7	that	that	SCONJ	IN	_	9	mark	9:mark	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
+9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	Cxn=Existential-CopPred-ThereExpl
 10	no	no	DET	DT	PronType=Neg	11	det	11:det	_
-11	correlation	correlation	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
+11	correlation	correlation	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 12	and	and	CCONJ	CC	_	17	cc	17:cc	_
 13	may	may	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
 14	consequently	consequently	ADV	RB	_	17	advmod	17:advmod	_
@@ -7132,7 +7132,7 @@
 6	suggestions	suggestion	NOUN	NNS	Number=Plur	4	conj	1:obl:for|4:conj:or	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	could	could	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	provide	provide	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+9	provide	provide	VERB	VB	VerbForm=Inf	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent18_01-0011
@@ -7178,7 +7178,7 @@
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	could	could	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
-7	give	give	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
+7	give	give	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
 8	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	7	iobj	7:iobj	_
 9	some	some	DET	DT	PronType=Ind	10	det	10:det	_
 10	references	reference	NOUN	NNS	Number=Plur	7	obj	7:obj	_
@@ -7507,13 +7507,13 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	PX	px	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
-4	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	_
+4	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	back	back	ADV	RB	_	4	advmod	4:advmod	_
 6	again	again	ADV	RB	_	4	advmod	4:advmod	SpaceAfter=No
 7	,	,	PUNCT	,	_	4	punct	4:punct	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	will	will	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	call	call	VERB	VB	VerbForm=Inf	0	root	0:root	_
+10	call	call	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 11	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 12	in	in	ADP	IN	_	14	case	14:case	SpaceAfter=No
 13	-	-	PUNCT	HYPH	_	12	punct	12:punct	SpaceAfter=No
@@ -7539,7 +7539,7 @@
 # text = Can you pass this along to Elizabeth to ensure Sanders is on board as well?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	pass	pass	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	pass	pass	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	this	this	PRON	DT	Number=Sing|PronType=Dem	3	obj	3:obj	_
 5	along	along	ADV	RB	_	3	advmod	3:advmod	_
 6	to	to	ADP	IN	_	7	case	7:case	_
@@ -7563,9 +7563,9 @@
 5	L/C's	l/c	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	on	on	ADP	IN	_	11	case	11:case	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-8	month	month	NOUN	NN	Number=Sing	11	compound	11:compound	_
-9	to	to	ADP	IN	_	10	case	10:case	_
-10	month	month	NOUN	NN	Number=Sing	8	nmod	8:nmod:to	_
+8	month	month	NOUN	NN	Number=Sing	11	compound	11:compound	Cxn=NPN|CxnElt=8:NPN.N1
+9	to	to	ADP	IN	_	10	case	10:case	CxnElt=8:NPN.P
+10	month	month	NOUN	NN	Number=Sing	8	nmod	8:nmod:to	CxnElt=8:NPN.N2
 11	basis	basis	NOUN	NN	Number=Sing	3	obl	3:obl:on	_
 12	for	for	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
@@ -7590,7 +7590,7 @@
 12	CASH	cash	NOUN	NN	Number=Sing	9	obj	9:obj|15:nsubj:pass	_
 13	that	that	PRON	WDT	PronType=Rel	15	nsubj:pass	12:ref	_
 14	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux:pass	15:aux:pass	_
-15	drawn	draw	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass
+15	drawn	draw	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
 16	down	down	ADV	RB	_	15	advmod	15:advmod	SpaceAfter=No
 17	...	...	PUNCT	,	_	19	punct	19:punct	SpaceAfter=No
 18	please	please	INTJ	UH	_	19	discourse	19:discourse	_
@@ -7652,9 +7652,9 @@
 6	PX	px	NOUN	NN	Number=Sing	2	obl	2:obl:to	_
 7	that	that	SCONJ	IN	_	9	mark	9:mark	_
 8	there	there	PRON	EX	_	9	expl	9:expl	_
-9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+9	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	Cxn=Existential-CopPred-ThereExpl
 10	excess	excess	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
-11	credit	credit	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	SpaceAfter=No
+11	credit	credit	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 12	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent32_02-0031
@@ -7669,7 +7669,7 @@
 8	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 9	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 10	not	not	PART	RB	Polarity=Neg	11	advmod	11:advmod	_
-11	keeping	keep	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+11	keeping	keep	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=11:Interrogative-Polar-Direct.Clause
 12	required	require	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	amod	13:amod	_
 13	levels	level	NOUN	NNS	Number=Plur	11	obj	11:obj|14:nsubj:xsubj	_
 14	available	available	ADJ	JJ	Degree=Pos	11	xcomp	11:xcomp	SpaceAfter=No
@@ -7784,7 +7784,7 @@
 15	)	)	PUNCT	-RRB-	_	14	punct	14:punct	SpaceAfter=No
 16	]	]	PUNCT	-RRB-	_	7	punct	7:punct	_
 17	who	who	PRON	WP	PronType=Rel	18	nsubj	4:ref	_
-18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
+18	conrfirmed	conrfirm	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 19	to	to	ADP	IN	_	20	case	20:case	_
 20	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	18	obl	18:obl:to	_
 21	that	that	SCONJ	IN	_	24	mark	24:mark	_
@@ -7915,7 +7915,7 @@
 12	13s	13	NOUN	NNS	Number=Plur	7	nmod	7:nmod:for|15:nsubj:pass	_
 13	which	which	PRON	WDT	PronType=Rel	15	nsubj:pass	12:ref	_
 14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	15	aux:pass	15:aux:pass	CorrectForm=is|CorrectNumber=Sing
-15	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj:pass
+15	attached	attach	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
 16	to	to	ADP	IN	_	19	case	19:case	_
 17	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	19	nmod:poss	19:nmod:poss	_
 18	sample	sample	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -8033,8 +8033,8 @@
 7	even	even	ADV	RB	_	10	advmod	10:advmod	_
 8	though	though	SCONJ	IN	_	10	mark	10:mark	_
 9	there	there	PRON	EX	_	10	expl	10:expl	_
-10	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:though	_
-11	blanks	blank	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	SpaceAfter=No
+10	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:though	Cxn=Existential-CopPred-ThereExpl
+11	blanks	blank	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	CxnElt=10:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent36_01-0028
@@ -8193,7 +8193,7 @@
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	8:expl	_
 6	would	would	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
 7	be	be	AUX	VB	VerbForm=Inf	8	cop	8:cop	_
-8	OK	ok	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	_
+8	OK	ok	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=8:Interrogative-Polar-Indirect.Clause
 9	for	for	SCONJ	IN	_	12	mark	12:mark	_
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
@@ -8276,7 +8276,7 @@
 5	if	if	SCONJ	IN	_	8	mark	8:mark	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 7	can	can	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	spend	spend	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	_
+8	spend	spend	VERB	VB	VerbForm=Inf	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=8:Interrogative-Polar-Indirect.Clause
 9	a	a	DET	DT	Definite=Ind|PronType=Art	10	det	10:det	_
 10	day	day	NOUN	NN	Number=Sing	8	obj	8:obj	SpaceAfter=No
 11	,	,	PUNCT	,	_	12	punct	12:punct	_
@@ -8296,7 +8296,7 @@
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	28:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	good	good	ADJ	JJ	Degree=Pos	28	amod	28:amod	_
-28	time	time	NOUN	NN	Number=Sing	23	advcl:relcl	23:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
+28	time	time	NOUN	NN	Number=Sing	23	advcl:relcl	23:advcl:relcl	SpaceAfter=No
 29	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent09_02-0008
@@ -8387,7 +8387,7 @@
 32	Robert	Robert	PROPN	NNP	Number=Sing	30	conj	29:obj|30:conj:and|34:nsubj:xsubj	_
 33	Lloyd	Lloyd	PROPN	NNP	Number=Sing	32	flat	32:flat	_
 34	know	know	VERB	VB	VerbForm=Inf	29	xcomp	29:xcomp	_
-35	what	what	PRON	WP	PronType=Int	34	ccomp	34:ccomp	_
+35	what	what	PRON	WP	PronType=Int	34	ccomp	34:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=35:Interrogative-WHInfo-Indirect.Clause,35:Interrogative-WHInfo-Indirect.WHWord
 36	the	the	DET	DT	Definite=Def|PronType=Art	38	det	38:det	_
 37	sitara	sitara	NOUN	NN	Number=Sing	38	compound	38:compound	_
 38	#	#	SYM	NN	Number=Sing	35	nsubj	35:nsubj	_
@@ -8672,7 +8672,7 @@
 # text = If you want to pass this web site address along to other folks, feel free.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	pass	pass	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
@@ -8684,7 +8684,7 @@
 12	other	other	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	folks	folk	NOUN	NNS	Number=Plur	5	obl	5:obl:to	SpaceAfter=No
 14	,	,	PUNCT	,	_	3	punct	3:punct	_
-15	feel	feel	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+15	feel	feel	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	free	free	ADJ	JJ	Degree=Pos	15	xcomp	15:xcomp	SpaceAfter=No
 17	.	.	PUNCT	.	_	15	punct	15:punct	_
 
@@ -8692,7 +8692,7 @@
 # text = If you want a CD copy of this web site, give me a yell.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	CD	cd	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	copy	copy	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -8701,7 +8701,7 @@
 9	web	web	NOUN	NN	Number=Sing	10	compound	10:compound	_
 10	site	site	NOUN	NN	Number=Sing	6	nmod	6:nmod:of	SpaceAfter=No
 11	,	,	PUNCT	,	_	3	punct	3:punct	_
-12	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+12	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	12	iobj	12:iobj	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	yell	yell	NOUN	NN	Number=Sing	12	obj	12:obj	SpaceAfter=No
@@ -8791,7 +8791,7 @@
 # text = Are you free for lunch some day this week?
 1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	for	for	ADP	IN	_	5	case	5:case	_
 5	lunch	lunch	NOUN	NN	Number=Sing	3	obl	3:obl:for	_
 6	some	some	DET	DT	PronType=Ind	7	det	7:det	_
@@ -8876,7 +8876,7 @@
 5	Master	master	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	draft	draft	NOUN	NN	Number=Sing	2	nsubj	2:nsubj|8:obj	_
 7	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+8	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 9	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = email-enronsent29_02-0011
@@ -8904,7 +8904,7 @@
 3	of	of	ADP	IN	_	4	case	4:case	_
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	nmod	2:nmod:of	_
 5	please	please	INTJ	UH	_	6	discourse	6:discourse	_
-6	email	email	VERB	VB	VerbForm=Inf	0	root	0:root	_
+6	email	email	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	6	iobj	6:iobj	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	copy	copy	NOUN	NN	Number=Sing	6	obj	6:obj	_
@@ -8913,7 +8913,7 @@
 12	standard	standard	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
 13	template	template	NOUN	NN	Number=Sing	9	nmod	9:nmod:of|15:obj	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-red-obj
+15	use	use	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 16	for	for	ADP	IN	_	20	case	20:case	_
 17	Enfolio	Enfolio	PROPN	NNP	Number=Sing	20	compound	20:compound	_
 18	gas	gas	NOUN	NN	Number=Sing	19	compound	19:compound	_
@@ -9078,7 +9078,7 @@
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
-7	interested	interested	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	SpaceAfter=No
+7	interested	interested	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause|SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent29_02-0026
@@ -9112,7 +9112,7 @@
 # text = Are you free for lunch some day this week?
 1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	free	free	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	for	for	ADP	IN	_	5	case	5:case	_
 5	lunch	lunch	NOUN	NN	Number=Sing	3	obl	3:obl:for	_
 6	some	some	DET	DT	PronType=Ind	7	det	7:det	_
@@ -9323,7 +9323,7 @@
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
-7	interested	interested	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	SpaceAfter=No
+7	interested	interested	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause|SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent29_02-0045
@@ -9646,7 +9646,7 @@
 10	since	since	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	Depression	Depression	PROPN	NNP	Number=Sing	9	nmod	9:nmod:since	_
-13	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl
+13	worked	work	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 14	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	way	way	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	down	down	ADV	RB	_	13	advmod	13:advmod	SpaceAfter=No
@@ -9678,7 +9678,7 @@
 22	Street	Street	PROPN	NNP	Number=Sing	20	obj	20:obj	SpaceAfter=No
 23	,	,	PUNCT	,	_	20	punct	20:punct	CheckAttachment=22
 24	many	many	ADJ	JJ	Degree=Pos	6	parataxis	6:parataxis|24.1:nsubj	CheckAttachment=22|CheckReln=appos
-24.1	left	left	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	_	_	6:parataxis	CopyOf=6
+24.1	left	left	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	_	_	6:parataxis	CopyOf=6|wordform=__EMPTY__
 25	for	for	ADP	IN	_	26	case	26:case	_
 26	good	good	ADJ	JJ	Degree=Pos	24	orphan	24.1:obl:for	CheckReln=nmod|SpaceAfter=No
 27	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -9875,7 +9875,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	spreadsheet	spreadsheet	NOUN	NN	Number=Sing	1	nsubj:pass	1:nsubj:pass|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	contains	contain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+6	contains	contain	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	values	value	NOUN	NNS	Number=Plur	6	obj	6:obj	SpaceAfter=No
 9	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -9918,16 +9918,16 @@
 2	addition	addition	NOUN	NN	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
-7	reduction	reduction	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
+7	reduction	reduction	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	22,101	22101	NUM	CD	NumForm=Digit|NumType=Card	10	nummod	10:nummod	SpaceAfter=No
 10	MMBTU	mmbtu	NOUN	NNS	Number=Plur	7	nmod	7:nmod:of|14:nsubj	_
 11	which	which	PRON	WDT	PronType=Rel	14	nsubj	10:ref	_
 12	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-14	difference	difference	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	Cxn=rc-wh-nsubj
+14	difference	difference	NOUN	NN	Number=Sing	10	acl:relcl	10:acl:relcl	_
 15	between	between	ADP	IN	_	18	case	18:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 17	SCADA	scada	NOUN	NN	Number=Sing	18	compound	18:compound	_
@@ -9938,7 +9938,7 @@
 22	)	)	PUNCT	-RRB-	_	21	punct	21:punct	_
 23	that	that	PRON	WDT	PronType=Rel	25	obj	18:ref	_
 24	Anita	Anita	PROPN	NNP	Number=Sing	25	nsubj	25:nsubj	_
-25	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-that-obj
+25	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 26	on	on	ADP	IN	_	31	case	31:case	_
 27	the	the	DET	DT	Definite=Def|PronType=Art	31	det	31:det	_
 28	February	February	PROPN	NNP	Number=Sing	31	compound	31:compound	_
@@ -9956,7 +9956,7 @@
 40	that	that	PRON	WDT	PronType=Rel	43	obj	39:ref	_
 41	Gary	Gary	PROPN	NNP	Number=Sing	43	nsubj	43:nsubj	_
 42	Wilson	Wilson	PROPN	NNP	Number=Sing	41	flat	41:flat	_
-43	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	Cxn=rc-that-obj
+43	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	39	acl:relcl	39:acl:relcl	_
 44	from	from	ADP	IN	_	45	case	45:case	_
 45	MIPS	mips	NOUN	NN	Number=Sing	43	obl	43:obl:from	SpaceAfter=No
 46	.	.	PUNCT	.	_	5	punct	5:punct	_
@@ -10001,13 +10001,13 @@
 # sent_id = email-enronsent28_01-0041
 # newpar id = email-enronsent28_01-p0011
 # text = Call me if there are any questions.
-1	Call	call	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+1	Call	call	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=1:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 2	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	1	obj	1:obj	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	advcl	1:advcl:if	Cxn=Existential-CopPred-ThereExpl|CxnElt=1:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	any	any	DET	DT	PronType=Ind	7	det	7:det	_
-7	questions	question	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	SpaceAfter=No
+7	questions	question	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent28_01-0042
@@ -10191,7 +10191,7 @@
 3	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	not	not	PART	RB	Polarity=Neg	6	advmod	6:advmod	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
-6	addressee	addressee	NOUN	NN	Number=Sing	27	advcl	27:advcl:if	_
+6	addressee	addressee	NOUN	NN	Number=Sing	27	advcl	27:advcl:if	CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	indicated	indicate	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl	6:acl	_
 8	in	in	ADP	IN	_	10	case	10:case	_
 9	this	this	DET	DT	Number=Sing|PronType=Dem	10	det	10:det	_
@@ -10212,7 +10212,7 @@
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj	_
 25	may	may	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 26	not	not	PART	RB	Polarity=Neg	27	advmod	27:advmod	_
-27	copy	copy	VERB	VB	VerbForm=Inf	0	root	0:root	_
+27	copy	copy	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 28	or	or	CCONJ	CC	_	29	cc	29:cc	_
 29	deliver	deliver	VERB	VB	VerbForm=Inf	27	conj	27:conj:or	_
 30	this	this	DET	DT	Number=Sing|PronType=Dem	31	det	31:det	_
@@ -10245,7 +10245,7 @@
 # sent_id = email-enronsent04_01-0011
 # text = Please advise immediately if you or your employer do not consent to Internet email for messages of this kind.
 1	Please	please	INTJ	UH	_	2	discourse	2:discourse	_
-2	advise	advise	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+2	advise	advise	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 3	immediately	immediately	ADV	RB	_	2	advmod	2:advmod	_
 4	if	if	SCONJ	IN	_	11	mark	11:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
@@ -10254,7 +10254,7 @@
 8	employer	employer	NOUN	NN	Number=Sing	5	conj	5:conj:or|11:nsubj	_
 9	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	not	not	PART	RB	Polarity=Neg	11	advmod	11:advmod	_
-11	consent	consent	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:if	_
+11	consent	consent	VERB	VB	VerbForm=Inf	2	advcl	2:advcl:if	CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 12	to	to	ADP	IN	_	14	case	14:case	_
 13	Internet	internet	NOUN	NN	Number=Sing	14	compound	14:compound	_
 14	email	email	NOUN	NN	Number=Sing	11	obl	11:obl:to	_
@@ -10279,7 +10279,7 @@
 10	that	that	PRON	WDT	PronType=Rel	13	nsubj	1:ref	_
 11	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	13:aux	_
 12	not	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	relate	relate	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-that-nsubj
+13	relate	relate	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 14	to	to	ADP	IN	_	17	case	17:case	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 16	official	official	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -10347,7 +10347,7 @@
 7	firm	firm	NOUN	NN	Number=Sing	0	root	0:root|10:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	10	nsubj	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
-10	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
+10	looking	look	VERB	VBG	Tense=Pres|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
 11	for	for	ADP	IN	_	13	case	13:case	_
 12	an	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 13	individual	individual	NOUN	NN	Number=Sing	10	obl	10:obl:for	_
@@ -10517,7 +10517,7 @@
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	people	people	NOUN	NNS	Number=Plur	3	obl	3:obl:from|12:obj	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
-12	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj
+12	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	_
 13	at	at	ADP	IN	_	14	case	14:case	_
 14	ENE	ENE	PROPN	NNP	Number=Sing	12	obl	12:obl:at	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -10541,8 +10541,8 @@
 # text = there will be talent and opportunity a plenty on the market soon.
 1	there	there	PRON	EX	_	3	expl	3:expl	_
 2	will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
-4	talent	talent	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+4	talent	talent	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	opportunity	opportunity	NOUN	NN	Number=Sing	4	conj	3:nsubj|4:conj:and	_
 7	a	aplenty	ADJ	GW	Degree=Pos|Typo=Yes	4	amod	4:amod	_
@@ -10611,7 +10611,7 @@
 44	at	at	ADP	IN	_	45	case	45:case	_
 45	Schlumberger	Schlumberger	PROPN	NNP	Number=Sing	3	conj	3:conj:and	_
 46	and	and	CCONJ	CC	_	47	cc	47:cc	_
-47	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	conj	45:conj:and	_
+47	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	45	conj	45:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=47:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 48	good	good	ADJ	JJ	Degree=Pos	49	amod	49:amod	_
 49	contacts	contact	NOUN	NNS	Number=Plur	47	obj	47:obj	_
 50	in	in	ADP	IN	_	51	case	51:case	_
@@ -10622,7 +10622,7 @@
 55-56	aren't	_	_	_	_	_	_	_	_
 55	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	57	cop	57:cop	_
 56	n't	not	PART	RB	Polarity=Neg	57	advmod	57:advmod	_
-57	married	married	ADJ	JJ	Degree=Pos	47	advcl	47:advcl:if	_
+57	married	married	ADJ	JJ	Degree=Pos	47	advcl	47:advcl:if	CxnElt=47:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 58	to	to	ADP	IN	_	61	case	61:case	_
 59	a	a	DET	DT	Definite=Ind|PronType=Art	61	det	61:det	_
 60	trading	trading	NOUN	NN	Number=Sing	61	compound	61:compound	_
@@ -10665,7 +10665,7 @@
 10	gas	gas	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	traders	trader	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|13:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	13	nsubj	11:ref	_
-13	made	make	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-that-nsubj
+13	made	make	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	18	nmod:poss	18:nmod:poss	_
 15	now	now	ADV	RB	PronType=Dem	17	advmod	17:advmod	_
 16	almost	almost	ADV	RB	_	17	advmod	17:advmod	_
@@ -10761,7 +10761,7 @@
 28	what	what	PRON	WP	PronType=Rel	26	obl	26:obl:to|31:obj	_
 29	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	31	nsubj	31:nsubj	_
 30	all	all	DET	DT	PronType=Tot	29	det	29:det	_
-31	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	Cxn=rc-free-obj
+31	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	28	acl:relcl	28:acl:relcl	_
 32	in	in	ADP	IN	_	33	case	33:case	_
 33	mind	mind	NOUN	NN	Number=Sing	31	obl	31:obl:in	SpaceAfter=No
 34	.	.	PUNCT	.	_	2	punct	2:punct	_
@@ -11086,7 +11086,7 @@
 18	banks	bank	NOUN	NNS	Number=Plur	15	nmod	15:nmod:of	_
 19	which	which	PRON	WDT	PronType=Rel	21	nsubj:pass	13:ref	_
 20	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	21	aux:pass	21:aux:pass	_
-21	granted	grant	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-nsubj:pass
+21	granted	grant	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	13	acl:relcl	13:acl:relcl	_
 22	in	in	ADP	IN	_	23	case	23:case	_
 23	connection	connection	NOUN	NN	Number=Sing	21	obl	21:obl:in	_
 24	with	with	ADP	IN	_	29	case	29:case	_
@@ -11137,7 +11137,7 @@
 17	form	form	NOUN	NN	Number=Sing	12	xcomp	12:xcomp|20:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	20	nsubj	17:ref	_
 19	will	will	AUX	MD	VerbForm=Fin	20	aux	20:aux	_
-20	acceptable	acceptable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
+20	acceptable	acceptable	ADJ	JJ	Degree=Pos	17	acl:relcl	17:acl:relcl	_
 21	to	to	ADP	IN	_	24	case	24:case	_
 22	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	24	nmod:poss	24:nmod:poss	_
 23	project	project	NOUN	NN	Number=Sing	24	compound	24:compound	_
@@ -11157,7 +11157,7 @@
 37	form	form	NOUN	NN	Number=Sing	34	obl	34:obl:with|40:nsubj:pass|48:nsubj:pass	_
 38	that	that	PRON	WDT	PronType=Rel	40	nsubj:pass	37:ref	_
 39	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	40	aux:pass	40:aux:pass	_
-40	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	37	acl:relcl	37:acl:relcl	Cxn=rc-that-nsubj:pass
+40	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	37	acl:relcl	37:acl:relcl	_
 41	in	in	ADP	IN	_	44	case	44:case	_
 42	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	44	nmod:poss	44:nmod:poss	_
 43	last	last	ADJ	JJ	Degree=Pos	44	amod	44:amod	_
@@ -11190,7 +11190,7 @@
 13	that	that	PRON	WDT	PronType=Rel	16	nsubj:pass	12:ref	_
 14	will	will	AUX	MD	VerbForm=Fin	16	aux	16:aux	_
 15	be	be	AUX	VB	VerbForm=Inf	16	aux:pass	16:aux:pass	_
-16	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj:pass
+16	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	12	acl:relcl	12:acl:relcl	_
 17	in	in	ADP	IN	_	18	case	18:case	_
 18	favor	favor	NOUN	NN	Number=Sing	16	obl	16:obl:in	_
 19	of	of	ADP	IN	_	20	case	20:case	_
@@ -11230,13 +11230,13 @@
 2	feel	feel	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 3	free	free	ADJ	JJ	Degree=Pos	2	xcomp	2:xcomp	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
-5	give	give	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:to	_
+5	give	give	VERB	VB	VerbForm=Inf	3	advcl	3:advcl:to	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 6	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	5	iobj	5:iobj	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	call	call	NOUN	NN	Number=Sing	5	obj	5:obj	_
 9	if	if	SCONJ	IN	_	11	mark	11:mark	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:if	_
+11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	advcl	5:advcl:if	CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 12	any	any	DET	DT	PronType=Ind	13	det	13:det	_
 13	questions	question	NOUN	NNS	Number=Plur	11	obj	11:obj	_
 14	concerning	concern	VERB	VBG	Tense=Pres|VerbForm=Part	17	case	17:case	_
@@ -11551,7 +11551,7 @@
 # text = Do you have any current info on deal status?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	any	any	DET	DT	PronType=Ind	6	det	6:det	_
 5	current	current	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	info	info	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -11581,7 +11581,7 @@
 # text = Are you going to be able to make the power VAR meeting on Thursday?
 1	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|6:nsubj:xsubj|8:nsubj:xsubj	_
-3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	to	to	PART	TO	_	6	mark	6:mark	_
 5	be	be	AUX	VB	VerbForm=Inf	6	cop	6:cop	_
 6	able	able	ADJ	JJ	Degree=Pos	3	xcomp	3:xcomp	_
@@ -11683,7 +11683,7 @@
 10	consulting	consulting	NOUN	NN	Number=Sing	11	compound	11:compound	_
 11	arrangement	arrangement	NOUN	NN	Number=Sing	5	obl	5:obl:regarding|13:obj	_
 12	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
+13	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	couple	couple	NOUN	NN	Number=Sing	18	obl:unmarked	18:obl:unmarked	_
 16	of	of	ADP	IN	_	17	case	17:case	_
@@ -11708,7 +11708,7 @@
 13	contract	contract	NOUN	NN	Number=Sing	5	obl	5:obl:with|16:obl|28:obl	_
 14	where	where	ADV	WRB	PronType=Rel	16	advmod	13:ref	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj|28:nsubj	_
-16	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-wh-obl
+16	give	give	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 17	some	some	DET	DT	PronType=Ind	18	det	18:det	_
 18	thoughts	thought	NOUN	NNS	Number=Plur	16	obj	16:obj	_
 19	to	to	ADP	IN	_	21	case	21:case	_
@@ -11718,7 +11718,7 @@
 23	issues	issue	NOUN	NNS	Number=Plur	21	nmod	21:nmod:of	_
 24	that	that	PRON	WDT	PronType=Rel	26	obj	21:ref	_
 25	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	Cxn=rc-that-obj
+26	discussed	discuss	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	21	acl:relcl	21:acl:relcl	_
 27	and	and	CCONJ	CC	_	28	cc	28:cc	_
 28	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	16	conj	13:acl:relcl|16:conj:and	_
 29	to	to	ADP	IN	_	30	case	30:case	_
@@ -11784,7 +11784,7 @@
 # text = Did you have a chance to take a look at the resume I sent you?
 1	Did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	chance	chance	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
@@ -11795,7 +11795,7 @@
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	resume	resume	NOUN	NN	Number=Sing	9	nmod	9:nmod:at|14:obj	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
-14	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	Cxn=rc-red-obj
+14	sent	send	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	12	acl:relcl	12:acl:relcl	_
 15	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	14	iobj	14:iobj	SpaceAfter=No
 16	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -11913,7 +11913,7 @@
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	presentation	presentation	NOUN	NN	Number=Sing	5	nsubj:pass	5:nsubj:pass|10:obj	_
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
+10	gave	give	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	at	at	ADP	IN	_	16	case	16:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 13	Canadian	Canadian	ADJ	NNP	Degree=Pos	16	amod	16:amod	_
@@ -12184,7 +12184,7 @@
 4-5	cannot	_	_	_	_	_	_	_	_
 4	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 5	not	not	PART	RB	Polarity=Neg	6	advmod	6:advmod	_
-6	help	help	VERB	VB	VerbForm=Inf	15	advcl	15:advcl:if	_
+6	help	help	VERB	VB	VerbForm=Inf	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	6	obj	6:obj	_
 8	here	here	ADV	RB	PronType=Dem	6	advmod	6:advmod	_
 9	in	in	ADP	IN	_	10	case	10:case	_
@@ -12193,7 +12193,7 @@
 12	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj|17:nsubj:xsubj	_
 13	may	may	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
 14	be	be	AUX	VB	VerbForm=Inf	15	cop	15:cop	_
-15	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	_
+15	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	to	to	PART	TO	_	17	mark	17:mark	_
 17	put	put	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	17	obj	17:obj	_
@@ -12380,7 +12380,7 @@
 16	could	could	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
 17	be	be	AUX	VB	VerbForm=Inf	19	aux:pass	19:aux:pass	_
 18	successfully	successfully	ADV	RB	_	19	advmod	19:advmod	_
-19	accomplished	accomplish	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	Cxn=rc-wh-obl-pfront|SpaceAfter=No
+19	accomplished	accomplish	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 20	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = email-enronsent18_02-0070
@@ -12418,7 +12418,7 @@
 11	elsewhere	elsewhere	ADV	RB	_	6	conj	5:advmod|6:conj:or|14:nsubj	_
 12	that	that	PRON	WDT	PronType=Rel	14	nsubj	11:ref	_
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	14:cop	_
-14	appropriate	appropriate	ADJ	JJ	Degree=Pos	11	advcl:relcl	11:advcl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+14	appropriate	appropriate	ADJ	JJ	Degree=Pos	11	advcl:relcl	11:advcl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = email-enronsent18_02-0072
@@ -12500,7 +12500,7 @@
 1	Would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	this	this	PRON	DT	Number=Sing|PronType=Dem	4	nsubj	4:nsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	fine	fine	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+4	fine	fine	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = email-enronsent18_02-0080
@@ -12565,11 +12565,11 @@
 # sent_id = email-enronsent21_02-0006
 # newpar id = email-enronsent21_02-p0004
 # text = Are there any new developments in the trader world?
-1	Are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
-5	developments	development	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	_
+5	developments	development	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot
 6	in	in	ADP	IN	_	9	case	9:case	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 8	trader	trader	NOUN	NN	Number=Sing	9	compound	9:compound	_
@@ -12587,7 +12587,7 @@
 7	books	book	NOUN	NNS	Number=Plur	5	conj	3:obj|5:conj:and|10:obj	_
 8	that	that	PRON	WDT	PronType=Rel	10	obj	5:ref	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-obj
+10	provided	provide	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 11	last	last	ADJ	JJ	Degree=Pos	12	amod	12:amod	_
 12	week	week	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	SpaceAfter=No|TemporalNPAdjunct=Yes
 13	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -12597,9 +12597,9 @@
 17	know	know	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
 18	if	if	SCONJ	IN	_	20	mark	20:mark	_
 19	there	there	PRON	EX	_	20	expl	20:expl	_
-20	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	ccomp	17:ccomp	_
+20	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	ccomp	17:ccomp	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Indirect|CxnElt=20:Interrogative-Polar-Indirect.Clause
 21	any	any	DET	DT	PronType=Ind	22	det	22:det	_
-22	changes	change	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	_
+22	changes	change	NOUN	NNS	Number=Plur	20	nsubj	20:nsubj	CxnElt=20:Existential-CopPred-ThereExpl.Pivot
 23	to	to	ADP	IN	_	24	case	24:case	_
 24	this	this	PRON	DT	Number=Sing|PronType=Dem	22	nmod	22:nmod:to	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -12612,7 +12612,7 @@
 4	know	know	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
 5	if	if	SCONJ	IN	_	7	mark	7:mark	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	7	nsubj	7:nsubj	_
-7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	_
+7	need	need	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	ccomp	4:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=7:Interrogative-Polar-Indirect.Clause
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	change	change	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	so	so	SCONJ	IN	ExtPos=SCONJ	15	mark	15:mark	_
@@ -12684,9 +12684,9 @@
 # newpar id = email-enronsent21_02-p0008
 # text = What's going on with the UBS weather position?
 1-2	What's	_	_	_	_	_	_	_	_
-1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	_
+1	What	what	PRON	WP	PronType=Int	3	nsubj	3:nsubj	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
-3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+3	going	go	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	on	on	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	with	with	ADP	IN	_	9	case	9:case	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
@@ -12699,7 +12699,7 @@
 # text = Has that gone anywhere or are the other possibilities you had better?
 1	Has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
-3	gone	go	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+3	gone	go	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	anywhere	anywhere	ADV	RB	PronType=Ind	3	advmod	3:advmod	_
 5	or	or	CCONJ	CC	_	12	cc	12:cc	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
@@ -12707,7 +12707,7 @@
 8	other	other	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	possibilities	possibility	NOUN	NNS	Number=Plur	12	nsubj	11:obj|12:nsubj	_
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj
+11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	better	good	ADJ	JJR	Degree=Cmp	3	conj	3:conj:or	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -12768,12 +12768,12 @@
 3	would	would	AUX	MD	VerbForm=Fin	6	aux	6:aux	_
 4	be	be	AUX	VB	VerbForm=Inf	6	cop	6:cop	_
 5	so	so	ADV	RB	_	6	advmod	6:advmod	_
-6	kind	kind	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	SpaceAfter=No
+6	kind	kind	ADJ	JJ	Degree=Pos	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 7	,	,	PUNCT	,	_	6	punct	6:punct	_
 8	could	could	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
 10	possibly	possibly	ADV	RB	_	11	advmod	11:advmod	_
-11	let	let	VERB	VB	VerbForm=Inf	0	root	0:root	_
+11	let	let	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,11:Interrogative-Polar-Direct.Clause
 12	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	11	obj	11:obj|13:nsubj:xsubj	_
 13	know	know	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	of	of	ADP	IN	_	16	case	16:case	_
@@ -12795,7 +12795,7 @@
 4	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	2	nmod	2:nmod:of	_
 5	who	who	PRON	WP	PronType=Rel	7	nsubj	2:ref	_
 6	already	already	ADV	RB	_	7	advmod	7:advmod	_
-7	sent	send	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-nsubj
+7	sent	send	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 8	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	7	iobj	7:iobj	_
 9	an	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 10	RSVP	rsvp	NOUN	NN	Number=Sing	11	compound	11:compound	_
@@ -12833,7 +12833,7 @@
 # text = Could you run those additional post-id's?
 1	Could	could	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	run	run	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	run	run	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	those	that	DET	DT	Number=Plur|PronType=Dem	8	det	8:det	_
 5	additional	additional	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 6	post	post	NOUN	NN	Number=Sing	8	compound	8:compound	SpaceAfter=No
@@ -12844,8 +12844,8 @@
 # sent_id = email-enronsent21_02-0027
 # text = There are deals in the Aruba book so I'm not sure why you aren't picking those up.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	deals	deal	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+3	deals	deal	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 4	in	in	ADP	IN	_	7	case	7:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	Aruba	Aruba	PROPN	NNP	Number=Sing	7	compound	7:compound	_
@@ -13064,14 +13064,14 @@
 1	could	could	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	also	also	ADV	RB	_	4	advmod	4:advmod	_
-4	CC	cc	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	CC	cc	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	iobj	4:iobj	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 7	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	9	amod	9:amod	_
 8	few	few	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	times	time	NOUN	NNS	Number=Plur	4	obl:unmarked	4:obl:unmarked|11:obl	TemporalNPAdjunct=Yes
 10	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	11	nsubj	11:nsubj	_
-11	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obl
+11	send	send	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 12	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	SpaceAfter=No
 13	?	?	PUNCT	.	_	4	punct	4:punct	_
 
@@ -13318,7 +13318,7 @@
 11	be	be	AUX	VB	VerbForm=Inf	14	cop	14:cop	_
 12	with	with	ADP	IN	_	14	case	14:case	_
 13	the	the	DET	DT	Definite=Def|PronType=Art	14	det	14:det	_
-14	estate	estate	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj|SpaceAfter=No
+14	estate	estate	NOUN	NN	Number=Sing	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = email-enronsent21_02-0064
@@ -13361,10 +13361,10 @@
 4	be	be	AUX	VB	VerbForm=Inf	5	cop	5:cop	_
 5	around	around	ADV	RB	_	0	root	0:root	_
 6	to	to	PART	TO	_	7	mark	7:mark	_
-7	assist	assist	VERB	VB	VerbForm=Inf	5	advcl	5:advcl:to	_
+7	assist	assist	VERB	VB	VerbForm=Inf	5	advcl	5:advcl:to	Cxn=Conditional-UnspecifiedEpistemic-Reduced|CxnElt=7:Conditional-UnspecifiedEpistemic-Reduced.Apodosis
 8	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	7	obj	7:obj	_
 9	if	if	SCONJ	IN	_	10	mark	10:mark	_
-10	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	advcl	7:advcl:if	SpaceAfter=No
+10	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-Reduced.Protasis|SpaceAfter=No
 11	.	.	PUNCT	.	_	5	punct	5:punct	_
 
 # sent_id = email-enronsent21_02-0066
@@ -13433,7 +13433,7 @@
 15	if	if	SCONJ	IN	_	18	mark	18:mark	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	could	could	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	shoot	shoot	VERB	VB	VerbForm=Inf	36	advcl	36:advcl:if	_
+18	shoot	shoot	VERB	VB	VerbForm=Inf	36	advcl	36:advcl:if	CxnElt=36:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 19	this	this	PRON	DT	Number=Sing|PronType=Dem	18	obj	18:obj	_
 20	off	off	ADP	RP	_	18	compound:prt	18:compound:prt	_
 21	over	overnight	ADV	AFX	Typo=Yes	18	advmod	18:advmod	_
@@ -13451,7 +13451,7 @@
 33	with	with	ADP	IN	_	32	obl	32:obl	Promoted=Yes
 34	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	36	nsubj	36:nsubj	_
 35	would	would	AUX	MD	VerbForm=Fin	36	aux	36:aux	_
-36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	parataxis	8:parataxis	_
+36	appreciate	appreciate	VERB	VB	VerbForm=Inf	8	parataxis	8:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=36:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 37	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	36	obj	36:obj	SpaceAfter=No
 38	.	.	PUNCT	.	_	8	punct	8:punct	_
 
@@ -13465,7 +13465,7 @@
 6-7	doesn't	_	_	_	_	_	_	_	_
 6	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	n't	not	PART	RB	Polarity=Neg	8	advmod	8:advmod	_
-8	seem	seem	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
+8	seem	seem	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=8:Interrogative-Polar-Indirect.Clause
 9	possible	possible	ADJ	JJ	Degree=Pos	8	xcomp	8:xcomp	SpaceAfter=No
 10	.	.	PUNCT	.	_	1	punct	1:punct	_
 
@@ -13509,10 +13509,10 @@
 # sent_id = newsgroup-groups.google.com_HarryPotterAppreciationSociety_a3adbf6ac3dc191c_ENG_20050921_061800-0003
 # text = what's your opinion?
 1-2	what's	_	_	_	_	_	_	_	_
-1	what	what	PRON	WP	PronType=Int	4	nsubj	4:nsubj	_
+1	what	what	PRON	WP	PronType=Int	4	nsubj	4:nsubj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 3	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	4	nmod:poss	4:nmod:poss	_
-4	opinion	opinion	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+4	opinion	opinion	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	SpaceAfter=No
 
 # sent_id = newsgroup-groups.google.com_HarryPotterAppreciationSociety_a3adbf6ac3dc191c_ENG_20050921_061800-0004
@@ -13703,9 +13703,9 @@
 6	-	-	PUNCT	HYPH	_	5	punct	5:punct	SpaceAfter=No
 7	tracks	track	NOUN	NNS	Number=Plur	3	conj	1:obj|3:conj:and	SpaceAfter=No
 8	,	,	PUNCT	,	_	9	punct	9:punct	_
-9	reel	reel	NOUN	NN	Number=Sing	3	conj	1:obj|3:conj:and	_
-10	to	to	ADP	IN	_	11	case	11:case	_
-11	reels	reel	NOUN	NNS	Number=Plur	9	nmod	9:nmod:to	SpaceAfter=No
+9	reel	reel	NOUN	NN	Number=Sing	3	conj	1:obj|3:conj:and	Cxn=NPN|CxnElt=9:NPN.N1
+10	to	to	ADP	IN	_	11	case	11:case	CxnElt=9:NPN.P
+11	reels	reel	NOUN	NNS	Number=Plur	9	nmod	9:nmod:to	CxnElt=9:NPN.N2|SpaceAfter=No
 12	,	,	PUNCT	,	_	13	punct	13:punct	_
 13	cassettes	cassette	NOUN	NNS	Number=Plur	3	conj	1:obj|3:conj:and	SpaceAfter=No
 14	,	,	PUNCT	,	_	16	punct	16:punct	_
@@ -13818,7 +13818,7 @@
 34	coupled	coupled	ADJ	JJ	Degree=Pos	35	amod	35:amod	_
 35	friends	friend	NOUN	NNS	Number=Plur	32	nmod	32:nmod:with|37:nsubj|40:nsubj:xsubj	_
 36	who	who	PRON	WP	PronType=Rel	37	nsubj	35:ref	_
-37	happen	happen	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	Cxn=rc-wh-nsubj
+37	happen	happen	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	35	acl:relcl	35:acl:relcl	_
 38	to	to	PART	TO	_	40	mark	40:mark	_
 39	be	be	AUX	VB	VerbForm=Inf	40	cop	40:cop	_
 40	gay	gay	ADJ	JJ	Degree=Pos	37	xcomp	37:xcomp	SpaceAfter=No
@@ -14401,7 +14401,7 @@
 18	'	'	PUNCT	''	_	10	punct	10:punct	SpaceAfter=No
 19	)	)	PUNCT	-RRB-	_	10	punct	10:punct	_
 20	aptly	aptly	ADV	RB	_	21	advmod	21:advmod	_
-21	summarised	summarise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl
+21	summarised	summarise	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	nature	nature	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	of	of	ADP	IN	_	26	case	26:case	_
@@ -14430,7 +14430,7 @@
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 4	for	for	ADP	IN	_	6	case	6:case	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
-6	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	_
+6	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	in	in	ADP	IN	_	9	case	9:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	best	good	ADJ	JJS	Degree=Sup	6	obl	6:obl:in	_
@@ -14444,7 +14444,7 @@
 17	artificial	artificial	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	hindrances	hindrance	NOUN	NNS	Number=Plur	20	nsubj:pass	20:nsubj:pass	_
 19	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux:pass	20:aux:pass	_
-20	put	put	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	advcl	6:advcl:if	_
+20	put	put	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 21	in	in	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	way	way	NOUN	NN	Number=Sing	20	obl	20:obl:in	_
@@ -14528,13 +14528,13 @@
 13	and	and	CCONJ	CC	_	22	cc	22:cc	_
 14	if	if	SCONJ	IN	_	16	mark	16:mark	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+16	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 17	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 18	charity	charity	NOUN	NN	Number=Sing	20	compound	20:compound	_
 19	/	/	PUNCT	,	_	18	punct	18:punct	_
 20	rescue	rescue	NOUN	NN	Number=Sing	16	obj	16:obj	SpaceAfter=No
 21	,	,	PUNCT	,	_	16	punct	16:punct	_
-22	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	_
+22	make	make	VERB	VB	Mood=Imp|VerbForm=Fin	3	conj	3:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 23	sure	sure	ADJ	JJ	Degree=Pos	22	xcomp	22:xcomp	_
 24	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	26	nsubj:pass	26:nsubj:pass	_
 25	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux:pass	26:aux:pass	_
@@ -14571,9 +14571,9 @@
 1	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 2	...	...	PUNCT	,	_	4	punct	4:punct	SpaceAfter=No
 3	there	there	PRON	EX	_	4	expl	4:expl	_
-4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	no	no	DET	DT	PronType=Neg	6	det	6:det	_
-6	companion	companion	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	_
+6	companion	companion	NOUN	NN	Number=Sing	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 7	quite	quite	ADV	RB	_	9	advmod	9:advmod	_
 8	so	so	ADV	RB	_	9	advmod	9:advmod	_
 9	devoted	devoted	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
@@ -14641,7 +14641,7 @@
 14	cortex	cortex	NOUN	NN	Number=Sing	9	nmod	9:nmod:in	SpaceAfter=No
 15	,	,	PUNCT	,	_	17	punct	17:punct	_
 16	which	which	PRON	WDT	PronType=Rel	17	nsubj	9:ref	_
-17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj
+17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	_
 18	important	important	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
 19	implications	implication	NOUN	NNS	Number=Plur	17	obj	17:obj	_
 20	for	for	ADP	IN	_	22	case	22:case	_
@@ -14963,10 +14963,10 @@
 13	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	12	obj	12:obj|15:nsubj:xsubj	_
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	reveal	reveal	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
-16	what	what	PRON	WP	PronType=Int	19	obl	19:obl:for	_
+16	what	what	PRON	WP	PronType=Int	19	obl	19:obl:for	CxnElt=19:Interrogative-WHInfo-Indirect.WHWord
 17	users	user	NOUN	NNS	Number=Plur	19	nsubj	19:nsubj	_
 18	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
-19	searching	search	VERB	VBG	Tense=Pres|VerbForm=Part	15	ccomp	15:ccomp	_
+19	searching	search	VERB	VBG	Tense=Pres|VerbForm=Part	15	ccomp	15:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=19:Interrogative-WHInfo-Indirect.Clause
 20	for	for	ADP	IN	_	16	case	16:case	SpaceAfter=No
 21	.	.	PUNCT	.	_	5	punct	5:punct	_
 
@@ -14993,7 +14993,7 @@
 5	sport	sport	NOUN	NN	Number=Sing	3	conj	3:conj:and|6:compound	_
 6	headlines	headline	NOUN	NNS	Number=Plur	1	obj	1:obj|8:obj	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+8	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	-	-	PUNCT	,	_	12	punct	12:punct	_
 10	when	when	ADV	WRB	PronType=Int	12	advmod	12:advmod	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
@@ -15077,7 +15077,7 @@
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj|7:nsubj:xsubj|14:nsubj|16:nsubj:xsubj	_
 3	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	not	not	PART	RB	Polarity=Neg	5	advmod	5:advmod	_
-5	wish	wish	VERB	VB	VerbForm=Inf	28	advcl	28:advcl:if	_
+5	wish	wish	VERB	VB	VerbForm=Inf	28	advcl	28:advcl:if	CxnElt=28:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	receive	receive	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	such	such	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
@@ -15101,7 +15101,7 @@
 25	service	service	NOUN	NN	Number=Sing	17	obl	17:obl:about	SpaceAfter=No
 26	,	,	PUNCT	,	_	5	punct	5:punct	_
 27	please	please	INTJ	UH	_	28	discourse	28:discourse	_
-28	read	read	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+28	read	read	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=28:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 29	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	32	nmod:poss	32:nmod:poss	_
 30	frequently	frequently	ADV	RB	_	31	advmod	31:advmod	_
 31	asked	ask	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	32	amod	32:amod	_
@@ -15270,7 +15270,7 @@
 9	will	will	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
 10	not	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
 11	only	only	ADV	RB	_	12	advmod	12:advmod	_
-12	help	help	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+12	help	help	VERB	VB	VerbForm=Inf	7	acl:relcl	7:acl:relcl	_
 13	strengthen	strengthen	VERB	VB	VerbForm=Inf	12	xcomp	12:xcomp	_
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 15	Chinese	Chinese	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -15659,7 +15659,7 @@
 # text = If you own a Retail Store or are a Professional Vendor who exhibits at Sport, Hunting, or Craft Shows and are interested in selling our products,please give us a call!
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|11:nsubj|24:nsubj	_
-3	own	own	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	31	advcl	31:advcl:if	_
+3	own	own	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	31	advcl	31:advcl:if	CxnElt=31:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	Retail	retail	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	Store	store	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -15669,7 +15669,7 @@
 10	Professional	professional	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	Vendor	vendor	NOUN	NN	Number=Sing	3	conj	3:conj:or|13:nsubj|31:advcl:if	_
 12	who	who	PRON	WP	PronType=Rel	13	nsubj	11:ref	_
-13	exhibits	exhibit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-nsubj
+13	exhibits	exhibit	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	at	at	ADP	IN	_	21	case	21:case	_
 15	Sport	sport	NOUN	NN	Number=Sing	21	compound	21:compound	SpaceAfter=No
 16	,	,	PUNCT	,	_	17	punct	17:punct	_
@@ -15687,7 +15687,7 @@
 28	products	product	NOUN	NNS	Number=Plur	26	obj	26:obj	SpaceAfter=No
 29	,	,	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
 30	please	please	INTJ	UH	_	31	discourse	31:discourse	_
-31	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+31	give	give	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=31:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 32	us	we	PRON	PRP	Case=Acc|Number=Plur|Person=1|PronType=Prs	31	iobj	31:iobj	_
 33	a	a	DET	DT	Definite=Ind|PronType=Art	34	det	34:det	_
 34	call	call	NOUN	NN	Number=Sing	31	obj	31:obj	SpaceAfter=No
@@ -16270,7 +16270,7 @@
 17	,	,	PUNCT	,	_	20	punct	20:punct	_
 18	who	who	PRON	WP	PronType=Rel	20	nsubj	16:ref	_
 19	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	20:aux	_
-20	known	know	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	Cxn=rc-wh-nsubj
+20	known	know	VERB	VBN	Tense=Past|VerbForm=Part	16	acl:relcl	16:acl:relcl	_
 21	no	no	DET	DT	PronType=Neg	23	det	23:det	_
 22	major	major	ADJ	JJ	Degree=Pos	23	amod	23:amod	_
 23	defeat	defeat	NOUN	NN	Number=Sing	20	obj	20:obj	_
@@ -16337,12 +16337,12 @@
 8	people	people	NOUN	NNS	Number=Plur	6	nmod	6:nmod:for|11:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	11	nsubj	8:ref	_
 10	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
-11	taking	take	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj
+11	taking	take	VERB	VBG	Tense=Pres|VerbForm=Part	8	acl:relcl	8:acl:relcl	_
 12	action	action	NOUN	NN	Number=Sing	11	obj	11:obj	_
 13	on	on	ADP	IN	_	14	case	14:case	_
 14	issues	issue	NOUN	NNS	Number=Plur	11	obl	11:obl:on|16:nsubj	_
 15	that	that	PRON	WDT	PronType=Rel	16	nsubj	14:ref	_
-16	concern	concern	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-that-nsubj
+16	concern	concern	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	16	obj	16:obj	SpaceAfter=No
 18	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -16428,7 +16428,7 @@
 19	where	where	ADV	WRB	PronType=Rel	22	advmod	18:ref	_
 20	people	people	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	_
 21	can	can	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	exchange	exchange	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-wh-obl
+22	exchange	exchange	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	_
 23	ideas	idea	NOUN	NNS	Number=Plur	22	obj	22:obj	_
 24	and	and	CCONJ	CC	_	25	cc	25:cc	_
 25	advice	advice	NOUN	NN	Number=Sing	23	conj	22:obj|23:conj:and	SpaceAfter=No
@@ -16439,18 +16439,18 @@
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
 2	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	_
+4	great	great	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	if	if	SCONJ	IN	_	15	mark	15:mark	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	person	person	NOUN	NN	Number=Sing	15	nsubj	11:nsubj|15:nsubj	_
 8	from	from	ADP	IN	_	9	case	9:case	_
 9	CHANT	CHANT	PROPN	NNP	Number=Sing	7	nmod	7:nmod:from	_
 10	who	who	PRON	WP	PronType=Rel	11	nsubj	7:ref	_
-11	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+11	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 12	this	this	DET	DT	Number=Sing|PronType=Dem	13	det	13:det	_
 13	page	page	NOUN	NN	Number=Sing	11	obj	11:obj	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	put	put	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	_
+15	put	put	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 16	up	up	ADV	RB	_	15	advmod	15:advmod	_
 17	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 18	short	short	ADJ	JJ	Degree=Pos	19	amod	19:amod	_
@@ -16490,13 +16490,13 @@
 14	or	or	CCONJ	CC	_	15	cc	15:cc	_
 15	try	try	VERB	VB	VerbForm=Inf	9	conj	7:acl:to|9:conj:or	_
 16	to	to	PART	TO	_	17	mark	17:mark	_
-17	rally	rally	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	_
+17	rally	rally	VERB	VB	VerbForm=Inf	15	xcomp	15:xcomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 18	together	together	ADV	RB	_	17	advmod	17:advmod	_
 19	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 20	group	group	NOUN	NN	Number=Sing	17	obj	17:obj	_
 21	if	if	SCONJ	IN	_	23	mark	23:mark	_
 22	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	23	nsubj	23:nsubj|25:nsubj:xsubj	_
-23	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	_
+23	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	17	advcl	17:advcl:if	CxnElt=17:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 24	to	to	PART	TO	_	25	mark	25:mark	_
 25	take	take	VERB	VB	VerbForm=Inf	23	xcomp	23:xcomp	_
 26	action	action	NOUN	NN	Number=Sing	25	obj	25:obj	_
@@ -16512,7 +16512,7 @@
 3	attach	attach	VERB	VB	VerbForm=Inf	0	root	0:root	_
 4	anything	anything	PRON	NN	Number=Sing|PronType=Ind	3	obj	3:obj|6:obj	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
+6	write	write	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	to	to	ADP	IN	_	8	case	8:case	_
 8	pages	page	NOUN	NNS	Number=Plur	3	obl	3:obl:to	_
 9	for	for	ADP	IN	_	12	case	12:case	_
@@ -16602,13 +16602,13 @@
 3	class	class	NOUN	NN	Number=Sing	6	obl	6:obl:in	SpaceAfter=No
 4	,	,	PUNCT	,	_	3	punct	3:punct	_
 5	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
-6	asks	ask	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+6	asks	ask	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	students	student	NOUN	NNS	Number=Plur	6	iobj	6:iobj	_
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	12	nsubj	12:nsubj	_
 11	can	can	AUX	MD	VerbForm=Fin	12	aux	12:aux	_
-12	give	give	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:if	_
+12	give	give	VERB	VB	VerbForm=Inf	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	him	he	PRON	PRP	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	12	iobj	12:iobj	_
 14	an	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 15	example	example	NOUN	NN	Number=Sing	12	obj	12:obj	_
@@ -16636,11 +16636,11 @@
 13	best	good	ADJ	JJS	Degree=Sup	14	amod	14:amod	_
 14	friend	friend	NOUN	NN	Number=Sing	20	nsubj	16:nsubj|20:nsubj	_
 15	who	who	PRON	WP	PronType=Rel	16	nsubj	14:ref	_
-16	lives	live	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-wh-nsubj
+16	lives	live	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	next	next	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	door	door	NOUN	NN	Number=Sing	16	obj	16:obj	_
 19	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	aux	20:aux	_
-20	playing	play	VERB	VBG	Tense=Pres|VerbForm=Part	37	advcl	37:advcl:if	_
+20	playing	play	VERB	VBG	Tense=Pres|VerbForm=Part	37	advcl	37:advcl:if	CxnElt=37:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 21	in	in	ADP	IN	_	23	case	23:case	_
 22	the	the	DET	DT	Definite=Def|PronType=Art	23	det	23:det	_
 23	street	street	NOUN	NN	Number=Sing	20	obl	20:obl:in	_
@@ -16657,7 +16657,7 @@
 34	would	would	AUX	MD	VerbForm=Fin	37	aux	37:aux	_
 35	be	be	AUX	VB	VerbForm=Inf	37	cop	37:cop	_
 36	a	a	DET	DT	Definite=Ind|PronType=Art	37	det	37:det	_
-37	tragedy	tragedy	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	SpaceAfter=No
+37	tragedy	tragedy	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=37:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 38	"	"	PUNCT	''	_	37	punct	37:punct	SpaceAfter=No
 39	.	.	PUNCT	.	_	4	punct	4:punct	_
 
@@ -16698,7 +16698,7 @@
 6	carrying	carry	VERB	VBG	VerbForm=Ger	5	acl	5:acl	_
 7	fifty	fifty	NUM	CD	NumForm=Word|NumType=Card	8	nummod	8:nummod	_
 8	children	child	NOUN	NNS	Number=Plur	6	obj	6:obj	_
-9	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	advcl	22:advcl:if	_
+9	drove	drive	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 10	off	off	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	cliff	cliff	NOUN	NN	Number=Sing	9	obl	9:obl:off	SpaceAfter=No
@@ -16711,7 +16711,7 @@
 19	would	would	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
 20	be	be	AUX	VB	VerbForm=Inf	22	cop	22:cop	_
 21	a	a	DET	DT	Definite=Ind|PronType=Art	22	det	22:det	_
-22	tragedy	tragedy	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
+22	tragedy	tragedy	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 23	"	"	PUNCT	''	_	22	punct	22:punct	SpaceAfter=No
 24	.	.	PUNCT	.	_	22	punct	22:punct	_
 
@@ -16734,7 +16734,7 @@
 14	what	what	PRON	WP	PronType=Rel	4	parataxis	4:parataxis|17:obj|20:nsubj:xsubj	_
 15	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	17	nsubj	17:nsubj	_
 16	would	would	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	call	call	VERB	VB	VerbForm=Inf	14	acl:relcl	14:acl:relcl	Cxn=rc-free-obj
+17	call	call	VERB	VB	VerbForm=Inf	14	acl:relcl	14:acl:relcl	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 19	GREAT	great	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 20	LOSS	loss	NOUN	NN	Number=Sing	17	xcomp	17:xcomp	SpaceAfter=No
@@ -16759,23 +16759,23 @@
 # sent_id = newsgroup-groups.google.com_jokecity_0566f0ba3b5f748f_ENG_20051125_240500-0009
 # text = "What?" asks Winston, "isn't there any one here who can give me an example of a tragedy?"
 1	"	"	PUNCT	``	_	2	punct	2:punct	SpaceAfter=No
-2	What	what	PRON	WP	PronType=Int	5	ccomp	5:ccomp	SpaceAfter=No
+2	What	what	PRON	WP	PronType=Int	5	ccomp	5:ccomp	CxnElt=5:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 3	?	?	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 4	"	"	PUNCT	''	_	2	punct	2:punct	_
-5	asks	ask	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	asks	ask	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	Winston	Winston	PROPN	NNP	Number=Sing	5	nsubj	5:nsubj	SpaceAfter=No
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
 8	"	"	PUNCT	``	_	9	punct	9:punct	SpaceAfter=No
 9-10	isn't	_	_	_	_	_	_	_	_
-9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	_
+9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	parataxis	5:parataxis	Cxn=Existential-CopPred-ThereExpl
 10	n't	not	PART	RB	Polarity=Neg	9	advmod	9:advmod	_
 11	there	there	PRON	EX	_	9	expl	9:expl	_
-12	any	anyone	PRON	GW	Number=Sing|PronType=Ind|Typo=Yes	9	nsubj	9:nsubj|17:nsubj	_
+12	any	anyone	PRON	GW	Number=Sing|PronType=Ind|Typo=Yes	9	nsubj	9:nsubj|17:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 13	one	_	X	NN	_	12	goeswith	12:goeswith	_
 14	here	here	ADV	RB	PronType=Dem	12	advmod	12:advmod	_
 15	who	who	PRON	WP	PronType=Rel	17	nsubj	12:ref	_
 16	can	can	AUX	MD	VerbForm=Fin	17	aux	17:aux	_
-17	give	give	VERB	VB	VerbForm=Inf	12	acl:relcl	12:acl:relcl	Cxn=rc-wh-nsubj
+17	give	give	VERB	VB	VerbForm=Inf	12	acl:relcl	12:acl:relcl	_
 18	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	17	iobj	17:iobj	_
 19	an	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 20	example	example	NOUN	NN	Number=Sing	17	obj	17:obj	_
@@ -16817,7 +16817,7 @@
 14	Winston	Winston	PROPN	NNP	Number=Sing	13	obj	13:obj	_
 15	Peters	Peters	PROPN	NNP	Number=Sing	14	flat	14:flat	_
 16	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	aux:pass	17:aux:pass	_
-17	blown	blow	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	27	advcl	27:advcl:if	_
+17	blown	blow	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	27	advcl	27:advcl:if	CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 18	up	up	ADP	RP	_	17	compound:prt	17:compound:prt	_
 19	by	by	ADP	IN	_	21	case	21:case	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
@@ -16827,7 +16827,7 @@
 24	would	would	AUX	MD	VerbForm=Fin	27	aux	27:aux	_
 25	be	be	AUX	VB	VerbForm=Inf	27	cop	27:cop	_
 26	a	a	DET	DT	Definite=Ind|PronType=Art	27	det	27:det	_
-27	tragedy	tragedy	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	SpaceAfter=No
+27	tragedy	tragedy	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=27:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 28	"	"	PUNCT	''	_	27	punct	27:punct	SpaceAfter=No
 29	.	.	PUNCT	.	_	7	punct	7:punct	_
 
@@ -16852,14 +16852,14 @@
 1	And	and	CCONJ	CC	_	4	cc	4:cc	_
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	4	iobj	4:iobj	_
-6	WHY	why	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
+6	WHY	why	ADV	WRB	PronType=Int	11	advmod	11:advmod	CxnElt=11:Interrogative-WHInfo-Indirect.WHWord
 7	that	that	PRON	DT	Number=Sing|PronType=Dem	11	nsubj	11:nsubj	_
 8	would	would	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 9	be	be	AUX	VB	VerbForm=Inf	11	cop	11:cop	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-11	tragedy	tragedy	NOUN	NN	Number=Sing	4	ccomp	4:ccomp	SpaceAfter=No
+11	tragedy	tragedy	NOUN	NN	Number=Sing	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=11:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 12	?	?	PUNCT	.	_	4	punct	4:punct	SpaceAfter=No
 13	"	"	PUNCT	''	_	4	punct	4:punct	SpaceAfter=No
 
@@ -16962,7 +16962,7 @@
 10	architecture	architecture	NOUN	NN	Number=Sing	7	obj	7:obj|13:nsubj	_
 11	that	that	PRON	WDT	PronType=Rel	13	nsubj	10:ref	_
 12	will	will	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	establish	establish	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj
+13	establish	establish	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	15	det	15:det	_
 15	equivalent	equivalent	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	of	of	ADP	IN	_	21	case	21:case	_
@@ -17297,7 +17297,7 @@
 24	this	this	DET	DT	Number=Sing|PronType=Dem	25	det	25:det	_
 25	country	country	NOUN	NN	Number=Sing	27	nsubj	27:nsubj	_
 26	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	aux	27:aux	_
-27	developed	develop	VERB	VBN	Tense=Past|VerbForm=Part	23	acl:relcl	23:acl:relcl	Cxn=rc-red-obj
+27	developed	develop	VERB	VBN	Tense=Past|VerbForm=Part	23	acl:relcl	23:acl:relcl	_
 28	in	in	ADP	IN	_	32	case	32:case	_
 29	more	more	ADJ	JJR	Degree=Cmp|ExtPos=ADV	32	advmod	32:advmod	_
 30	than	than	ADP	IN	_	29	fixed	29:fixed	_
@@ -17357,12 +17357,12 @@
 # sent_id = newsgroup-groups.google.com_hiddennook_e21e429b3ad58235_ENG_20050830_214700-0005
 # text = It looks as if NASA is transitioning away from the shuttle model, as in the past they have proven to be quite dangerous as Columbia has recently proved.
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	2:nsubj	_
-2	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	looks	look	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 3	as	as	SCONJ	IN	_	7	mark	7:mark	_
 4	if	if	SCONJ	IN	_	7	mark	7:mark	_
 5	NASA	NASA	PROPN	NNP	Number=Sing	7	nsubj	7:nsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	transitioning	transition	VERB	VBG	Tense=Pres|VerbForm=Part	2	advcl	2:advcl:if	_
+7	transitioning	transition	VERB	VBG	Tense=Pres|VerbForm=Part	2	advcl	2:advcl:if	CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 8	away	away	ADV	RB	_	7	advmod	7:advmod	_
 9	from	from	ADP	IN	_	12	case	12:case	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
@@ -17688,14 +17688,14 @@
 1	We	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 2	could	could	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	certainly	certainly	ADV	RB	_	4	advmod	4:advmod	_
-4	slow	slow	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	slow	slow	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	aging	aging	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	process	process	NOUN	NN	Number=Sing	4	obj	4:obj	_
 8	down	down	ADP	RP	_	4	compound:prt	4:compound:prt	_
 9	if	if	SCONJ	IN	_	11	mark	11:mark	_
 10	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj|13:nsubj:xsubj	_
-11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:if	_
+11	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	advcl	4:advcl:if	CxnElt=4:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 12	to	to	PART	TO	_	13	mark	13:mark	_
 13	work	work	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
 14	its	its	PRON	PRP$	Case=Gen|Gender=Neut|Number=Sing|Person=3|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
@@ -17817,7 +17817,7 @@
 # text = If you get a good wife, you'll become happy; if you get a bad one, you'll become a philosopher.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	_
+3	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	10	advcl	10:advcl:if	CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	wife	wife	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
@@ -17825,12 +17825,12 @@
 8-9	you'll	_	_	_	_	_	_	_	_
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|11:nsubj:xsubj	_
 9	'll	will	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	become	become	VERB	VB	VerbForm=Inf	0	root	0:root	_
+10	become	become	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 11	happy	happy	ADJ	JJ	Degree=Pos	10	xcomp	10:xcomp	SpaceAfter=No
 12	;	;	PUNCT	,	_	22	punct	22:punct	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	15	nsubj	15:nsubj	_
-15	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	_
+15	get	get	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	22	advcl	22:advcl:if	CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 16	a	a	DET	DT	Definite=Ind|PronType=Art	18	det	18:det	_
 17	bad	bad	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
 18	one	one	NOUN	NN	Number=Sing	15	obj	15:obj	SpaceAfter=No
@@ -17838,7 +17838,7 @@
 20-21	you'll	_	_	_	_	_	_	_	_
 20	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	22	nsubj	22:nsubj|24:nsubj:xsubj	_
 21	'll	will	AUX	MD	VerbForm=Fin	22	aux	22:aux	_
-22	become	become	VERB	VB	VerbForm=Inf	11	parataxis	11:parataxis	_
+22	become	become	VERB	VB	VerbForm=Inf	11	parataxis	11:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=22:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 23	a	a	DET	DT	Definite=Ind|PronType=Art	24	det	24:det	_
 24	philosopher	philosopher	NOUN	NN	Number=Sing	22	xcomp	22:xcomp	SpaceAfter=No
 25	.	.	PUNCT	.	_	11	punct	11:punct	_
@@ -18067,10 +18067,10 @@
 3	be	be	AUX	VB	VerbForm=Inf	6	cop	6:cop	_
 4	an	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	ideal	ideal	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
-6	state	state	NOUN	NN	Number=Sing	0	root	0:root	_
+6	state	state	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	if	if	SCONJ	IN	_	9	mark	9:mark	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
-9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:if	_
+9	came	come	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	little	little	ADJ	JJ	Degree=Pos	12	obl:unmarked	12:obl:unmarked	_
 12	later	late	ADV	RBR	Degree=Cmp	9	advmod	9:advmod	_
@@ -18223,7 +18223,7 @@
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	man	man	NOUN	NN	Number=Sing	7	nsubj	7:nsubj	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
-7	wise	wise	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obl
+7	wise	wise	ADJ	JJ	Degree=Pos	3	acl:relcl	3:acl:relcl	_
 8	enough	enough	ADV	RB	_	7	advmod	7:advmod	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	watch	watch	VERB	VB	VerbForm=Inf	7	advcl	7:advcl:to	_
@@ -18256,7 +18256,7 @@
 # text = Do You Yahoo!?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	You	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	Yahoo!	yahoo!	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+3	Yahoo!	yahoo!	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 4	?	?	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = newsgroup-groups.google.com_JokeEruption_df151b356f94881c_ENG_20050819_155700-0060
@@ -18292,10 +18292,10 @@
 # sent_id = answers-20090605110621AA3jC62_ans-0001
 # newpar id = answers-20090605110621AA3jC62_ans-p0001
 # text = What language is talked in Iguazu?
-1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
+1	What	what	DET	WDT	PronType=Int	2	det	2:det	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	language	language	NOUN	NN	Number=Sing	4	nsubj:pass	4:nsubj:pass	_
 3	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux:pass	4:aux:pass	_
-4	talked	talk	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	_
+4	talked	talk	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	in	in	ADP	IN	_	6	case	6:case	_
 6	Iguazu	Iguazu	PROPN	NNP	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 7	?	?	PUNCT	.	_	4	punct	4:punct	_
@@ -18342,7 +18342,7 @@
 # sent_id = answers-20080426140040AA4YiX5_ans-0001
 # newpar id = answers-20080426140040AA4YiX5_ans-p0001
 # text = What is this Miramar?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	this	this	DET	DT	Number=Sing|PronType=Dem	4	det	4:det	_
 4	Miramar	Miramar	PROPN	NNP	Number=Sing	1	nsubj	1:nsubj	SpaceAfter=No
@@ -18365,7 +18365,7 @@
 # text = Does anyone know any good restaurants in cordoba?
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	any	any	DET	DT	PronType=Ind	6	det	6:det	_
 5	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	restaurants	restaurant	NOUN	NNS	Number=Plur	3	obj	3:obj	_
@@ -18387,7 +18387,7 @@
 # text = Does anyone know of any good food in iguazu?
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	of	of	ADP	IN	_	7	case	7:case	_
 5	any	any	DET	DT	PronType=Ind	7	det	7:det	_
 6	good	good	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
@@ -18408,14 +18408,14 @@
 # sent_id = answers-20111107173321AASNJjc_ans-0001
 # newpar id = answers-20111107173321AASNJjc_ans-p0001
 # text = Which wonderful contact of mine is thumbs upping all my best answers ^^?
-1	Which	which	DET	WDT	PronType=Int	3	det	3:det	ManuallyChecked=PronType
+1	Which	which	DET	WDT	PronType=Int	3	det	3:det	CxnElt=8:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	wonderful	wonderful	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	contact	contact	NOUN	NN	Number=Sing	8	nsubj	8:nsubj	_
 4	of	of	ADP	IN	_	5	case	5:case	_
 5	mine	my	PRON	PRP	Number=Sing|Person=1|Poss=Yes|PronType=Prs	3	nmod	3:nmod:of	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	thumbs	thumb	NOUN	NNS	Number=Plur	8	obl:unmarked	8:obl:unmarked	_
-8	upping	up	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+8	upping	up	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=8:Interrogative-WHInfo-Direct.Clause
 9	all	all	DET	PDT	PronType=Tot	12	det:predet	12:det:predet	_
 10	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 11	best	good	ADJ	JJS	Degree=Sup	12	amod	12:amod	_
@@ -18432,7 +18432,7 @@
 # sent_id = answers-20111107144434AA0lJDI_ans-0001
 # newpar id = answers-20111107144434AA0lJDI_ans-p0001
 # text = What are some Major land forms in Ireland?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	PronType=Ind	6	det	6:det	_
 4	Major	major	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
@@ -18460,7 +18460,7 @@
 # text = Do you know the online streaming link for Red FM 93.5 delhi ?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 5	online	online	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 6	streaming	streaming	NOUN	NN	Number=Sing	7	compound	7:compound	_
@@ -18489,8 +18489,8 @@
 # sent_id = answers-20111108063043AAOhkv9_ans-0001
 # newpar id = answers-20111108063043AAOhkv9_ans-p0001
 # text = how fare of kolkatta?
-1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
-2	fare	fare	NOUN	NN	Number=Sing	0	root	0:root	_
+1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	fare	fare	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	of	of	ADP	IN	_	4	case	4:case	_
 4	kolkatta	Kolkata	PROPN	NNP	Number=Sing	2	nmod	2:nmod:of	SpaceAfter=No
 5	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -18525,10 +18525,10 @@
 # sent_id = answers-20090801154222AA09uXV_ans-0001
 # newpar id = answers-20090801154222AA09uXV_ans-p0001
 # text = Which do you prefer Crab or Shrimp?
-1	Which	which	PRON	WDT	PronType=Int	4	obj	4:obj	ManuallyChecked=PronType
+1	Which	which	PRON	WDT	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	Crab	crab	NOUN	NN	Number=Sing	1	appos	1:appos	_
 6	or	or	CCONJ	CC	_	7	cc	7:cc	_
 7	Shrimp	shrimp	NOUN	NN	Number=Sing	5	conj	1:appos|5:conj:or	SpaceAfter=No
@@ -18563,11 +18563,11 @@
 # sent_id = answers-20111108044917AALAHtc_ans-0001
 # newpar id = answers-20111108044917AALAHtc_ans-p0001
 # text = how much does it cost to join world resorts international?
-1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	much	much	ADJ	JJ	Degree=Pos	5	obj	5:obj	_
 3	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	5:expl	_
-5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	join	join	VERB	VB	VerbForm=Inf	5	csubj	5:csubj	_
 8	world	World	PROPN	NNP	Number=Sing	10	compound	10:compound	_
@@ -18634,11 +18634,11 @@
 # sent_id = answers-20110828235728AAvFDPs_ans-0001
 # newpar id = answers-20110828235728AAvFDPs_ans-p0001
 # text = How much does it cost to buy a Big Mac meal in your area?
-1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	much	much	ADJ	JJ	Degree=Pos	5	obj	5:obj	_
 3	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	5:expl	_
-5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	buy	buy	VERB	VB	VerbForm=Inf	5	csubj	5:csubj	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
@@ -18693,7 +18693,7 @@
 3	chain	chain	NOUN	NN	Number=Sing	9	nsubj	9:nsubj	_
 4	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+6	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=6:Interrogative-Polar-Direct.Clause
 7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 8	as	as	ADV	RB	_	9	advmod	9:advmod	_
 9	good	good	ADJ	JJ	Degree=Pos	6	ccomp	6:ccomp	_
@@ -18718,9 +18718,9 @@
 # sent_id = answers-20111108051957AALVg5J_ans-0001
 # newpar id = answers-20111108051957AALVg5J_ans-p0001
 # text = Where to buy bodybuilding supplements in Delhi?
-1	Where	where	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	Where	where	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	to	to	PART	TO	_	3	mark	3:mark	_
-3	buy	buy	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	buy	buy	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	bodybuilding	bodybuilding	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	supplements	supplement	NOUN	NNS	Number=Plur	3	obj	3:obj	_
 6	in	in	ADP	IN	_	7	case	7:case	_
@@ -18735,7 +18735,7 @@
 3	shop	shop	NOUN	NN	Number=Sing	0	root	0:root|6:obl	_
 4	that	that	PRON	WDT	PronType=Rel	6	obl	3:ref	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
-6	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-that-obl-pstrand
+6	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 7	of	of	ADP	IN	_	4	case	4:case	_
 8	AND	and	CCONJ	CC	_	10	cc	10:cc	_
 9	their	their	PRON	PRP$	Case=Gen|Number=Plur|Person=3|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -18770,11 +18770,11 @@
 # text = Do you think there are any koreans in Miramar?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	_
+5	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	3:ccomp	Cxn=Existential-CopPred-ThereExpl
 6	any	any	DET	DT	PronType=Ind	7	det	7:det	_
-7	koreans	Korean	PROPN	NNPS	Number=Plur	5	nsubj	5:nsubj	_
+7	koreans	Korean	PROPN	NNPS	Number=Plur	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 8	in	in	ADP	IN	_	9	case	9:case	_
 9	Miramar	Miramar	PROPN	NNP	Number=Sing	5	obl	5:obl:in	SpaceAfter=No
 10	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -18785,11 +18785,11 @@
 1	Heck	heck	INTJ	UH	_	4	discourse	4:discourse	_
 2	there	there	PRON	EX	_	4	expl	4:expl	_
 3	must	must	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 5	at	at	ADP	IN	_	6	case	6:case	_
 6	least	least	ADJ	JJS	Degree=Sup	7	nmod	7:nmod:at	_
 7	1	1	NUM	CD	NumForm=Digit|NumType=Card	8	nummod	8:nummod	_
-8	korean	Korean	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	SpaceAfter=No
+8	korean	Korean	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 9	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20090709103651AAwwZKx_ans-0003
@@ -18819,7 +18819,7 @@
 # text = Can you use the 'find my phone' feature to track someone else's phone?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	use	use	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 5	'	'	PUNCT	``	_	6	punct	6:punct	SpaceAfter=No
 6	find	find	VERB	VB	VerbForm=Inf	10	compound	10:compound	_
@@ -18851,13 +18851,13 @@
 9	,	,	PUNCT	,	_	18	punct	18:punct	_
 10	if	if	SCONJ	IN	_	12	mark	12:mark	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	12	nsubj	12:nsubj	_
-12	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:if	_
+12	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	18	advcl	18:advcl:if	CxnElt=18:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	that	that	PRON	DT	Number=Sing|PronType=Dem	12	obj	12:obj	_
 14	then	then	ADV	RB	PronType=Dem	18	advmod	18:advmod	_
 15	yes	yes	INTJ	UH	Polarity=Pos	18	discourse	18:discourse	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	track	track	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
+18	track	track	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=18:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 19	any	any	DET	DT	PronType=Ind	20	det	20:det	_
 20	iPhone	iPhone	PROPN	NNP	Number=Sing	18	obj	18:obj	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -18871,11 +18871,11 @@
 3	good	good	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	foods	food	NOUN	NNS	Number=Plur	2	obj	2:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	2	punct	2:punct	_
-6	what	what	PRON	WP	PronType=Int	10	obj	10:obj	_
+6	what	what	PRON	WP	PronType=Int	10	obj	10:obj	CxnElt=10:Interrogative-WHInfo-Direct.WHWord
 7	else	else	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 8	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	people	people	NOUN	NNS	Number=Plur	10	nsubj	10:nsubj	_
-10	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	_
+10	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=10:Interrogative-WHInfo-Direct.Clause
 11	in	in	ADP	IN	_	12	case	12:case	_
 12	Miramar	Miramar	PROPN	NNP	Number=Sing	10	obl	10:obl:in	SpaceAfter=No
 13	?	?	PUNCT	.	_	10	punct	10:punct	_
@@ -18893,7 +18893,7 @@
 8	sports	sport	NOUN	NNS	Number=Plur	6	nmod	6:nmod:of	_
 9	that	that	PRON	WDT	PronType=Rel	11	obj	6:ref	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
-11	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-obj
+11	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 12	like	like	ADP	IN	_	13	case	13:case	_
 13	basketball	basketball	NOUN	NN	Number=Sing	6	nmod	6:nmod:like	SpaceAfter=No
 14	,	,	PUNCT	,	_	15	punct	15:punct	_
@@ -18921,7 +18921,7 @@
 1	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	4:cop	_
 2	Hank	Hank	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
 3	Green	Green	PROPN	NNP	Number=Sing	2	flat	2:flat	_
-4	Awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+4	Awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20110101171252AA43jJo_ans-0002
@@ -18931,7 +18931,7 @@
 2	Hank	Hank	PROPN	NNP	Number=Sing	8	nsubj	5:obj|8:nsubj	_
 3	Green	Green	PROPN	NNP	Number=Sing	2	flat	2:flat	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+5	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 6	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 7	hardly	hardly	ADV	RB	_	8	advmod	8:advmod	_
 8	awesome	awesome	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
@@ -18998,8 +18998,8 @@
 3	or	or	CCONJ	CC	_	4	cc	4:cc	_
 4	may	may	AUX	MD	VerbForm=Fin	2	conj	2:conj:or	_
 5	not	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
-6	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
-7	snow	snow	NOUN	NN	Number=Sing	6	nsubj	2:nsubj|6:nsubj	SpaceAfter=No
+6	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+7	snow	snow	NOUN	NN	Number=Sing	6	nsubj	2:nsubj|6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 8	,	,	PUNCT	,	_	13	punct	13:punct	_
 9	depending	depend	VERB	VBG	Tense=Pres|VerbForm=Part	13	case	13:case	_
 10	on	on	ADP	IN	_	13	case	13:case	_
@@ -19019,11 +19019,11 @@
 7	there	there	PRON	EX	_	10	expl	10:expl	_
 8	will	will	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
 9	likely	likely	ADV	RB	_	10	advmod	10:advmod	_
-10	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
+10	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 11	man	man	NOUN	NN	Number=Sing	13	obl:unmarked	13:obl:unmarked	SpaceAfter=No
 12	-	-	PUNCT	HYPH	_	11	punct	11:punct	SpaceAfter=No
 13	made	make	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	amod	14:amod	_
-14	snow	snow	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
+14	snow	snow	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	CxnElt=10:Existential-CopPred-ThereExpl.Pivot
 15	on	on	ADP	IN	_	17	case	17:case	_
 16	the	the	DET	DT	Definite=Def|PronType=Art	17	det	17:det	_
 17	slopes	slope	NOUN	NNS	Number=Plur	10	obl	10:obl:on	SpaceAfter=No
@@ -19117,7 +19117,7 @@
 14	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	cop	17:cop	_
 15	n't	not	PART	RB	Polarity=Neg	17	advmod	17:advmod	_
 16	very	very	ADV	RB	_	17	advmod	17:advmod	_
-17	common	common	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	Cxn=rc-that-nsubj
+17	common	common	ADJ	JJ	Degree=Pos	12	acl:relcl	12:acl:relcl	_
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	have	have	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	conj	12:acl:relcl|17:conj:and	_
 20	a	a	DET	DT	Definite=Ind|PronType=Art	21	det	21:det	_
@@ -19156,10 +19156,10 @@
 # sent_id = answers-20111107201117AANg07J_ans-0001
 # newpar id = answers-20111107201117AANg07J_ans-p0001
 # text = how do you mold silicone or rubber into a mermaid tail?
-1	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	how	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	mold	mold	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	mold	mold	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	silicone	silicone	NOUN	NN	Number=Sing	4	obj	4:obj	_
 6	or	or	CCONJ	CC	_	7	cc	7:cc	_
 7	rubber	rubber	NOUN	NN	Number=Sing	5	conj	4:obj|5:conj:or	_
@@ -19229,7 +19229,7 @@
 # text = Do you prefer ham, bacon or sausages with your breakfast?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	prefer	prefer	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	ham	ham	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
 6	bacon	bacon	NOUN	NN	Number=Sing	4	conj	3:obj|4:conj:or	_
@@ -19296,7 +19296,7 @@
 # text = Can police trace a cell phone even if it is switched off?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	police	police	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	trace	trace	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	trace	trace	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	cell	cell	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	phone	phone	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -19304,7 +19304,7 @@
 8	if	if	SCONJ	IN	_	11	mark	11:mark	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj:pass	11:nsubj:pass	_
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux:pass	11:aux:pass	_
-11	switched	switch	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	advcl	3:advcl:if	_
+11	switched	switch	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 12	off	off	ADP	RP	_	11	compound:prt	11:compound:prt	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -19313,7 +19313,7 @@
 # text = Can police trace a cell phone even if it is switched off?
 1	Can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	police	police	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
-3	trace	trace	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	trace	trace	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 5	cell	cell	NOUN	NN	Number=Sing	6	compound	6:compound	_
 6	phone	phone	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -19321,7 +19321,7 @@
 8	if	if	SCONJ	IN	_	11	mark	11:mark	_
 9	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj:pass	11:nsubj:pass	_
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux:pass	11:aux:pass	_
-11	switched	switch	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	advcl	3:advcl:if	_
+11	switched	switch	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 12	off	off	ADP	RP	_	11	compound:prt	11:compound:prt	SpaceAfter=No
 13	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -19417,20 +19417,20 @@
 7-8	Ive	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	9	aux	9:aux	CorrectForm='ve
-9	read	read	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+9	read	read	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	say	say	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 11	so	so	ADV	RB	_	10	advmod	10:advmod	_
 12	and	and	CCONJ	CC	_	15	cc	15:cc	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 14	will	will	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	travel	travel	VERB	VB	VerbForm=Inf	10	conj	10:conj:and	_
+15	travel	travel	VERB	VB	VerbForm=Inf	10	conj	10:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 16	from	from	ADP	IN	_	17	case	17:case	_
 17	maryland	Maryland	PROPN	NNP	Number=Sing	15	obl	15:obl:from	_
 18	if	if	SCONJ	IN	_	21	mark	21:mark	_
 19-20	thats	_	_	_	_	_	_	_	_
 19	that	that	PRON	DT	Number=Sing|PronType=Dem	21	nsubj	21:nsubj	_
 20	s	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	21	cop	21:cop	CorrectForm='s
-21	true	true	ADJ	JJ	Degree=Pos	15	advcl	15:advcl:if	_
+21	true	true	ADJ	JJ	Degree=Pos	15	advcl	15:advcl:if	CxnElt=15:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 
 # sent_id = answers-20111024202518AA18Sg7_ans-0004
 # newpar id = answers-20111024202518AA18Sg7_ans-p0003
@@ -19472,14 +19472,14 @@
 18	dinner	dinner	NOUN	NN	Number=Sing	13	obl	13:obl:for	_
 19	where	where	ADV	WRB	PronType=Rel	21	advmod	11:ref	_
 20	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
+21	play	play	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 22	music	music	NOUN	NN	Number=Sing	21	obj	21:obj	_
 23	and	and	CCONJ	CC	_	25	cc	25:cc	_
 24	there	there	PRON	EX	_	25	expl	25:expl	_
-25	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	conj	11:acl:relcl|21:conj:and	_
+25	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	conj	11:acl:relcl|21:conj:and	Cxn=Existential-CopPred-ThereExpl
 26	a	a	DET	DT	Definite=Ind|PronType=Art	28	det	28:det	_
 27	dance	dance	NOUN	NN	Number=Sing	28	compound	28:compound	_
-28	floor	floor	NOUN	NN	Number=Sing	25	nsubj	25:nsubj	SpaceAfter=No
+28	floor	floor	NOUN	NN	Number=Sing	25	nsubj	25:nsubj	CxnElt=25:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 29	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111105235047AAgQW4l_ans-0003
@@ -19487,14 +19487,14 @@
 1-2	It's	_	_	_	_	_	_	_	_
 1	It	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	3:nsubj	_
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
-3	okay	okay	ADJ	JJ	Degree=Pos	0	root	0:root	_
+3	okay	okay	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	if	if	SCONJ	IN	_	9	mark	9:mark	_
 5-6	it's	_	_	_	_	_	_	_	_
 5	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 6	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	9:cop	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	little	little	ADJ	JJ	Degree=Pos	9	obl:unmarked	9:obl:unmarked	_
-9	pricier	pricy	ADJ	JJR	Degree=Cmp	3	advcl	3:advcl:if	SpaceAfter=No
+9	pricier	pricy	ADJ	JJR	Degree=Cmp	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111105235047AAgQW4l_ans-0004
@@ -19539,16 +19539,16 @@
 10	Two	Two	PROPN	NNP	Number=Sing	9	appos	9:appos	SpaceAfter=No
 11	"	"	PUNCT	''	_	7	punct	7:punct	SpaceAfter=No
 12	,	,	PUNCT	,	_	3	punct	3:punct	_
-13	How	how	ADV	WRB	PronType=Int	14	advmod	14:advmod	_
+13	How	how	ADV	WRB	PronType=Int	14	advmod	14:advmod	CxnElt=19:Interrogative-WHInfo-Direct#2.WHWord
 14	many	many	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
 15	diffrent	different	ADJ	JJ	Degree=Pos|Typo=Yes	16	amod	16:amod	CorrectForm=different
-16	painting	painting	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	SpaceAfter=No
+16	painting	painting	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	CxnElt=19:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 17	/	/	SYM	,	_	18	cc	18:cc	SpaceAfter=No
 18	scupltures	sculpture	NOUN	NNS	Number=Plur|Typo=Yes	16	conj	16:conj|19:nsubj	CorrectForm=sculptures
-19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-WHInfo-Direct,Interrogative-WHInfo-Direct#2|CxnElt=19:Interrogative-WHInfo-Direct.Clause,19:Interrogative-WHInfo-Direct#2.Clause
 20	their	there	PRON	EX	Typo=Yes	19	expl	19:expl	CorrectForm=there
 21	and	and	CCONJ	CC	_	22	cc	22:cc	_
-22	who	who	PRON	WP	PronType=Int	19	conj	19:conj:and	_
+22	who	who	PRON	WP	PronType=Int	19	conj	19:conj:and	CxnElt=19:Interrogative-WHInfo-Direct.WHWord
 23	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
 24	the	the	DET	DT	Definite=Def|PronType=Art	25	det	25:det	_
 25	artists	artist	NOUN	NNS	Number=Plur	22	nsubj	22:nsubj	SpaceAfter=No
@@ -19597,12 +19597,12 @@
 1	Name	name	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	something	something	PRON	NN	Number=Sing|PronType=Ind	1	obj	1:obj|4:obj|9:nsubj	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+4	find	find	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	at	at	ADP	IN	_	7	case	7:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 7	carnival	carnival	NOUN	NN	Number=Sing	4	obl	4:obl:at	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	2:ref	_
-9	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj
+9	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 10	on	on	ADP	IN	_	12	case	12:case	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
 12	stick	stick	NOUN	NN	Number=Sing	9	obl	9:obl:on	SpaceAfter=No
@@ -19665,11 +19665,11 @@
 
 # sent_id = answers-20111107163942AA08rP5_ans-0009
 # text = What country are we talking about?
-1	What	what	DET	WDT	PronType=Int	2	det	2:det	_
+1	What	what	DET	WDT	PronType=Int	2	det	2:det	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	country	country	NOUN	NN	Number=Sing	5	obl	5:obl:about	_
 3	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+5	talking	talk	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	about	about	ADP	IN	_	2	case	2:case	SpaceAfter=No
 7	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -19691,11 +19691,11 @@
 # sent_id = answers-20090717130909AAPrVWu_ans-0001
 # newpar id = answers-20090717130909AAPrVWu_ans-p0001
 # text = How come no one bothers to ask any questions in this section?
-1	How	how	ADV	WRB	ExtPos=ADV|PronType=Int	5	advmod	5:advmod	_
+1	How	how	ADV	WRB	ExtPos=ADV|PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	come	come	VERB	VB	VerbForm=Inf	1	fixed	1:fixed	_
 3	no	no	DET	DT	PronType=Neg	4	det	4:det	_
 4	one	one	PRON	NN	Number=Sing|PronType=Neg	5	nsubj	5:nsubj|7:nsubj:xsubj	_
-5	bothers	bother	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+5	bothers	bother	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	ask	ask	VERB	VB	VerbForm=Inf	5	xcomp	5:xcomp	_
 8	any	any	DET	DT	PronType=Ind	9	det	9:det	_
@@ -19768,7 +19768,7 @@
 11	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	advcl	6:advcl:because	_
 12	no	no	DET	DT	PronType=Neg	13	det	13:det	_
 13	clue	clue	NOUN	NN	Number=Sing	11	obj	11:obj	_
-14	what	what	PRON	WP	PronType=Int	11	ccomp	11:ccomp	_
+14	what	what	PRON	WP	PronType=Int	11	ccomp	11:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=14:Interrogative-WHInfo-Indirect.Clause,14:Interrogative-WHInfo-Indirect.WHWord
 15	"	"	PUNCT	``	_	16	punct	16:punct	SpaceAfter=No
 16	Iguazu	Iguazu	PROPN	NNP	Number=Sing	14	nsubj	14:nsubj	SpaceAfter=No
 17	"	"	PUNCT	''	_	16	punct	16:punct	_
@@ -19779,10 +19779,10 @@
 # sent_id = answers-20111108064636AAvIKDE_ans-0001
 # newpar id = answers-20111108064636AAvIKDE_ans-p0001
 # text = What do you think of Air France?
-1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	of	of	ADP	IN	_	7	case	7:case	_
 6	Air	Air	PROPN	NNP	Number=Sing	7	compound	7:compound	_
 7	France	France	PROPN	NNP	Number=Sing	4	obl	4:obl:of	SpaceAfter=No
@@ -19869,7 +19869,7 @@
 # newpar id = answers-20111108102612AASRNao_ans-p0001
 # text = What's the difference between Indian and African ringnecks and alexandrine parrots? ?
 1-2	What's	_	_	_	_	_	_	_	_
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	difference	difference	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	_
@@ -19928,7 +19928,7 @@
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	breeds	breed	NOUN	NNS	Number=Plur	2	obj	2:obj|7:nsubj|10:nsubj:xsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
+7	look	look	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 9	lot	lot	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	_
 10	alike	alike	ADJ	JJ	Degree=Pos	7	xcomp	7:xcomp	SpaceAfter=No
@@ -19939,8 +19939,8 @@
 1	So	so	ADV	RB	_	4	advmod	4:advmod	_
 2	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj	_
-4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	_
-5	what	what	PRON	WP	PronType=Int	4	ccomp	4:ccomp	_
+4	know	know	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
+5	what	what	PRON	WP	PronType=Int	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=4:Interrogative-WHInfo-Direct.WHWord,5:Interrogative-WHInfo-Indirect.Clause,5:Interrogative-WHInfo-Indirect.WHWord
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	difference	difference	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	SpaceAfter=No
@@ -19956,7 +19956,7 @@
 # text = if i preorder a game at gamestop can someone else pick it up for me?
 1	if	if	SCONJ	IN	_	3	mark	3:mark	_
 2	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
-3	preorder	preorder	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	_
+3	preorder	preorder	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	advcl	11:advcl:if	CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	game	game	NOUN	NN	Number=Sing	3	obj	3:obj	_
 6	at	at	ADP	IN	_	7	case	7:case	_
@@ -19964,7 +19964,7 @@
 8	can	can	AUX	MD	VerbForm=Fin	11	aux	11:aux	_
 9	someone	someone	PRON	NN	Number=Sing|PronType=Ind	11	nsubj	11:nsubj	_
 10	else	else	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
-11	pick	pick	VERB	VB	VerbForm=Inf	0	root	0:root	_
+11	pick	pick	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=11:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,11:Interrogative-Polar-Direct.Clause
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	obj	11:obj	_
 13	up	up	ADP	RP	_	11	compound:prt	11:compound:prt	_
 14	for	for	ADP	IN	_	15	case	15:case	_
@@ -20041,7 +20041,7 @@
 1	Has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj	_
 3	ever	ever	ADV	RB	PronType=Ind	4	advmod	4:advmod	_
-4	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+4	worked	work	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	for	for	ADP	IN	_	8	case	8:case	_
 6	steiner	Steiner	PROPN	NNP	Number=Sing	8	compound	8:compound	_
 7	leisure	Leisure	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -20078,7 +20078,7 @@
 2	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	5	nsubj	5:nsubj	_
-5	knew	know	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	knew	know	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	ccomp	2:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=5:Interrogative-Polar-Indirect.Clause
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	rough	rough	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	estimate	estimate	NOUN	NN	Number=Sing	5	obj	5:obj	_
@@ -20108,7 +20108,7 @@
 10	of	of	ADP	IN	_	11	case	11:case	_
 11	people	people	NOUN	NNS	Number=Plur	9	nmod	9:nmod:of	_
 12	who	who	PRON	WP	PronType=Rel	13	nsubj	9:ref	_
-13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Cxn=rc-wh-nsubj-auxstrand|Promoted=Yes|SpaceAfter=No
+13	have	have	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	acl:relcl	9:acl:relcl	Promoted=Yes|SpaceAfter=No
 14	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111107214231AA68BMD_ans-0005
@@ -20140,15 +20140,15 @@
 # sent_id = answers-20111024111513AAAQhAO_ans-0002
 # newpar id = answers-20111024111513AAAQhAO_ans-p0002
 # text = What is the best pos system I can buy in philadelphia pa?
-1	What	what	PRON	WP	PronType=Int	6	nsubj	6:nsubj	_
+1	What	what	PRON	WP	PronType=Int	6	nsubj	6:nsubj	CxnElt=6:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	best	good	ADJ	JJS	Degree=Sup	6	amod	6:amod	_
 5	pos	pos	NOUN	NN	Number=Sing	6	compound	6:compound	_
-6	system	system	NOUN	NN	Number=Sing	0	root	0:root|9:obj	_
+6	system	system	NOUN	NN	Number=Sing	0	root	0:root|9:obj	Cxn=Interrogative-WHInfo-Direct|CxnElt=6:Interrogative-WHInfo-Direct.Clause
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	can	can	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	buy	buy	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+9	buy	buy	VERB	VB	VerbForm=Inf	6	acl:relcl	6:acl:relcl	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	philadelphia	Philadelphia	PROPN	NNP	Number=Sing	9	obl	9:obl:in	_
 12	pa	PA	PROPN	NNP	Number=Sing	11	appos	11:appos	SpaceAfter=No
@@ -20228,7 +20228,7 @@
 # sent_id = answers-20111108081519AAdHz5c_ans-0001
 # newpar id = answers-20111108081519AAdHz5c_ans-p0001
 # text = What are "good" speakers?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	"	"	PUNCT	``	_	4	punct	4:punct	SpaceAfter=No
 4	good	good	ADJ	JJ	Degree=Pos	6	amod	6:amod	SpaceAfter=No
@@ -20264,12 +20264,12 @@
 21	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	23:nsubj	_
 22	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	aux	23:aux	_
 23	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	4	parataxis	4:parataxis	_
-24	what	what	PRON	WP	PronType=Int	29	nsubj	29:nsubj	_
+24	what	what	PRON	WP	PronType=Int	29	nsubj	29:nsubj	CxnElt=29:Interrogative-WHInfo-Indirect.WHWord
 25	would	would	AUX	MD	VerbForm=Fin	29	aux	29:aux	_
 26	be	be	AUX	VB	VerbForm=Inf	29	cop	29:cop	_
 27	a	a	DET	DT	Definite=Ind|PronType=Art	29	det	29:det	_
 28	good	good	ADJ	JJ	Degree=Pos	29	amod	29:amod	_
-29	set	set	NOUN	NN	Number=Sing	23	ccomp	23:ccomp	_
+29	set	set	NOUN	NN	Number=Sing	23	ccomp	23:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=29:Interrogative-WHInfo-Indirect.Clause
 30	of	of	ADP	IN	_	31	case	31:case	_
 31	speakers	speaker	NOUN	NNS	Number=Plur	29	nmod	29:nmod:of	SpaceAfter=No
 32	.	.	PUNCT	.	_	4	punct	4:punct	_
@@ -20393,17 +20393,17 @@
 
 # sent_id = answers-20111108071652AA8GAZw_ans-0006
 # text = why will hav to pay customs if it is a gift...??
-1	why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	will	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	hav	have	VERB	VB	Abbr=Yes|VerbForm=Inf	0	root	0:root	CorrectForm=have
+3	hav	have	VERB	VB	Abbr=Yes|VerbForm=Inf	0	root	0:root	CorrectForm=have|Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	to	to	PART	TO	_	5	mark	5:mark	_
-5	pay	pay	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
+5	pay	pay	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 6	customs	custom	NOUN	NNS	Number=Plur	5	obj	5:obj	_
 7	if	if	SCONJ	IN	_	11	mark	11:mark	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
-11	gift	gift	NOUN	NN	Number=Sing	5	advcl	5:advcl:if	SpaceAfter=No
+11	gift	gift	NOUN	NN	Number=Sing	5	advcl	5:advcl:if	CxnElt=5:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 12	...	...	PUNCT	,	_	3	punct	3:punct	SpaceAfter=No
 13	??	??	PUNCT	.	_	3	punct	3:punct	_
 
@@ -20414,10 +20414,10 @@
 3	thought	think	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 4-5	theres	_	_	_	_	_	_	_	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	3	ccomp	3:ccomp	CorrectForm='s
+5	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	3	ccomp	3:ccomp	CorrectForm='s|Cxn=Existential-CopPred-ThereExpl
 6	no	no	DET	DT	PronType=Neg	8	det	8:det	_
 7	custom	custom	NOUN	NN	Number=Sing	8	compound	8:compound	_
-8	charges	charge	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	_
+8	charges	charge	NOUN	NNS	Number=Plur	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot
 9	for	for	ADP	IN	_	10	case	10:case	_
 10	gifts	gift	NOUN	NNS	Number=Plur	8	nmod	8:nmod:for	SpaceAfter=No
 11	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -20458,9 +20458,9 @@
 1	Well	well	INTJ	UH	_	3	discourse	3:discourse	_
 2-3	theres	_	_	_	_	_	_	_	_
 2	there	there	PRON	EX	_	3	expl	3:expl	_
-3	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm='s
+3	s	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	0	root	0:root	CorrectForm='s|Cxn=Existential-CopPred-ThereExpl
 4-5	Mc.Donalds	_	_	_	_	_	_	_	SpaceAfter=No
-4	Mc.Donald	McDonald	PROPN	NNP	Number=Sing|Typo=Yes	3	nsubj	3:nsubj	CorrectForm=McDonald
+4	Mc.Donald	McDonald	PROPN	NNP	Number=Sing|Typo=Yes	3	nsubj	3:nsubj	CorrectForm=McDonald|CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 5	s	's	PART	POS	Typo=Yes	4	case	4:case	CorrectForm='s
 6	,	,	PUNCT	,	_	8	punct	8:punct	SpaceAfter=No
 7	Taco	Taco	PROPN	NNP	Number=Sing	8	compound	8:compound	_
@@ -20511,7 +20511,7 @@
 # newpar id = answers-20111107035344AAdi9dS_ans-p0003
 # text = Nearby what?
 1	Nearby	nearby	ADP	IN	_	2	case	2:case	_
-2	what	what	PRON	WP	PronType=Int	0	root	0:root	SpaceAfter=No
+2	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause,2:Interrogative-WHInfo-Direct.WHWord|SpaceAfter=No
 3	?	?	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = answers-20111107035344AAdi9dS_ans-0006
@@ -20561,7 +20561,7 @@
 2	:	:	PUNCT	:	_	1	punct	1:punct	_
 3	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	aux	5:aux	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	decided	decide	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+5	decided	decide	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	who	who	PRON	WP	PronType=Int	11	obl	11:obl:for	_
 7-8	you're	_	_	_	_	_	_	_	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj|11:nsubj:xsubj	_
@@ -20578,7 +20578,7 @@
 1	And	and	CCONJ	CC	_	4	cc	4:cc	_
 2	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	this	this	PRON	DT	Number=Sing|PronType=Dem	4	nsubj	4:nsubj	_
-4	changed	change	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	_
+4	changed	change	VERB	VBN	Tense=Past|VerbForm=Part	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	from	from	ADP	IN	_	7	case	7:case	_
 6	previous	previous	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
 7	years	year	NOUN	NNS	Number=Plur	4	obl	4:obl:from	SpaceAfter=No
@@ -20602,7 +20602,7 @@
 5	Are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	cop	8:cop	_
 6	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 7	even	even	ADV	RB	_	8	advmod	8:advmod	_
-8	old	old	ADJ	JJ	Degree=Pos	0	root	0:root	_
+8	old	old	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=8:Interrogative-Polar-Direct.Clause
 9	enough	enough	ADV	RB	_	8	advmod	8:advmod	_
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	vote	vote	VERB	VB	VerbForm=Inf	8	advcl	8:advcl:to	SpaceAfter=No
@@ -20838,7 +20838,7 @@
 1	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	_
+4	able	able	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	go	go	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	back	back	ADV	RB	_	6	advmod	6:advmod	_
@@ -20897,21 +20897,21 @@
 5	whatever	whatever	DET	WDT	PronType=Int	6	det	6:det	_
 6	age	age	NOUN	NN	Number=Sing	3	obl:unmarked	3:obl:unmarked|8:obl	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
-8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl-auxstrand|Promoted=Yes|SpaceAfter=No
+8	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Promoted=Yes|SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = answers-20111108074555AAFT8Aj_ans
 # sent_id = answers-20111108074555AAFT8Aj_ans-0001
 # newpar id = answers-20111108074555AAFT8Aj_ans-p0001
 # text = What would you call the device that hold up your photography backdrop?
-1	What	what	PRON	WP	PronType=Int	4	xcomp	4:xcomp	_
+1	What	what	PRON	WP	PronType=Int	4	xcomp	4:xcomp	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	would	would	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	call	call	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	call	call	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	device	device	NOUN	NN	Number=Sing	4	obj	4:obj|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	hold	hold	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	6	acl:relcl	6:acl:relcl	CorrectForm=holds|CorrectNumber=Sing|Cxn=rc-that-nsubj
+8	hold	hold	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	6	acl:relcl	6:acl:relcl	CorrectForm=holds|CorrectNumber=Sing
 9	up	up	ADP	RP	_	8	compound:prt	8:compound:prt	_
 10	your	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 11	photography	photography	NOUN	NN	Number=Sing	12	compound	12:compound	_
@@ -20922,10 +20922,10 @@
 # newpar id = answers-20111108074555AAFT8Aj_ans-p0002
 # text = and where can I find them?
 1	and	and	CCONJ	CC	_	5	cc	5:cc	_
-2	where	where	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+2	where	where	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 3	can	can	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	find	find	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	5	obj	5:obj	SpaceAfter=No
 7	?	?	PUNCT	.	_	5	punct	5:punct	_
 
@@ -21033,12 +21033,12 @@
 10	(	(	PUNCT	-LRB-	_	11	punct	11:punct	SpaceAfter=No
 11	cruises	cruise	NOUN	NNS	Number=Plur	3	appos	3:appos	SpaceAfter=No
 12	)	)	PUNCT	-RRB-	_	11	punct	11:punct	_
-13	which	which	PRON	WDT	PronType=Int	16	nsubj	16:nsubj|18:nsubj	ManuallyChecked=PronType
+13	which	which	PRON	WDT	PronType=Int	16	nsubj	16:nsubj|18:nsubj	CxnElt=16:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 14	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 15	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
-16	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	_
+16	best	good	ADJ	JJS	Degree=Sup	0	root	0:root	Cxn=Interrogative-WHInfo-Direct,Interrogative-WHInfo-Direct#2|CxnElt=16:Interrogative-WHInfo-Direct.Clause,16:Interrogative-WHInfo-Direct#2.Clause
 17	and	and	CCONJ	CC	_	18	cc	18:cc	_
-18	why	why	ADV	WRB	PronType=Int	16	conj	16:conj:and	SpaceAfter=No
+18	why	why	ADV	WRB	PronType=Int	16	conj	16:conj:and	CxnElt=16:Interrogative-WHInfo-Direct#2.WHWord|SpaceAfter=No
 19	?	?	PUNCT	.	_	16	punct	16:punct	_
 
 # sent_id = answers-20111107155815AA6LXXJ_ans-0002
@@ -21057,9 +21057,9 @@
 # sent_id = answers-20111107155815AA6LXXJ_ans-0003
 # text = There is so much to do onboard.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	so	so	ADV	RB	_	4	advmod	4:advmod	_
-4	much	much	ADJ	JJ	Degree=Pos	2	nsubj	2:nsubj	_
+4	much	much	ADJ	JJ	Degree=Pos	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	do	do	VERB	VB	VerbForm=Inf	4	acl	4:acl:to	_
 7	onboard	onboard	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
@@ -21142,20 +21142,20 @@
 4	phone	phone	NOUN	NN	Number=Sing	5	compound	5:compound	_
 5	chargers	charger	NOUN	NNS	Number=Plur	7	nsubj	7:nsubj	_
 6	still	still	ADV	RB	_	7	advmod	7:advmod	_
-7	charge	charge	VERB	VB	VerbForm=Inf	0	root	0:root	_
+7	charge	charge	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion,Interrogative-Polar-Direct|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis,7:Interrogative-Polar-Direct.Clause
 8	even	even	ADV	RB	_	12	advmod	12:advmod	_
 9	if	if	SCONJ	IN	_	12	mark	12:mark	_
 10-11	they're	_	_	_	_	_	_	_	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj:pass	12:nsubj:pass	_
 11	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
-12	hooked	hook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	advcl	7:advcl:if	_
+12	hooked	hook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	up	up	ADP	RP	_	12	compound:prt	12:compound:prt	_
 14	to	to	ADP	IN	_	16	case	16:case	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
 16	computer	computer	NOUN	NN	Number=Sing	12	obl	12:obl:to|19:nsubj:pass	_
 17	that	that	PRON	WDT	PronType=Rel	19	nsubj:pass	16:ref	_
 18	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux:pass	19:aux:pass	_
-19	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	Cxn=rc-that-nsubj:pass
+19	turned	turn	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	16	acl:relcl	16:acl:relcl	_
 20	off	off	ADP	RP	_	19	compound:prt	19:compound:prt	SpaceAfter=No
 21	?	?	PUNCT	.	_	7	punct	7:punct	_
 
@@ -21190,7 +21190,7 @@
 3	computer	computer	NOUN	NN	Number=Sing	6	nsubj:pass	6:nsubj:pass	_
 4	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 5	completely	completely	ADV	RB	_	6	advmod	6:advmod	_
-6	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	advcl	14:advcl:if	_
+6	shut	shut	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	off	off	ADP	RP	_	6	compound:prt	6:compound:prt	SpaceAfter=No
 8	,	,	PUNCT	,	_	6	punct	6:punct	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
@@ -21199,7 +21199,7 @@
 12-13	aren't	_	_	_	_	_	_	_	_
 12	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	n't	not	PART	RB	Polarity=Neg	14	advmod	14:advmod	_
-14	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	_
+14	getting	get	VERB	VBG	Tense=Pres|VerbForm=Part	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 15	power	power	NOUN	NN	Number=Sing	14	obj	14:obj	SpaceAfter=No
 16	,	,	PUNCT	,	_	21	punct	21:punct	_
 17	so	so	ADV	RB	_	21	advmod	21:advmod	_
@@ -21222,7 +21222,7 @@
 7	now	now	ADV	RB	PronType=Dem	3	advmod	3:advmod	SpaceAfter=No
 8	,	,	PUNCT	,	_	10	punct	10:punct	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	4:ref	_
-10	allow	allow	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+10	allow	allow	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
 12	PC	pc	NOUN	NN	Number=Sing	10	iobj	10:iobj|14:nsubj:xsubj|21:nsubj:xsubj	_
 13	to	to	PART	TO	_	14	mark	14:mark	_
@@ -21248,7 +21248,7 @@
 # sent_id = answers-20081218053636AA9vV0u_ans-0001
 # newpar id = answers-20081218053636AA9vV0u_ans-p0001
 # text = what is a good slogan for an Argentinian restaurant?
-1	what	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -21280,9 +21280,9 @@
 # text = Come see how we continue this tradition."
 1	Come	come	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
 2	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	parataxis	1:parataxis	_
-3	how	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	_
+3	how	how	ADV	WRB	PronType=Int	5	advmod	5:advmod	CxnElt=5:Interrogative-WHInfo-Indirect.WHWord
 4	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	_
+5	continue	continue	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	2:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=5:Interrogative-WHInfo-Indirect.Clause
 6	this	this	DET	DT	Number=Sing|PronType=Dem	7	det	7:det	_
 7	tradition	tradition	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	1:punct	SpaceAfter=No
@@ -21304,7 +21304,7 @@
 3	some	some	DET	DT	PronType=Ind	4	det	4:det	_
 4	articles	article	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	discuss	discuss	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+6	discuss	discuss	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 8	details	detail	NOUN	NNS	Number=Plur	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -21314,10 +21314,10 @@
 
 # sent_id = answers-20081218053636AA9vV0u_ans-0006
 # text = Why certain slogans work and why some don't.
-1	Why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	certain	certain	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	slogans	slogan	NOUN	NNS	Number=Plur	4	nsubj	4:nsubj	_
-4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6	why	why	ADV	WRB	PronType=Int	8	advmod	8:advmod	_
 7	some	some	DET	DT	PronType=Ind	8	nsubj	8:nsubj	_
@@ -21377,13 +21377,13 @@
 # sent_id = answers-20111108083559AAp6Jfq_ans-0001
 # newpar id = answers-20111108083559AAp6Jfq_ans-p0001
 # text = Which Compact System Camera Should I Get...?
-1	Which	which	DET	WDT	PronType=Int	4	det	4:det	ManuallyChecked=PronType
+1	Which	which	DET	WDT	PronType=Int	4	det	4:det	CxnElt=7:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	Compact	compact	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
 3	System	system	NOUN	NN	Number=Sing	4	compound	4:compound	_
 4	Camera	camera	NOUN	NN	Number=Sing	7	obj	7:obj	_
 5	Should	should	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	Get	get	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+7	Get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=7:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 8	...	...	PUNCT	,	_	7	punct	7:punct	SpaceAfter=No
 9	?	?	PUNCT	.	_	7	punct	7:punct	_
 
@@ -21398,7 +21398,7 @@
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	camera	camera	NOUN	NN	Number=Sing	3	obl	3:obl:for|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
+8	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	really	really	ADV	RB	_	10	advmod	10:advmod	_
 10	good	good	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	zoom	zoom	NOUN	NN	Number=Sing	8	obj	8:obj	_
@@ -21441,19 +21441,19 @@
 21	)	)	PUNCT	-RRB-	_	20	punct	20:punct	_
 22	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	24	nsubj	24:nsubj	_
 23	should	should	AUX	MD	VerbForm=Fin	24	aux	24:aux	_
-24	purchase	purchase	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+24	purchase	purchase	VERB	VB	VerbForm=Inf	18	acl:relcl	18:acl:relcl	SpaceAfter=No
 25	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111108083559AAp6Jfq_ans-0004
 # text = Also how much do compact system cameras drop on boxing day?
 1	Also	also	ADV	RB	_	8	advmod	8:advmod	_
-2	how	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+2	how	how	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=8:Interrogative-WHInfo-Direct.WHWord
 3	much	much	ADJ	JJ	Degree=Pos	8	obl:unmarked	8:obl:unmarked	_
 4	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 5	compact	compact	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	system	system	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	cameras	camera	NOUN	NNS	Number=Plur	8	nsubj	8:nsubj	_
-8	drop	drop	VERB	VB	VerbForm=Inf	0	root	0:root	_
+8	drop	drop	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=8:Interrogative-Polar-Direct.Clause,8:Interrogative-WHInfo-Direct.Clause
 9	on	on	ADP	IN	_	11	case	11:case	_
 10	boxing	boxing	PROPN	NNP	Number=Sing	11	compound	11:compound	_
 11	day	day	PROPN	NNP	Number=Sing	8	obl	8:obl:on	SpaceAfter=No
@@ -21501,7 +21501,7 @@
 # sent_id = answers-20111108082432AAph0C0_ans-0002
 # newpar id = answers-20111108082432AAph0C0_ans-p0002
 # text = What are some cool ideas for making a postor usint the word MAD on a white paper in a weird or artsy way?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	some	some	DET	DT	PronType=Ind	5	det	5:det	_
 4	cool	cool	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -21610,7 +21610,7 @@
 # sent_id = answers-20111107164802AAq8nhF_ans-0001
 # newpar id = answers-20111107164802AAq8nhF_ans-p0001
 # text = what is the fall of hanoi?
-1	what	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	what	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	fall	fall	NOUN	NN	Number=Sing	1	nsubj	1:nsubj	_
@@ -21623,10 +21623,10 @@
 # text = can anyone tell me exactly what it is and what took place?
 1	can	can	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	tell	tell	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	3	iobj	3:iobj	_
 5	exactly	exactly	ADV	RB	_	6	advmod	6:advmod	_
-6	what	what	PRON	WP	PronType=Int	3	ccomp	3:ccomp	_
+6	what	what	PRON	WP	PronType=Int	3	ccomp	3:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=3:Interrogative-WHInfo-Direct.WHWord,6:Interrogative-WHInfo-Indirect.Clause,6:Interrogative-WHInfo-Indirect.WHWord
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	6:nsubj	_
 8	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 9	and	and	CCONJ	CC	_	11	cc	11:cc	_
@@ -21697,10 +21697,10 @@
 # text = Is that what you are referring to?
 1	Is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	3:cop	_
 2	that	that	PRON	DT	Number=Sing|PronType=Dem	3	nsubj	3:nsubj	_
-3	what	what	PRON	WP	PronType=Rel	0	root	0:root|6:obl:to	_
+3	what	what	PRON	WP	PronType=Rel	0	root	0:root|6:obl:to	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause,3:Interrogative-WHInfo-Direct.Clause,3:Interrogative-WHInfo-Direct.WHWord
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 5	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
-6	referring	refer	VERB	VBG	Tense=Pres|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-free-obl-pstrand
+6	referring	refer	VERB	VBG	Tense=Pres|VerbForm=Part	3	acl:relcl	3:acl:relcl	_
 7	to	to	ADP	IN	_	6	obl	3:case	Promoted=Yes|SpaceAfter=No
 8	?	?	PUNCT	.	_	3	punct	3:punct	_
 
@@ -21739,7 +21739,7 @@
 2	a	a	DET	DT	Definite=Ind|PronType=Art	3	det	3:det	_
 3	pacman	pacman	NOUN	NN	Number=Sing	5	nsubj	5:nsubj	_
 4	absolutely	absolutely	ADV	RB	_	5	advmod	5:advmod	_
-5	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	need	need	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=5:Interrogative-Polar-Direct.Clause
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	uv	uv	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	lamp	lamp	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
@@ -21797,10 +21797,10 @@
 5-6	wouldn't	_	_	_	_	_	_	_	_
 5	would	would	AUX	MD	VerbForm=Fin	7	aux	7:aux	_
 6	n't	not	PART	RB	Polarity=Neg	7	advmod	7:advmod	_
-7	hurt	hurt	VERB	VB	VerbForm=Inf	0	root	0:root	_
+7	hurt	hurt	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 8	if	if	SCONJ	IN	_	10	mark	10:mark	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
-10	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:if	_
+10	wanted	want	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	provide	provide	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	one	one	NUM	CD	NumForm=Word|NumType=Card	12	obj	12:obj	SpaceAfter=No
@@ -21817,7 +21817,7 @@
 7	heat	heat	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	source	source	NOUN	NN	Number=Sing	5	obj	5:obj|10:nsubj	_
 9	that	that	PRON	WDT	PronType=Rel	10	nsubj	8:ref	_
-10	creates	create	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-that-nsubj
+10	creates	create	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	basking	basking	NOUN	NN	Number=Sing	13	compound	13:compound	_
 13	temp	temp	NOUN	NN	Number=Sing	10	obj	10:obj	_
@@ -21952,9 +21952,9 @@
 # sent_id = answers-20111104115933AA30CRJ_ans-0006
 # newpar id = answers-20111104115933AA30CRJ_ans-p0003
 # text = Why not put together a bottle of champagne, a picnic and have a date on Treasure Island.
-1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	_
+1	Why	why	ADV	WRB	PronType=Int	3	advmod	3:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	not	not	PART	RB	Polarity=Neg	3	advmod	3:advmod	_
-3	put	put	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	put	put	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	together	together	ADV	RB	_	3	advmod	3:advmod	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	bottle	bottle	NOUN	NN	Number=Sing	3	obj	3:obj	_
@@ -21987,8 +21987,8 @@
 # newpar id = answers-20111104115933AA30CRJ_ans-p0004
 # text = There are plenty of cheap restaurants.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-3	plenty	plenty	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+3	plenty	plenty	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 4	of	of	ADP	IN	_	6	case	6:case	_
 5	cheap	cheap	ADJ	JJ	Degree=Pos	6	amod	6:amod	_
 6	restaurants	restaurant	NOUN	NNS	Number=Plur	3	nmod	3:nmod:of	SpaceAfter=No
@@ -22086,11 +22086,11 @@
 26	and	and	CCONJ	CC	_	33	cc	33:cc	_
 27	ig	if	SCONJ	IN	Typo=Yes	29	mark	29:mark	CorrectForm=if
 28	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	nsubj	29:nsubj	_
-29	costs	cost	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	advcl	33:advcl:if	_
+29	costs	cost	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	advcl	33:advcl:if	CxnElt=33:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 30	a	a	DET	DT	Definite=Ind|PronType=Art	32	det	32:det	_
 31	whole	whole	ADJ	JJ	Degree=Pos	32	amod	32:amod	_
 32	lot	lot	NOUN	NN	Number=Sing	29	obj	29:obj	_
-33	ask	ask	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj:and	_
+33	ask	ask	VERB	VB	Mood=Imp|VerbForm=Fin	2	conj	2:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=33:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 34	hlep	help	NOUN	NN	Number=Sing|Typo=Yes	33	obj	33:obj	CorrectForm=help
 35	from	from	ADP	IN	_	37	case	37:case	_
 36	you	your	PRON	PRP$	Case=Gen|Person=2|Poss=Yes|PronType=Prs|Typo=Yes	37	nmod:poss	37:nmod:poss	CorrectForm=your
@@ -22133,11 +22133,11 @@
 # sent_id = answers-20111106130843AA7yj7U_ans-0001
 # newpar id = answers-20111106130843AA7yj7U_ans-p0001
 # text = How much would it cost for me to take me and three friends to Andiamos restaurant for dinner?
-1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	How	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	much	much	ADJ	JJ	Degree=Pos	5	obj	5:obj	_
 3	would	would	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	expl	5:expl	_
-5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	cost	cost	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	for	for	SCONJ	IN	_	9	mark	9:mark	_
 7	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
@@ -22180,7 +22180,7 @@
 19	girl	girl	NOUN	NN	Number=Sing	8	conj	7:obj|8:conj:and|22:obj	_
 20	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	22	nsubj	22:nsubj	_
 21	really	really	ADV	RB	_	22	advmod	22:advmod	_
-22	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj
+22	like	like	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	acl:relcl	19:acl:relcl	_
 23	out	out	ADP	RP	_	7	compound:prt	7:compound:prt	_
 24	to	to	ADP	IN	_	25	case	25:case	_
 25	dinner	dinner	NOUN	NN	Number=Sing	7	obl	7:obl:to	_
@@ -22208,11 +22208,11 @@
 14	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	just	just	ADV	RB	_	16	advmod	16:advmod	_
 16	wondering	wonder	VERB	VBG	Tense=Pres|VerbForm=Part	3	conj	3:conj:and	_
-17	how	how	ADV	WRB	PronType=Int	18	advmod	18:advmod	_
+17	how	how	ADV	WRB	PronType=Int	18	advmod	18:advmod	CxnElt=21:Interrogative-WHInfo-Indirect.WHWord
 18	much	much	ADJ	JJ	Degree=Pos	21	obj	21:obj	_
 19	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	expl	21:expl	_
 20	would	would	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
-21	cost	cost	VERB	VB	VerbForm=Inf	16	ccomp	16:ccomp	_
+21	cost	cost	VERB	VB	VerbForm=Inf	16	ccomp	16:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=21:Interrogative-WHInfo-Indirect.Clause
 22	for	for	SCONJ	IN	_	28	mark	28:mark	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	four	four	NUM	CD	NumForm=Word|NumType=Card	28	nsubj	28:nsubj	_
@@ -22228,14 +22228,14 @@
 1	Have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 2	no	no	DET	DT	PronType=Neg	3	det	3:det	_
 3	idea	idea	NOUN	NN	Number=Sing	1	obj	1:obj	_
-4	what	what	DET	WDT	PronType=Int	5	det	5:det	_
-5	kind	kind	NOUN	NN	Number=Sing	1	ccomp	1:ccomp	_
+4	what	what	DET	WDT	PronType=Int	5	det	5:det	CxnElt=5:Interrogative-WHInfo-Indirect.WHWord
+5	kind	kind	NOUN	NN	Number=Sing	1	ccomp	1:ccomp	Cxn=Interrogative-WHInfo-Indirect,Interrogative-WHInfo-Indirect#2|CxnElt=5:Interrogative-WHInfo-Indirect.Clause,5:Interrogative-WHInfo-Indirect#2.Clause
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	restaurant	restaurant	NOUN	NN	Number=Sing	5	nmod	5:nmod:of	_
 8	this	this	PRON	DT	Number=Sing|PronType=Dem	5	nsubj	5:nsubj	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 10	or	or	CCONJ	CC	_	11	cc	11:cc	_
-11	where	where	ADV	WRB	PronType=Int	5	conj	1:ccomp|5:conj:or	_
+11	where	where	ADV	WRB	PronType=Int	5	conj	1:ccomp|5:conj:or	CxnElt=5:Interrogative-WHInfo-Indirect#2.WHWord
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	11:nsubj	_
 13	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -22257,10 +22257,10 @@
 # sent_id = answers-20111106130843AA7yj7U_ans-0006
 # text = Or more if you have drinks.
 1	Or	or	CCONJ	CC	_	2	cc	2:cc	_
-2	more	more	ADJ	JJR	Degree=Cmp	0	root	0:root	_
+2	more	more	ADJ	JJR	Degree=Cmp	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 3	if	if	SCONJ	IN	_	5	mark	5:mark	_
 4	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
-5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:if	_
+5	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	2	advcl	2:advcl:if	CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 6	drinks	drink	NOUN	NNS	Number=Plur	5	obj	5:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
@@ -22417,9 +22417,9 @@
 # sent_id = answers-20111107211645AA391wC_ans-0001
 # newpar id = answers-20111107211645AA391wC_ans-p0001
 # text = how many ounces in a pint in ireland?
-1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
+1	how	how	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=3:Interrogative-WHInfo-Direct.WHWord
 2	many	many	ADJ	JJ	Degree=Pos	3	amod	3:amod	_
-3	ounces	ounce	NOUN	NNS	Number=Plur	0	root	0:root	_
+3	ounces	ounce	NOUN	NNS	Number=Plur	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-WHInfo-Direct.Clause
 4	in	in	ADP	IN	_	6	case	6:case	_
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	pint	pint	NOUN	NN	Number=Sing	3	nmod	3:nmod:in	_
@@ -22450,11 +22450,11 @@
 # text = If you mean fluid ounces, 20, as opposed to the 16 in America.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	_
+3	mean	mean	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	7	advcl	7:advcl:if	CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	fluid	fluid	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	ounces	ounce	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
-7	20	20	NUM	CD	NumForm=Digit|NumType=Card	0	root	0:root	SpaceAfter=No
+7	20	20	NUM	CD	NumForm=Digit|NumType=Card	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=7:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 8	,	,	PUNCT	,	_	13	punct	13:punct	_
 9	as	as	ADP	IN	ExtPos=ADP	13	case	13:case	_
 10	opposed	oppose	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	9	fixed	9:fixed	_
@@ -22499,9 +22499,9 @@
 5	said	say	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:as	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	there	there	PRON	EX	_	8	expl	8:expl	_
-8	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 9	only	only	ADV	RB	_	10	advmod	10:advmod	_
-10	16	16	NUM	CD	NumForm=Digit|NumType=Card	8	nsubj	8:nsubj	_
+10	16	16	NUM	CD	NumForm=Digit|NumType=Card	8	nsubj	8:nsubj	CxnElt=8:Existential-CopPred-ThereExpl.Pivot
 11	in	in	ADP	IN	_	14	case	14:case	_
 12	an	a	DET	DT	Definite=Ind|PronType=Art	14	det	14:det	_
 13	American	American	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
@@ -22527,7 +22527,7 @@
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	canada	Canada	PROPN	NNP	Number=Sing	14	nmod	14:nmod:in	_
 17	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	18	nsubj	18:nsubj	_
-18	grew	grow	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obl-pstrand
+18	grew	grow	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 19	up	up	ADP	RP	_	18	compound:prt	18:compound:prt	_
 20	in	in	ADP	IN	_	18	obl	18:obl	Promoted=Yes
 21	used	use	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	ccomp	6:ccomp	_
@@ -22635,10 +22635,10 @@
 2	if	if	SCONJ	IN	_	5	mark	5:mark	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	5	nsubj	5:nsubj	_
 4	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
-5	interested	interested	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:if	SpaceAfter=No
+5	interested	interested	ADJ	JJ	Degree=Pos	8	advcl	8:advcl:if	CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
-8	suggest	suggest	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+8	suggest	suggest	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=8:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
 10	have	have	VERB	VB	Mood=Sub|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	ccomp	8:ccomp	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -22696,8 +22696,8 @@
 1	And	and	CCONJ	CC	_	3	cc	3:cc	_
 2-3	there's	_	_	_	_	_	_	_	_
 2	there	there	PRON	EX	_	3	expl	3:expl	_
-3	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-4	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	3	nsubj	3:nsubj	_
+3	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+4	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 5	distinctly	distinctly	ADV	RB	_	6	advmod	6:advmod	_
 6	Irish	Irish	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 7	about	about	ADP	IN	_	8	case	8:case	_
@@ -22718,7 +22718,7 @@
 9	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	12:cop	_
 10	from	from	ADP	IN	_	12	case	12:case	_
 11	the	the	DET	DT	Definite=Def|PronType=Art	12	det	12:det	_
-12	UK	UK	PROPN	NNP	Number=Sing	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
+12	UK	UK	PROPN	NNP	Number=Sing	5	acl:relcl	5:acl:relcl	_
 13	and	and	CCONJ	CC	_	14	cc	14:cc	_
 14	US	US	PROPN	NNP	Number=Sing	12	conj	5:acl:relcl|12:conj:and	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -22811,7 +22811,7 @@
 10	last	last	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
 11	one	one	NOUN	NN	Number=Sing	14	nsubj	13:obj|14:nsubj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	bought	buy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
+13	bought	buy	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	11	acl:relcl	11:acl:relcl	_
 14	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	parataxis	3:parataxis	_
 15	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	14	obj	14:obj|16:nsubj:xsubj	_
 16	soaked	soaked	ADJ	JJ	Degree=Pos	14	xcomp	14:xcomp	_
@@ -22830,7 +22830,7 @@
 1-2	I'll	_	_	_	_	_	_	_	_
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	3:nsubj	_
 2	'll	will	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	pay	pay	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	pay	pay	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 4	up	up	ADP	IN	ExtPos=ADV	6	advmod	6:advmod	_
 5	to	to	ADP	IN	_	4	fixed	4:fixed	_
 6	200	200	NUM	CD	NumForm=Digit|NumType=Card	3	obj	3:obj	SpaceAfter=No
@@ -22840,7 +22840,7 @@
 10	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	obl	3:obl:for	_
 11	if	if	SCONJ	IN	_	13	mark	13:mark	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
-13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	_
+13	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	advcl	3:advcl:if	CxnElt=3:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 14	to	to	PART	TO	_	13	xcomp	13:xcomp	SpaceAfter=No
 15	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -22949,10 +22949,10 @@
 4	...	...	PUNCT	,	_	6	punct	6:punct	_
 5-6	there's	_	_	_	_	_	_	_	_
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	_
+6	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	2:parataxis	Cxn=Existential-CopPred-ThereExpl
 7	no	no	DET	DT	PronType=Neg	9	det	9:det	_
 8	such	such	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
-9	thing	thing	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
+9	thing	thing	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
 10	as	as	ADP	IN	_	12	case	12:case	_
 11	"	"	PUNCT	``	_	12	punct	12:punct	SpaceAfter=No
 12	pause	pause	NOUN	NN	Number=Sing	8	obl	8:obl:as	SpaceAfter=No
@@ -22972,7 +22972,7 @@
 5	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 6	buffer	buffer	NOUN	NN	Number=Sing	0	root	0:root|8:nsubj	_
 7	that	that	PRON	WDT	PronType=Rel	8	nsubj	6:ref	_
-8	holds	hold	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	Cxn=rc-that-nsubj
+8	holds	hold	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl:relcl	6:acl:relcl	_
 9	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 10	data	data	NOUN	NN	Number=Sing	8	obj	8:obj	_
 11	until	until	SCONJ	IN	_	14	mark	14:mark	_
@@ -23020,7 +23020,7 @@
 1	All	all	DET	DT	PronType=Tot	6	nsubj:outer	4:obj|6:nsubj:outer|14:nsubj:outer	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	do	do	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+4	do	do	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 5	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
 6	take	take	VERB	VB	VerbForm=Inf	0	root	0:root	_
 7	each	each	DET	DT	PronType=Tot	8	det	8:det	_
@@ -23164,11 +23164,11 @@
 # text = Do you get what's wrong with this picture?
 1	Do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	get	get	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause,3:Interrogative-WHInfo-Direct.Clause
 4-5	what's	_	_	_	_	_	_	_	_
-4	what	what	PRON	WP	PronType=Int	6	nsubj	6:nsubj	_
+4	what	what	PRON	WP	PronType=Int	6	nsubj	6:nsubj	CxnElt=3:Interrogative-WHInfo-Direct.WHWord,6:Interrogative-WHInfo-Indirect.WHWord
 5	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	6:cop	_
-6	wrong	wrong	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	_
+6	wrong	wrong	ADJ	JJ	Degree=Pos	3	ccomp	3:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=6:Interrogative-WHInfo-Indirect.Clause
 7	with	with	ADP	IN	_	9	case	9:case	_
 8	this	this	DET	DT	Number=Sing|PronType=Dem	9	det	9:det	_
 9	picture	picture	NOUN	NN	Number=Sing	6	obl	6:obl:with	SpaceAfter=No
@@ -23212,11 +23212,11 @@
 # sent_id = answers-20111106015552AAj6rCu_ans-0001
 # newpar id = answers-20111106015552AAj6rCu_ans-p0001
 # text = is there any good places to get an ice-cream sundae from in Invercargill New Zealand?
-1	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
-5	places	place	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	_
+5	places	place	NOUN	NNS	Number=Plur	1	nsubj	1:nsubj	CxnElt=1:Existential-CopPred-ThereExpl.Pivot
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	get	get	VERB	VB	VerbForm=Inf	5	acl	5:acl:to	_
 8	an	a	DET	DT	Definite=Ind|PronType=Art	12	det	12:det	_
@@ -23248,10 +23248,10 @@
 12	know	know	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	_
 13	if	if	SCONJ	IN	_	15	mark	15:mark	_
 14	there	there	PRON	EX	_	15	expl	15:expl	_
-15	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	ccomp	12:ccomp	_
+15	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	ccomp	12:ccomp	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Indirect|CxnElt=15:Interrogative-Polar-Indirect.Clause
 16	any	any	DET	DT	PronType=Ind	18	det	18:det	_
 17	good	good	ADJ	JJ	Degree=Pos	18	amod	18:amod	_
-18	places	place	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	_
+18	places	place	NOUN	NNS	Number=Plur	15	nsubj	15:nsubj	CxnElt=15:Existential-CopPred-ThereExpl.Pivot
 19	to	to	PART	TO	_	20	mark	20:mark	_
 20	buy	buy	VERB	VB	VerbForm=Inf	18	acl	18:acl:to	_
 21	an	a	DET	DT	Definite=Ind|PronType=Art	25	det	25:det	_
@@ -23392,7 +23392,7 @@
 # sent_id = answers-20111106103415AAqdokn_ans-0002
 # newpar id = answers-20111106103415AAqdokn_ans-p0002
 # text = which is the best burger chain in the chicago metro area like for example burger king portillos white castle which one do like the best?
-1	which	which	PRON	WDT	PronType=Int	0	root	0:root	ManuallyChecked=PronType
+1	which	which	PRON	WDT	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	6	det	6:det	_
 4	best	good	ADJ	JJS	Degree=Sup	6	amod	6:amod	_
@@ -23416,7 +23416,7 @@
 21	which	which	DET	WDT	PronType=Int	22	det	22:det	ManuallyChecked=PronType
 22	one	one	NOUN	NN	Number=Sing	24	obj	24:obj	_
 23	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
-23.1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	_	_	24:nsubj	_
+23.1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	_	_	24:nsubj	wordform=__EMPTY__
 24	like	like	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	best	well	ADV	RBS	Degree=Sup	24	obl:unmarked	24:obl:unmarked	SpaceAfter=No
@@ -23463,7 +23463,7 @@
 # text = Does 5 make a chain?
 1	Does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	3:aux	_
 2	5	5	NUM	CD	NumForm=Digit|NumType=Card	3	nsubj	3:nsubj	_
-3	make	make	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	make	make	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	5:det	_
 5	chain	chain	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -23479,7 +23479,7 @@
 6	burger	burger	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	formula	formula	NOUN	NN	Number=Sing	3	obj	3:obj|9:nsubj	_
 8	that	that	PRON	WDT	PronType=Rel	9	nsubj	7:ref	_
-9	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-that-nsubj
+9	started	start	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 10	about	about	ADV	RB	_	11	advmod	11:advmod	_
 11	80	80	NUM	CD	NumForm=Digit|NumType=Card	12	nummod	12:nummod	_
 12	years	year	NOUN	NNS	Number=Plur	13	obl:unmarked	13:obl:unmarked	_
@@ -23489,10 +23489,10 @@
 # sent_id = answers-20111106103415AAqdokn_ans-0010
 # text = There are currently 5 locations:
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	currently	currently	ADV	RB	_	2	advmod	2:advmod	_
 4	5	5	NUM	CD	NumForm=Digit|NumType=Card	5	nummod	5:nummod	_
-5	locations	location	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	SpaceAfter=No
+5	locations	location	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 6	:	:	PUNCT	:	_	2	punct	2:punct	_
 
 # sent_id = answers-20111106103415AAqdokn_ans-0011
@@ -23524,11 +23524,11 @@
 # sent_id = answers-20111106103415AAqdokn_ans-0014
 # text = See what DD&D showed at the original place on Harms Rd in Glenview:
 1	See	see	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
-2	what	what	PRON	WP	PronType=Int	6	obj	6:obj	_
+2	what	what	PRON	WP	PronType=Int	6	obj	6:obj	CxnElt=6:Interrogative-WHInfo-Indirect.WHWord
 3	DD	DD	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	SpaceAfter=No
 4	&	&	CCONJ	CC	_	5	cc	5:cc	SpaceAfter=No
 5	D	D	PROPN	NNP	Number=Sing	3	conj	3:conj|6:nsubj	_
-6	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	_
+6	showed	show	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	ccomp	1:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=6:Interrogative-WHInfo-Indirect.Clause
 7	at	at	ADP	IN	_	10	case	10:case	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	10	det	10:det	_
 9	original	original	ADJ	JJ	Degree=Pos	10	amod	10:amod	_
@@ -23551,7 +23551,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	great	great	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	burger	burger	NOUN	NN	Number=Sing	6	obl	6:obl:with	_
-6	try	try	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+6	try	try	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 7	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 8	brick	brick	NOUN	NN	Number=Sing	6	obj	6:obj	_
 9	of	of	ADP	IN	_	11	case	11:case	_
@@ -23561,7 +23561,7 @@
 13	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
 14	are	be	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	16	cop	16:cop	_
 15	with	with	ADP	IN	_	16	case	16:case	_
-16	someone	someone	PRON	NN	Number=Sing|PronType=Ind	6	advcl	6:advcl:if	SpaceAfter=No
+16	someone	someone	PRON	NN	Number=Sing|PronType=Ind	6	advcl	6:advcl:if	CxnElt=6:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 17	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # sent_id = answers-20111106103415AAqdokn_ans-0017
@@ -23602,10 +23602,10 @@
 
 # sent_id = answers-20111108111112AAAjhoy_ans-0002
 # text = What should I do?
-1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	_
+1	What	what	PRON	WP	PronType=Int	4	obj	4:obj	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	should	should	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+4	do	do	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108111112AAAjhoy_ans-0003
@@ -23629,7 +23629,7 @@
 
 # sent_id = answers-20111108111112AAAjhoy_ans-0004
 # text = What could it be?
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	could	could	AUX	MD	VerbForm=Fin	1	aux	1:aux	_
 3	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	nsubj	1:nsubj	_
 4	be	be	AUX	VB	VerbForm=Inf	1	cop	1:cop	SpaceAfter=No
@@ -23640,7 +23640,7 @@
 1	Should	should	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 2	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
 3	be	be	AUX	VB	VerbForm=Inf	4	cop	4:cop	_
-4	concerned	concerned	ADJ	JJ	Degree=Pos	0	root	0:root	SpaceAfter=No
+4	concerned	concerned	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause|SpaceAfter=No
 5	?	?	PUNCT	.	_	4	punct	4:punct	_
 
 # sent_id = answers-20111108111112AAAjhoy_ans-0006
@@ -23683,13 +23683,13 @@
 1	esp	esp	ADV	RB	_	4	advmod	4:advmod	_
 2	if	if	SCONJ	IN	_	4	mark	4:mark	_
 3	not	not	PART	RB	Polarity=Neg	4	advmod	4:advmod	_
-4	eating	eat	VERB	VBG	Tense=Pres|VerbForm=Part	26	advcl	26:advcl:if	_
+4	eating	eat	VERB	VBG	Tense=Pres|VerbForm=Part	26	advcl	26:advcl:if	CxnElt=26:Conditional-NegativeEpistemic-Reduced.Protasis
 5	-	-	PUNCT	,	_	4	punct	4:punct	_
 6	if	if	SCONJ	IN	_	10	mark	10:mark	_
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj|14:nsubj	_
 8	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
 9	only	only	ADV	RB	_	10	advmod	10:advmod	_
-10	happened	happen	VERB	VBN	Tense=Past|VerbForm=Part	26	advcl	26:advcl:if	_
+10	happened	happen	VERB	VBN	Tense=Past|VerbForm=Part	26	advcl	26:advcl:if	CxnElt=26:Conditional-NegativeEpistemic-NoInversion.Protasis
 11	once	once	ADV	RB	NumForm=Word|NumType=Mult	10	advmod	10:advmod	_
 12	and	and	CCONJ	CC	_	14	cc	14:cc	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
@@ -23705,7 +23705,7 @@
 23	have	have	AUX	VB	VerbForm=Inf	26	aux	26:aux	_
 24	been	be	AUX	VBN	Tense=Past|VerbForm=Part	26	cop	26:cop	_
 25	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	26	nsubj	26:nsubj	_
-26	missed	miss	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	0:root	_
+26	missed	miss	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Conditional-NegativeEpistemic-NoInversion,Conditional-NegativeEpistemic-Reduced|CxnElt=26:Conditional-NegativeEpistemic-NoInversion.Apodosis,26:Conditional-NegativeEpistemic-Reduced.Apodosis
 27	his	his	PRON	PRP$	Case=Gen|Gender=Masc|Number=Sing|Person=3|Poss=Yes|PronType=Prs	29	nmod:poss	29:nmod:poss	_
 28	meal	meal	NOUN	NN	Number=Sing	29	compound	29:compound	_
 29	time	time	NOUN	NN	Number=Sing	26	obj	26:obj	_
@@ -23737,7 +23737,7 @@
 55	to	_	X	IN	_	54	goeswith	54:goeswith	_
 56	something	something	PRON	NN	Number=Sing|PronType=Ind	53	obl	53:obl:to|58:nsubj|61:nsubj:xsubj	_
 57	that	that	PRON	WDT	PronType=Rel	58	nsubj	56:ref	_
-58	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	56	acl:relcl	56:acl:relcl	Cxn=rc-that-nsubj-pstrand
+58	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	56	acl:relcl	56:acl:relcl	_
 59	to	to	PART	TO	_	61	mark	61:mark	_
 60	be	be	AUX	VB	VerbForm=Inf	61	aux:pass	61:aux:pass	_
 61	attended	attend	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	58	xcomp	58:xcomp	_
@@ -23769,11 +23769,11 @@
 # sent_id = answers-20111107200249AAIyCy5_ans-0001
 # newpar id = answers-20111107200249AAIyCy5_ans-p0001
 # text = why are there two statues of David?
-1	why	why	ADV	WRB	PronType=Int	2	advmod	2:advmod	_
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	why	why	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	there	there	PRON	EX	_	2	expl	2:expl	_
 4	two	two	NUM	CD	NumForm=Word|NumType=Card	5	nummod	5:nummod	_
-5	statues	statue	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	_
+5	statues	statue	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 6	of	of	ADP	IN	_	7	case	7:case	_
 7	David	David	PROPN	NNP	Number=Sing	5	nmod	5:nmod:of	SpaceAfter=No
 8	?	?	PUNCT	.	_	2	punct	2:punct	_
@@ -23793,9 +23793,9 @@
 10	notice	notice	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	2:conj:and	_
 11	that	that	SCONJ	IN	_	13	mark	13:mark	_
 12	there	there	PRON	EX	_	13	expl	13:expl	_
-13	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	_
+13	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	10:ccomp	Cxn=Existential-CopPred-ThereExpl
 14	two	two	NUM	CD	NumForm=Word|NumType=Card	15	nummod	15:nummod	_
-15	statues	statue	NOUN	NNS	Number=Plur	13	nsubj	13:nsubj	_
+15	statues	statue	NOUN	NNS	Number=Plur	13	nsubj	13:nsubj	CxnElt=13:Existential-CopPred-ThereExpl.Pivot
 16	of	of	ADP	IN	_	17	case	17:case	_
 17	David	David	PROPN	NNP	Number=Sing	15	nmod	15:nmod:of	SpaceAfter=No
 18	,	,	PUNCT	,	_	21	punct	21:punct	_
@@ -23818,13 +23818,13 @@
 7	why	why	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
 8	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	10:aux	_
 9	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
-10	do	do	VERB	VB	VerbForm=Inf	2	conj	2:conj:but	_
+10	do	do	VERB	VB	VerbForm=Inf	2	conj	2:conj:but	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 11	another	another	DET	DT	PronType=Ind	10	obj	10:obj	_
 12	if	if	SCONJ	IN	_	16	mark	16:mark	_
 13	Donatello	Donatello	PROPN	NNP	Number=Sing	16	nsubj	16:nsubj	_
 14	had	have	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	16:aux	_
 15	already	already	ADV	RB	_	16	advmod	16:advmod	_
-16	made	make	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	_
+16	made	make	VERB	VBN	Tense=Past|VerbForm=Part	10	advcl	10:advcl:if	CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 17	one	one	NUM	CD	NumForm=Word|NumType=Card	16	obj	16:obj	SpaceAfter=No
 18	?	?	PUNCT	.	_	2	punct	2:punct	_
 
@@ -23839,10 +23839,10 @@
 6	confused	confused	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	,	,	PUNCT	,	_	9	punct	9:punct	_
 8	why	why	ADV	WRB	PronType=Int	9	advmod	9:advmod	_
-9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
+9	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	Cxn=Existential-CopPred-ThereExpl
 10	there	there	PRON	EX	_	9	expl	9:expl	_
 11	two	two	NUM	CD	NumForm=Word|NumType=Card	12	nummod	12:nummod	_
-12	statues	statue	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	_
+12	statues	statue	NOUN	NNS	Number=Plur	9	nsubj	9:nsubj	CxnElt=9:Existential-CopPred-ThereExpl.Pivot
 13	of	of	ADP	IN	_	14	case	14:case	_
 14	David	David	PROPN	NNP	Number=Sing	12	nmod	12:nmod:of	SpaceAfter=No
 15	?	?	PUNCT	.	_	6	punct	6:punct	_
@@ -23930,7 +23930,7 @@
 33	could	could	AUX	MD	VerbForm=Fin	36	aux	36:aux	_
 34	have	have	AUX	VB	VerbForm=Inf	36	aux	36:aux	_
 35	been	be	AUX	VBN	Tense=Past|VerbForm=Part	36	aux:pass	36:aux:pass	_
-36	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	Cxn=rc-that-nsubj:pass
+36	used	use	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	31	acl:relcl	31:acl:relcl	_
 37	making	make	VERB	VBG	Tense=Pres|VerbForm=Part	36	advcl	36:advcl	_
 38	a	a	DET	DT	Definite=Ind|PronType=Art	39	det	39:det	_
 39	statue	statue	NOUN	NN	Number=Sing	37	obj	37:obj	_
@@ -23980,7 +23980,7 @@
 23	style	style	NOUN	NN	Number=Sing	24	compound	24:compound	_
 24	restaurant	restaurant	NOUN	NN	Number=Sing	18	nmod	18:nmod:of|26:obj	_
 25	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	26:nsubj	_
-26	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	Cxn=rc-red-obj
+26	visited	visit	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	24	acl:relcl	24:acl:relcl	_
 27	while	while	SCONJ	IN	_	29	mark	29:mark	_
 28	out	out	ADV	RB	_	29	advmod	29:advmod	_
 29	there	there	ADV	RB	PronType=Dem	26	advcl	26:advcl:while	_
@@ -24082,7 +24082,7 @@
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj	_
 4	can	can	AUX	MD	VerbForm=Fin	6	aux	6:aux	SpaceAfter=No
 5	-	-	PUNCT	HYPH	_	4	punct	4:punct	SpaceAfter=No
-6	eat	eat	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	Cxn=rc-red-obj
+6	eat	eat	VERB	VB	VerbForm=Inf	1	acl:relcl	1:acl:relcl	_
 7	style	style	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	deal	deal	NOUN	NN	Number=Sing	0	root	0:root	SpaceAfter=No
 9	.	.	PUNCT	.	_	8	punct	8:punct	_
@@ -24126,7 +24126,7 @@
 # newpar id = answers-20111108050147AAOkFgL_ans-p0001
 # text = What's the best time to start a trip around the world?
 1-2	What's	_	_	_	_	_	_	_	_
-1	What	what	PRON	WP	PronType=Int	0	root	0:root	_
+1	What	what	PRON	WP	PronType=Int	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=1:Interrogative-WHInfo-Direct.Clause,1:Interrogative-WHInfo-Direct.WHWord
 2	's	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	1:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	best	good	ADJ	JJS	Degree=Sup	5	amod	5:amod	_
@@ -24191,10 +24191,10 @@
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	world	world	NOUN	NN	Number=Sing	17	obl	17:obl:around	SpaceAfter=No
 21	,	,	PUNCT	,	_	7	punct	7:punct	CorrectSpaceAfter=Yes|SpaceAfter=No
-22	what	what	PRON	WP	PronType=Int	25	obj	25:obj	_
+22	what	what	PRON	WP	PronType=Int	25	obj	25:obj	CxnElt=25:Interrogative-WHInfo-Direct.WHWord
 23	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	25	aux	25:aux	_
 24	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	25	nsubj	25:nsubj	_
-25	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	SpaceAfter=No
+25	think	think	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=25:Interrogative-WHInfo-Direct.Clause|SpaceAfter=No
 26	,	,	PUNCT	,	_	29	punct	29:punct	CorrectSpaceAfter=Yes|SpaceAfter=No
 27	should	should	AUX	MD	VerbForm=Fin	29	aux	29:aux	_
 28	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	29	nsubj	29:nsubj	_
@@ -24213,7 +24213,7 @@
 1	If	if	SCONJ	IN	_	4	mark	4:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj|6:nsubj:xsubj	_
 3	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
-4	afford	afford	VERB	VB	VerbForm=Inf	14	advcl	14:advcl:if	_
+4	afford	afford	VERB	VB	VerbForm=Inf	14	advcl	14:advcl:if	CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	go	go	VERB	VB	VerbForm=Inf	4	xcomp	4:xcomp	_
 7	before	before	ADV	RB	_	6	advmod	6:advmod	SpaceAfter=No
@@ -24223,14 +24223,14 @@
 11	all	all	DET	DT	PronType=Tot	12	det	12:det	_
 12	means	means	NOUN	NNS	Number=Ptan	14	obl	14:obl:by	SpaceAfter=No
 13	,	,	PUNCT	,	_	12	punct	12:punct	_
-14	GO	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+14	GO	go	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=14:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 15	.	.	PUNCT	.	_	14	punct	14:punct	_
 
 # sent_id = answers-20111108050147AAOkFgL_ans-0005
 # text = If you have to wait, due to financial reasons, then wait.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
+3	have	have	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	wait	wait	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	SpaceAfter=No
 6	,	,	PUNCT	,	_	10	punct	10:punct	_
@@ -24240,7 +24240,7 @@
 10	reasons	reason	NOUN	NNS	Number=Plur	5	obl	5:obl:due_to	SpaceAfter=No
 11	,	,	PUNCT	,	_	3	punct	3:punct	_
 12	then	then	ADV	RB	PronType=Dem	13	advmod	13:advmod	_
-13	wait	wait	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	SpaceAfter=No
+13	wait	wait	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis|SpaceAfter=No
 14	.	.	PUNCT	.	_	13	punct	13:punct	_
 
 # sent_id = answers-20111108050147AAOkFgL_ans-0006
@@ -24375,7 +24375,7 @@
 # text = did anyone have this issue?
 1	did	do	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	3:aux	_
 2	anyone	anyone	PRON	NN	Number=Sing|PronType=Ind	3	nsubj	3:nsubj	_
-3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	have	have	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-Polar-Direct|CxnElt=3:Interrogative-Polar-Direct.Clause
 4	this	this	DET	DT	Number=Sing|PronType=Dem	5	det	5:det	_
 5	issue	issue	NOUN	NN	Number=Sing	3	obj	3:obj	SpaceAfter=No
 6	?	?	PUNCT	.	_	3	punct	3:punct	_
@@ -24488,7 +24488,7 @@
 13	just	just	ADV	RB	_	15	advmod	15:advmod	_
 14	like	like	ADP	IN	_	15	case	15:case	_
 15	what	what	PRON	WP	PronType=Rel	10	obl	10:obl:like|16:nsubj	_
-16	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-free-nsubj
+16	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 17	in	in	ADP	IN	_	19	case	19:case	_
 18	a	a	DET	DT	Definite=Ind|PronType=Art	19	det	19:det	_
 19	computer	computer	NOUN	NN	Number=Sing	16	obl	16:obl:in	_
@@ -24497,9 +24497,9 @@
 22	a	a	DET	DT	Definite=Ind|PronType=Art	23	det	23:det	_
 23	re-start	re-start	NOUN	NN	Number=Sing	21	obj	21:obj	_
 24	from	from	ADP	IN	_	25	case	25:case	_
-25	time	time	NOUN	NN	Number=Sing	21	obl	21:obl:from	_
-26	to	to	ADP	IN	_	27	case	27:case	_
-27	time	time	NOUN	NN	Number=Sing	25	nmod	25:nmod:to	_
+25	time	time	NOUN	NN	Number=Sing	21	obl	21:obl:from	Cxn=NPN|CxnElt=25:NPN.N1
+26	to	to	ADP	IN	_	27	case	27:case	CxnElt=25:NPN.P
+27	time	time	NOUN	NN	Number=Sing	25	nmod	25:nmod:to	CxnElt=25:NPN.N2
 28	but	but	CCONJ	CC	_	33	cc	33:cc	_
 29	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	33	nsubj	33:nsubj	_
 30-31	shouldn't	_	_	_	_	_	_	_	_
@@ -24564,11 +24564,11 @@
 
 # sent_id = answers-20111108102205AArwNzY_ans-0003
 # text = Which airlines should I look into and when should I buy my ticket?
-1	Which	which	DET	WDT	PronType=Int	2	det	2:det	ManuallyChecked=PronType
+1	Which	which	DET	WDT	PronType=Int	2	det	2:det	CxnElt=5:Interrogative-WHInfo-Direct.WHWord|ManuallyChecked=PronType
 2	airlines	airline	NOUN	NNS	Number=Plur	5	obl	5:obl:into	_
 3	should	should	AUX	MD	VerbForm=Fin	5	aux	5:aux	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	5:nsubj	_
-5	look	look	VERB	VB	VerbForm=Inf	0	root	0:root	_
+5	look	look	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	into	into	ADP	IN	_	2	case	2:case	_
 7	and	and	CCONJ	CC	_	11	cc	11:cc	_
 8	when	when	ADV	WRB	PronType=Int	11	advmod	11:advmod	_
@@ -24606,9 +24606,9 @@
 4	Expedia	Expedia	PROPN	NNP	Number=Sing	2	conj	1:obj|2:conj:or	_
 5	and	and	CCONJ	CC	_	6	cc	6:cc	_
 6	see	see	VERB	VB	Mood=Imp|VerbForm=Fin	1	conj	1:conj:and	_
-7	what	what	PRON	WP	PronType=Int	9	obl	9:obl:with	_
+7	what	what	PRON	WP	PronType=Int	9	obl	9:obl:with	CxnElt=9:Interrogative-WHInfo-Indirect.WHWord
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
-9	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	_
+9	come	come	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	6	ccomp	6:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=9:Interrogative-WHInfo-Indirect.Clause
 10	up	up	ADV	RB	_	9	advmod	9:advmod	_
 11	with	with	ADP	IN	_	7	case	7:case	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -24720,18 +24720,18 @@
 7	rates	rate	NOUN	NNS	Number=Plur	5	conj	2:obj|5:conj	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 9	could	could	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+10	find	find	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	SpaceAfter=No
 11	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = answers-20111103205154AAOod9K_ans
 # sent_id = answers-20111103205154AAOod9K_ans-0001
 # newpar id = answers-20111103205154AAOod9K_ans-p0001
 # text = What is the best place to get discounts for San Francisco restaurants?
-1	What	what	PRON	WP	PronType=Int	5	nsubj	5:nsubj	_
+1	What	what	PRON	WP	PronType=Int	5	nsubj	5:nsubj	CxnElt=5:Interrogative-WHInfo-Direct.WHWord
 2	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	5:cop	_
 3	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 4	best	good	ADJ	JJS	Degree=Sup	5	amod	5:amod	_
-5	place	place	NOUN	NN	Number=Sing	0	root	0:root	_
+5	place	place	NOUN	NN	Number=Sing	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=5:Interrogative-WHInfo-Direct.Clause
 6	to	to	PART	TO	_	7	mark	7:mark	_
 7	get	get	VERB	VB	VerbForm=Inf	5	acl	5:acl:to	_
 8	discounts	discount	NOUN	NNS	Number=Plur	7	obj	7:obj	_
@@ -24759,12 +24759,12 @@
 12	if	if	SCONJ	IN	_	14	mark	14:mark	_
 13-14	there's	_	_	_	_	_	_	_	_
 13	there	there	PRON	EX	_	14	expl	14:expl	_
-14	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	ccomp	11:ccomp	_
+14	's	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	ccomp	11:ccomp	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Indirect|CxnElt=14:Interrogative-Polar-Indirect.Clause
 15	a	a	DET	DT	Definite=Ind|PronType=Art	16	det	16:det	_
-16	place	place	NOUN	NN	Number=Sing	14	nsubj	14:nsubj|19:obl	_
+16	place	place	NOUN	NN	Number=Sing	14	nsubj	14:nsubj|19:obl	CxnElt=14:Existential-CopPred-ThereExpl.Pivot
 17	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 18	can	can	AUX	MD	VerbForm=Fin	19	aux	19:aux	_
-19	get	get	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	Cxn=rc-red-obl
+19	get	get	VERB	VB	VerbForm=Inf	16	acl:relcl	16:acl:relcl	_
 20	good	good	ADJ	JJ	Degree=Pos	21	amod	21:amod	_
 21	deals	deal	NOUN	NNS	Number=Plur	19	obj	19:obj	_
 22	on	on	ADP	IN	_	23	case	23:case	_
@@ -24812,11 +24812,11 @@
 13	whatever	whatever	DET	WDT	PronType=Rel	14	det	14:det	_
 14	Restaurant	restaurant	NOUN	NN	Number=Sing	11	nmod	11:nmod:to|16:obj	_
 15	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	16:nsubj	_
-16	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+16	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	acl:relcl	14:acl:relcl	SpaceAfter=No
 17	,	,	PUNCT	,	_	18	punct	18:punct	_
 18	whenever	whenever	ADV	WRB	PronType=Rel	8	advmod	8:advmod|20:advmod	_
 19	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	advcl:relcl	18:advcl:relcl	Cxn=rc-free-advmod|SpaceAfter=No
+20	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	advcl:relcl	18:advcl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = answers-20111103205154AAOod9K_ans-0005
@@ -24872,7 +24872,7 @@
 7	whatever	whatever	DET	WDT	PronType=Int	8	det	8:det	_
 8	deal	deal	NOUN	NN	Number=Sing	6	obj	6:obj|10:obj	_
 9	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj	_
-10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obj
+10	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	anytime	anytime	ADV	RB	PronType=Ind	6	advmod	6:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -24903,7 +24903,7 @@
 # text = If you want to eat cheaply without worrying about all those daily deal emails every day, ZebraKlub should be perfect for you.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj|5:nsubj:xsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	21	advcl	21:advcl:if	CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	eat	eat	VERB	VB	VerbForm=Inf	3	xcomp	3:xcomp	_
 6	cheaply	cheaply	ADV	RB	_	5	advmod	5:advmod	_
@@ -24921,7 +24921,7 @@
 18	ZebraKlub	ZebraKlub	PROPN	NNP	Number=Sing	21	nsubj	21:nsubj	_
 19	should	should	AUX	MD	VerbForm=Fin	21	aux	21:aux	_
 20	be	be	AUX	VB	VerbForm=Inf	21	cop	21:cop	_
-21	perfect	perfect	ADJ	JJ	Degree=Pos	0	root	0:root	_
+21	perfect	perfect	ADJ	JJ	Degree=Pos	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=21:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 22	for	for	ADP	IN	_	23	case	23:case	_
 23	you	you	PRON	PRP	Case=Acc|Person=2|PronType=Prs	21	obl	21:obl:for	SpaceAfter=No
 24	.	.	PUNCT	.	_	21	punct	21:punct	_
@@ -24930,10 +24930,10 @@
 # sent_id = answers-20111106230959AAuYQ5Q_ans-0001
 # newpar id = answers-20111106230959AAuYQ5Q_ans-p0001
 # text = Where can I go on a first date (adults)?
-1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	Where	where	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	can	can	AUX	MD	VerbForm=Fin	4	aux	4:aux	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	on	on	ADP	IN	_	8	case	8:case	_
 6	a	a	DET	DT	Definite=Ind|PronType=Art	8	det	8:det	_
 7	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	8	amod	8:amod	_
@@ -25032,7 +25032,7 @@
 25	exhibits	exhibit	NOUN	NNS	Number=Plur	22	obj	22:obj|28:obj	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	28	nsubj	28:nsubj	_
 27	might	might	AUX	MD	VerbForm=Fin	28	aux	28:aux	_
-28	enjoy	enjoy	VERB	VB	VerbForm=Inf	25	acl:relcl	25:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+28	enjoy	enjoy	VERB	VB	VerbForm=Inf	25	acl:relcl	25:acl:relcl	SpaceAfter=No
 29	,	,	PUNCT	,	_	33	punct	33:punct	_
 30	food	food	NOUN	NN	Number=Sing	33	nsubj	33:nsubj	_
 31	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	cop	33:cop	_
@@ -25084,9 +25084,9 @@
 8	have	have	VERB	VB	VerbForm=Inf	3	parataxis	3:parataxis	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	sit	sit	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
-11	face	face	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	_
-12	to	to	ADP	IN	_	13	case	13:case	_
-13	face	face	NOUN	NN	Number=Sing	11	nmod	11:nmod:to	_
+11	face	face	NOUN	NN	Number=Sing	10	obl:unmarked	10:obl:unmarked	Cxn=NPN|CxnElt=11:NPN.N1
+12	to	to	ADP	IN	_	13	case	13:case	CxnElt=11:NPN.P
+13	face	face	NOUN	NN	Number=Sing	11	nmod	11:nmod:to	CxnElt=11:NPN.N2
 14	to	to	PART	TO	_	15	mark	15:mark	_
 15	try	try	VERB	VB	VerbForm=Inf	10	advcl	10:advcl:to	_
 
@@ -25104,11 +25104,11 @@
 9	so	so	ADV	RB	_	16	advmod	16:advmod	_
 10	if	if	SCONJ	IN	_	12	mark	12:mark	_
 11	things	thing	NOUN	NNS	Number=Plur	12	nsubj	12:nsubj	_
-12	go	go	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	_
+12	go	go	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	16:advcl:if	CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 13	great	great	ADV	RB	_	12	advmod	12:advmod	SpaceAfter=No
 14	,	,	PUNCT	,	_	12	punct	12:punct	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	can	can	AUX	MD	VerbForm=Fin	7	parataxis	7:parataxis	_
+16	can	can	AUX	MD	VerbForm=Fin	7	parataxis	7:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=16:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 
 # sent_id = answers-20111106230959AAuYQ5Q_ans-0009
 # text = extend, and if you want to end it, you just say bye,
@@ -25117,14 +25117,14 @@
 3	and	and	CCONJ	CC	_	13	cc	13:cc	_
 4	if	if	SCONJ	IN	_	6	mark	6:mark	_
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	6	nsubj	6:nsubj|8:nsubj:xsubj	_
-6	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	_
+6	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	13	advcl	13:advcl:if	CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 7	to	to	PART	TO	_	8	mark	8:mark	_
 8	end	end	VERB	VB	VerbForm=Inf	6	xcomp	6:xcomp	_
 9	it	it	PRON	PRP	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	obj	8:obj	SpaceAfter=No
 10	,	,	PUNCT	,	_	6	punct	6:punct	_
 11	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	13	nsubj	13:nsubj	_
 12	just	just	ADV	RB	_	13	advmod	13:advmod	_
-13	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	_
+13	say	say	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	1	conj	1:conj:and	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=13:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 14	bye	bye	INTJ	UH	_	13	discourse	13:discourse	SpaceAfter=No
 15	,	,	PUNCT	,	_	1	punct	1:punct	_
 
@@ -25224,7 +25224,7 @@
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	one	one	NOUN	NN	Number=Sing	3	obj	3:obj|7:nsubj	_
 6	that	that	PRON	WDT	PronType=Rel	7	nsubj	5:ref	_
-7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-that-nsubj
+7	sounds	sound	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	the	the	DET	DT	Definite=Def|PronType=Art	9	det	9:det	_
 9	best	well	ADV	RBS	Degree=Sup	7	advmod	7:advmod	_
 10	after	after	SCONJ	IN	_	11	mark	11:mark	_
@@ -25297,14 +25297,14 @@
 # text = If you took out the clown loach it would make a nice 150 gallon tank.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:if	_
+3	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	10	advcl	10:advcl:if	CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	out	out	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 6	clown	clown	NOUN	NN	Number=Sing	7	compound	7:compound	_
 7	loach	loach	NOUN	NN	Number=Sing	3	obj	3:obj	_
 8	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	nsubj	10:nsubj	_
 9	would	would	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	make	make	VERB	VB	VerbForm=Inf	0	root	0:root	_
+10	make	make	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=10:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 11	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 12	nice	nice	NOUN	NN	Number=Sing	15	compound	15:compound	_
 13	150	150	NUM	CD	NumForm=Digit|NumType=Card	14	nummod	14:nummod	_
@@ -25475,7 +25475,7 @@
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	ever	ever	ADV	RB	PronType=Ind	6	advmod	6:advmod	_
-6	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl|SpaceAfter=No
+6	stayed	stay	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	SpaceAfter=No
 7	!	!	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-314938
@@ -25639,7 +25639,7 @@
 3	the	the	DET	DT	Definite=Def|PronType=Art	4	det	4:det	_
 4	pics	pic	NOUN	NNS	Number=Plur	2	obj	2:obj|6:obj	_
 5	geeksquad	geeksquad	PROPN	NNP	Number=Sing	6	nsubj	6:nsubj	_
-6	deleted	delete	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+6	deleted	delete	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-255757-0002
@@ -25693,7 +25693,7 @@
 4-5	I'd	_	_	_	_	_	_	_	_
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 5	'd	have	AUX	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	6	aux	6:aux	_
-6	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	Cxn=rc-that-obj
+6	had	have	VERB	VBN	Tense=Past|VerbForm=Part	2	acl:relcl	2:acl:relcl	_
 7	so	so	ADV	RB	_	8	advmod	8:advmod	_
 8	far	far	ADV	RB	Degree=Pos	6	advmod	6:advmod	SpaceAfter=No
 9	!	!	PUNCT	.	_	2	punct	2:punct	_
@@ -25747,7 +25747,7 @@
 4	some	some	DET	DT	PronType=Ind	5	det	5:det	_
 5	shirts	shirt	NOUN	NNS	Number=Plur	3	obj	3:obj|7:obj	_
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	too	too	ADV	RB	_	3	advmod	3:advmod	SpaceAfter=No
 9	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -25851,7 +25851,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	PronType=Ind	11	advmod	11:advmod	_
-11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obl-pstrand
+11	been	be	AUX	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
 12	to	to	ADP	IN	_	11	obl	11:obl	Promoted=Yes
 
 # newdoc id = reviews-343336
@@ -26022,7 +26022,7 @@
 9	what	what	PRON	WP	PronType=Rel	12	obj	8:ref	_
 10	a	a	DET	DT	Definite=Ind|PronType=Art	11	det	11:det	_
 11	customer	customer	NOUN	NN	Number=Sing	12	nsubj	12:nsubj	_
-12	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-obj|SpaceAfter=No
+12	needs	need	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	acl:relcl	8:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	7	punct	7:punct	_
 
 # newdoc id = reviews-086914
@@ -26114,11 +26114,11 @@
 3	impossible	impossible	ADJ	JJ	Degree=Pos	0	root	0:root	_
 4	to	to	PART	TO	_	5	mark	5:mark	_
 5	understand	understand	VERB	VB	VerbForm=Inf	3	ccomp	3:ccomp	_
-6	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	_
+6	how	how	ADV	WRB	PronType=Int	10	advmod	10:advmod	CxnElt=10:Interrogative-WHInfo-Indirect.WHWord
 7	this	this	DET	DT	Number=Sing|PronType=Dem	8	det	8:det	_
 8	place	place	NOUN	NN	Number=Sing	10	nsubj	10:nsubj	_
 9	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
-10	survived	survive	VERB	VBN	Tense=Past|VerbForm=Part	5	ccomp	5:ccomp	SpaceAfter=No
+10	survived	survive	VERB	VBN	Tense=Past|VerbForm=Part	5	ccomp	5:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=10:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 11	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # newdoc id = reviews-266955
@@ -26262,8 +26262,8 @@
 
 # sent_id = reviews-224117-0002
 # text = Who does that?!
-1	Who	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj	_
-2	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+1	Who	who	PRON	WP	PronType=Int	2	nsubj	2:nsubj	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
+2	does	do	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
 3	that	that	PRON	DT	Number=Sing|PronType=Dem	2	obj	2:obj	SpaceAfter=No
 4	?!	?!	PUNCT	.	_	2	punct	2:punct	_
 
@@ -26285,7 +26285,7 @@
 12	area	area	NOUN	NN	Number=Sing	9	nmod	9:nmod:in	_
 13	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 14	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
-15	count	count	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obl-pstrand
+15	count	count	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	_
 16	on	on	ADP	IN	_	15	obl	15:obl	Promoted=Yes|SpaceAfter=No
 17	.	.	PUNCT	.	_	9	punct	9:punct	_
 
@@ -26454,7 +26454,7 @@
 10	reason	reason	NOUN	NN	Number=Sing	1	parataxis	1:parataxis|13:obl	_
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	13	nsubj	13:nsubj	_
 12	would	would	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	go	go	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obl
+13	go	go	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
 14	to	to	ADP	IN	_	17	case	17:case	_
 15	this	this	DET	DT	Number=Sing|PronType=Dem	17	det	17:det	_
 16	particular	particular	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
@@ -26532,7 +26532,7 @@
 4	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 5	ve	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	7	aux	7:aux	CorrectForm='ve
 6	ever	ever	ADV	RB	PronType=Ind	7	advmod	7:advmod	_
-7	had	have	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+7	had	have	VERB	VBN	Tense=Past|VerbForm=Part	3	acl:relcl	3:acl:relcl	SpaceAfter=No
 8	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-104703-0003
@@ -26576,7 +26576,7 @@
 11-12	didn't	_	_	_	_	_	_	_	_
 11	did	do	AUX	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	13	aux	13:aux	_
 12	n't	not	PART	RB	Polarity=Neg	13	advmod	13:advmod	_
-13	like	like	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+13	like	like	VERB	VB	VerbForm=Inf	9	acl:relcl	9:acl:relcl	SpaceAfter=No
 14	!	!	PUNCT	.	_	5	punct	5:punct	_
 
 # newdoc id = reviews-200668
@@ -26722,7 +26722,7 @@
 1	Did	do	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
 2	services	service	NOUN	NNS	Number=Plur	1	obj	1:obj|8:obj	_
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj|8:obj	_
-4	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj_xcomp
+4	asked	ask	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	them	they	PRON	PRP	Case=Acc|Number=Plur|Person=3|PronType=Prs	4	iobj	4:iobj|8:nsubj:xsubj	_
 6	NOT	not	PART	RB	Polarity=Neg	8	advmod	8:advmod	CorrectSpaceAfter=Yes|SpaceAfter=No
 7	to	to	PART	TO	_	8	mark	8:mark	_
@@ -26785,10 +26785,10 @@
 
 # sent_id = reviews-363482-0002
 # text = How do you run a cafe, with no refills on coffee-?
-1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	_
+1	How	how	ADV	WRB	PronType=Int	4	advmod	4:advmod	CxnElt=4:Interrogative-WHInfo-Direct.WHWord
 2	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	4	aux	4:aux	_
 3	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	4	nsubj	4:nsubj	_
-4	run	run	VERB	VB	VerbForm=Inf	0	root	0:root	_
+4	run	run	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Interrogative-WHInfo-Direct|CxnElt=4:Interrogative-WHInfo-Direct.Clause
 5	a	a	DET	DT	Definite=Ind|PronType=Art	6	det	6:det	_
 6	cafe	cafe	NOUN	NN	Number=Sing	4	obj	4:obj	SpaceAfter=No
 7	,	,	PUNCT	,	_	10	punct	10:punct	_
@@ -26932,10 +26932,10 @@
 # newpar id = reviews-210153-p0002
 # text = There is no lower rating for Noonan's Liquor, owners and employees.
 1	There	there	PRON	EX	_	2	expl	2:expl	_
-2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
+2	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 3	no	no	DET	DT	PronType=Neg	5	det	5:det	_
 4	lower	low	ADJ	JJR	Degree=Cmp	5	amod	5:amod	_
-5	rating	rating	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	_
+5	rating	rating	NOUN	NN	Number=Sing	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot
 6	for	for	ADP	IN	_	9	case	9:case	_
 7-8	Noonan's	_	_	_	_	_	_	_	_
 7	Noonan	Noonan	PROPN	NNP	Number=Sing	9	nmod:poss	9:nmod:poss	_
@@ -27018,7 +27018,7 @@
 16	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	19	nsubj	19:nsubj	_
 17	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	aux	19:aux	_
 18	ever	ever	ADV	RB	PronType=Ind	19	advmod	19:advmod	_
-19	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	15	acl:relcl	15:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+19	met	meet	VERB	VBN	Tense=Past|VerbForm=Part	15	acl:relcl	15:acl:relcl	SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-396046-0002
@@ -27147,7 +27147,7 @@
 7-8	I've	_	_	_	_	_	_	_	_
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
-9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+9	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 10	in	in	ADP	IN	_	11	case	11:case	_
 11	Seattle	Seattle	PROPN	NNP	Number=Sing	9	obl	9:obl:in	SpaceAfter=No
 12	.	.	PUNCT	.	_	1	punct	1:punct	_
@@ -27159,7 +27159,7 @@
 3	a	a	DET	DT	Definite=Ind|PronType=Art	4	det	4:det	_
 4	place	place	NOUN	NN	Number=Sing	0	root	0:root|6:nsubj	_
 5	that	that	PRON	WDT	PronType=Rel	6	nsubj	4:ref	_
-6	specializes	specialize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-that-nsubj
+6	specializes	specialize	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	in	in	ADP	IN	_	10	case	10:case	_
 8	high	high	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	quality	quality	NOUN	NN	Number=Sing	10	compound	10:compound	_
@@ -27181,7 +27181,7 @@
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 8	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	PronType=Ind	10	advmod	10:advmod	_
-10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	SpaceAfter=No
 11	!	!	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-314024-0002
@@ -27191,7 +27191,7 @@
 3	that	that	PRON	WDT	PronType=Rel	6	nsubj:pass	2:ref	_
 4	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux:pass	6:aux:pass	_
 5	already	already	ADV	RB	_	6	advmod	6:advmod	_
-6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	acl:relcl	2:acl:relcl	Cxn=rc-that-nsubj:pass|SpaceAfter=No
+6	cooked	cook	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	2	acl:relcl	2:acl:relcl	SpaceAfter=No
 7	,	,	PUNCT	,	_	8	punct	8:punct	_
 8	easy	easy	ADJ	JJ	Degree=Pos	6	conj	2:acl:relcl|6:conj	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
@@ -27259,7 +27259,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	best	good	ADJ	JJS	Degree=Sup	0	root	0:root|4:obj	_
 3	darlington	darlington	PROPN	NNP	Number=Sing	4	nsubj	4:nsubj	_
-4	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+4	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	to	to	PART	TO	_	6	mark	6:mark	_
 6	offer	offer	VERB	VB	VerbForm=Inf	4	advcl	4:advcl:to	_
 7	in	in	ADP	IN	_	9	case	9:case	_
@@ -27499,7 +27499,7 @@
 9	bagh	Bagh	PROPN	NNP	Number=Sing	8	flat	8:flat	_
 10	which	which	PRON	WDT	PronType=Rel	12	nsubj:pass	8:ref	_
 11	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	12:aux:pass	_
-12	done	do	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	Cxn=rc-wh-nsubj:pass
+12	done	do	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	8	acl:relcl	8:acl:relcl	_
 13	under	under	ADP	IN	_	16	case	16:case	_
 14	the	the	DET	DT	Definite=Def|PronType=Art	16	det	16:det	_
 15	wooden	wooden	ADJ	JJ	Degree=Pos	16	amod	16:amod	_
@@ -27608,10 +27608,10 @@
 11	time	time	NOUN	NN	Number=Sing	8	obl	8:obl:at	_
 12	when	when	ADV	WRB	PronType=Int	14	advmod	14:advmod	_
 13	there	there	PRON	EX	_	14	expl	14:expl	_
-14	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	_
+14	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	advcl	8:advcl:when	Cxn=Existential-CopPred-ThereExpl
 15	very	very	ADV	RB	_	16	advmod	16:advmod	_
 16	few	few	ADJ	JJ	Degree=Pos	17	amod	17:amod	_
-17	clients	client	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	_
+17	clients	client	NOUN	NNS	Number=Plur	14	nsubj	14:nsubj	CxnElt=14:Existential-CopPred-ThereExpl.Pivot
 18	in	in	ADP	IN	_	20	case	20:case	_
 19	the	the	DET	DT	Definite=Def|PronType=Art	20	det	20:det	_
 20	facility	facility	NOUN	NN	Number=Sing	17	nmod	17:nmod:in	SpaceAfter=No
@@ -27723,7 +27723,7 @@
 7	last	last	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	time	time	NOUN	NN	Number=Sing	6	obl:unmarked	6:obl:unmarked|10:obl	TemporalNPAdjunct=Yes
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
-10	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	Cxn=rc-red-obl
+10	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	8	acl:relcl	8:acl:relcl	_
 11	there	there	ADV	RB	PronType=Dem	10	advmod	10:advmod	SpaceAfter=No
 12	.	.	PUNCT	.	_	6	punct	6:punct	_
 
@@ -27757,7 +27757,7 @@
 4	Sam	Sam	PROPN	NNP	Number=Sing	2	obl	2:obl:with|7:nsubj	_
 5	Mones	Mones	PROPN	NNP	Number=Sing	4	flat	4:flat	_
 6	who	who	PRON	WP	PronType=Rel	7	nsubj	4:ref	_
-7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-wh-nsubj
+7	took	take	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 8	great	great	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	care	care	NOUN	NN	Number=Sing	7	obj	7:obj	_
 10	of	of	ADP	IN	_	11	case	11:case	_
@@ -27836,7 +27836,7 @@
 11	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 12	Have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	14	aux	14:aux	_
 13	Ever	ever	ADV	RB	PronType=Ind	14	advmod	14:advmod	_
-14	Met	meet	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+14	Met	meet	VERB	VBN	Tense=Past|VerbForm=Part	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	10	punct	10:punct	_
 
 # sent_id = reviews-181696-0003
@@ -27912,7 +27912,7 @@
 # text = If you want the best for your child, don't hesitate in visiting this wornderful school.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	_
+3	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	12	advcl	12:advcl:if	CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	the	the	DET	DT	Definite=Def|PronType=Art	5	det	5:det	_
 5	best	good	ADJ	JJS	Degree=Sup	3	obj	3:obj	_
 6	for	for	ADP	IN	_	8	case	8:case	_
@@ -27922,7 +27922,7 @@
 10-11	don't	_	_	_	_	_	_	_	_
 10	do	do	AUX	VB	Mood=Imp|VerbForm=Fin	12	aux	12:aux	_
 11	n't	not	PART	RB	Polarity=Neg	12	advmod	12:advmod	_
-12	hesitate	hesitate	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	_
+12	hesitate	hesitate	VERB	VB	Mood=Imp|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=12:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 13	in	in	SCONJ	IN	_	14	mark	14:mark	_
 14	visiting	visit	VERB	VBG	Tense=Pres|VerbForm=Part	12	advcl	12:advcl:in	_
 15	this	this	DET	DT	Number=Sing|PronType=Dem	17	det	17:det	_
@@ -28093,7 +28093,7 @@
 6	the	the	DET	DT	Definite=Def|PronType=Art	7	det	7:det	_
 7	service	service	NOUN	NN	Number=Sing	4	nmod	4:nmod:about|9:obj	_
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
-9	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+9	received	receive	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	SpaceAfter=No
 10	.	.	PUNCT	.	_	2	punct	2:punct	SpaceAfter=No
 
 # sent_id = reviews-101864-0003
@@ -28162,7 +28162,7 @@
 6	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	9:nsubj	_
 7	VE	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|Typo=Yes|VerbForm=Fin	9	aux	9:aux	CorrectForm='VE
 8	BEEN	be	AUX	VBN	Tense=Past|VerbForm=Part	9	cop	9:cop	_
-9	TO	to	ADP	IN	_	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes|SpaceAfter=No
+9	TO	to	ADP	IN	_	5	acl:relcl	5:acl:relcl	Promoted=Yes|SpaceAfter=No
 10	!!!!!!	!!!!!!	PUNCT	.	_	5	punct	5:punct	_
 
 # newdoc id = reviews-270889
@@ -28383,9 +28383,9 @@
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
 2	know	know	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	0:root	_
 3	now	now	ADV	RB	PronType=Dem	2	advmod	2:advmod	_
-4	where	where	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
+4	where	where	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=6:Interrogative-WHInfo-Indirect.WHWord
 5	to	to	PART	TO	_	6	mark	6:mark	_
-6	get	get	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	_
+6	get	get	VERB	VB	VerbForm=Inf	2	ccomp	2:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=6:Interrogative-WHInfo-Indirect.Clause
 7	all	all	DET	DT	PronType=Tot	6	obj	6:obj	_
 8	of	of	ADP	IN	_	10	case	10:case	_
 9	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	10	nmod:poss	10:nmod:poss	_
@@ -28462,7 +28462,7 @@
 7	emergency	emergency	NOUN	NN	Number=Sing	8	compound	8:compound	_
 8	plumbers	plumber	NOUN	NNS	Number=Plur	5	obj	5:obj|10:nsubj	_
 9	who	who	PRON	WP	PronType=Rel	10	nsubj	8:ref	_
-10	visted	visit	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited|Cxn=rc-wh-nsubj
+10	visted	visit	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|Typo=Yes|VerbForm=Fin	8	acl:relcl	8:acl:relcl	CorrectForm=visited
 11	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	12	nmod:poss	12:nmod:poss	_
 12	shop	shop	NOUN	NN	Number=Sing	10	obj	10:obj	_
 13	in	in	ADP	IN	_	15	case	15:case	_
@@ -28506,7 +28506,7 @@
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	8:nsubj	_
 6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	8:aux	_
 7	ever	ever	ADV	RB	PronType=Ind	8	advmod	8:advmod	_
-8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
+8	had	have	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 9	in	in	ADP	IN	_	10	case	10:case	_
 10	Australia	Australia	PROPN	NNP	Number=Sing	8	obl	8:obl:in	SpaceAfter=No
 11	,	,	PUNCT	,	_	13	punct	13:punct	_
@@ -28665,7 +28665,7 @@
 11	anything	anything	PRON	NN	Number=Sing|PronType=Ind	9	obj	9:obj|14:obj	_
 12	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	14	nsubj	14:nsubj	_
 13	could	could	AUX	MD	VerbForm=Fin	14	aux	14:aux	_
-14	want	want	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-red-obj
+14	want	want	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
 15	in	in	ADP	IN	_	16	case	16:case	_
 16	terms	term	NOUN	NNS	Number=Plur	14	obl	14:obl:in	_
 17	of	of	ADP	IN	_	21	case	21:case	_
@@ -28735,11 +28735,11 @@
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
 3	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
+4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	CxnElt=7:Interrogative-WHInfo-Indirect.WHWord
 5-6	they're	_	_	_	_	_	_	_	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 6	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	SpaceAfter=No
+7	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=7:Interrogative-WHInfo-Indirect.Clause|SpaceAfter=No
 8	!	!	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-287360-0007
@@ -28828,7 +28828,7 @@
 4	other	other	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	utilities	utility	NOUN	NNS	Number=Plur	11	nsubj	9:obj|11:nsubj	_
 6	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj|9:nsubj:xsubj	_
-7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-red-obj_xcomp
+7	had	have	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	5	acl:relcl	5:acl:relcl	_
 8	to	to	PART	TO	_	9	mark	9:mark	_
 9	set	set	VERB	VB	VerbForm=Inf	7	xcomp	7:xcomp	_
 10	up	up	ADP	RP	_	9	compound:prt	9:compound:prt	_
@@ -28873,7 +28873,7 @@
 10	product	product	NOUN	NN	Number=Sing	13	nsubj	13:nsubj	_
 11	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	cop	13:cop	_
 12	in	in	ADP	IN	_	13	case	13:case	_
-13	stock	stock	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	SpaceAfter=No
+13	stock	stock	NOUN	NN	Number=Sing	7	ccomp	7:ccomp	Cxn=Interrogative-Polar-Indirect|CxnElt=13:Interrogative-Polar-Indirect.Clause|SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-343813-0004
@@ -28891,8 +28891,8 @@
 2	there	there	ADV	RB	PronType=Dem	1	advmod	1:advmod	_
 3	and	and	CCONJ	CC	_	5	cc	5:cc	_
 4	there	there	PRON	EX	_	5	expl	5:expl	_
-5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	_
-6	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	5	nsubj	5:nsubj	SpaceAfter=No
+5	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	conj	1:conj:and	Cxn=Existential-CopPred-ThereExpl
+6	nothing	nothing	PRON	NN	Number=Sing|PronType=Neg	5	nsubj	5:nsubj	CxnElt=5:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 7	.	.	PUNCT	.	_	1	punct	1:punct	_
 
 # sent_id = reviews-343813-0006
@@ -28943,7 +28943,7 @@
 18	every	every	DET	DT	PronType=Tot	19	det	19:det	_
 19	step	step	NOUN	NN	Number=Sing	16	obl	16:obl:for|21:obj	_
 20	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	21:nsubj	_
-21	take	take	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	19	acl:relcl	19:acl:relcl	CorrectForm=takes|Cxn=rc-red-obj
+21	take	take	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|Typo=Yes|VerbForm=Fin	19	acl:relcl	19:acl:relcl	CorrectForm=takes
 22	.	.	PUNCT	.	_	6	punct	6:punct	_
 
 # newdoc id = reviews-307170
@@ -29026,11 +29026,11 @@
 1	These	this	DET	DT	Number=Plur|PronType=Dem	2	det	2:det	_
 2	guys	guy	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj|9:nsubj	_
 3	know	know	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	_
-4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	_
+4	what	what	PRON	WP	PronType=Int	7	obj	7:obj	CxnElt=7:Interrogative-WHInfo-Indirect.WHWord
 5-6	they're	_	_	_	_	_	_	_	_
 5	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj	7:nsubj	_
 6	're	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	_
+7	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	3	ccomp	3:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=7:Interrogative-WHInfo-Indirect.Clause
 8	and	and	CCONJ	CC	_	9	cc	9:cc	_
 9	helped	help	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	3	conj	3:conj:and	_
 10	me	I	PRON	PRP	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obj	9:obj	_
@@ -29099,7 +29099,7 @@
 3	fresh	fresh	ADJ	JJ	Degree=Pos	4	amod	4:amod	_
 4	flowers	flower	NOUN	NNS	Number=Plur	2	obj	2:obj|6:nsubj	SpaceAfter=No
 5	,	,	PUNCT	,	_	6	punct	6:punct	_
-6	lasted	last	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	Cxn=rc-red-nsubj
+6	lasted	last	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	4:acl:relcl	_
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	long	long	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
 9	while	while	NOUN	NN	Number=Sing	6	obl:unmarked	6:obl:unmarked	TemporalNPAdjunct=Yes
@@ -29167,14 +29167,14 @@
 # text = If you check RecWarehouse.com, they don't list this as a location.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	check	check	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	check	check	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	RecWarehouse.com	RecWarehouse.com	PROPN	ADD	_	3	obj	3:obj	SpaceAfter=No
 5	,	,	PUNCT	,	_	3	punct	3:punct	_
 6	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	9	nsubj	9:nsubj	_
 7-8	don't	_	_	_	_	_	_	_	_
 7	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	n't	not	PART	RB	Polarity=Neg	9	advmod	9:advmod	_
-9	list	list	VERB	VB	VerbForm=Inf	0	root	0:root	_
+9	list	list	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 10	this	this	PRON	DT	Number=Sing|PronType=Dem	9	obj	9:obj	_
 11	as	as	ADP	IN	_	13	case	13:case	_
 12	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
@@ -29326,7 +29326,7 @@
 17	therapist	therapist	NOUN	NN	Number=Sing	13	obl	13:obl:with|20:obj	_
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
 19	regularly	regularly	ADV	RB	_	20	advmod	20:advmod	_
-20	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+20	see	see	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-045972-0003
@@ -29339,13 +29339,13 @@
 5	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	obj	4:obj|8:nsubj|10:nsubj:xsubj	_
 6	who	who	PRON	WP	PronType=Rel	8	nsubj	5:ref	_
 7	can	can	AUX	MD	VerbForm=Fin	8	aux	8:aux	_
-8	manage	manage	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+8	manage	manage	VERB	VB	VerbForm=Inf	5	acl:relcl	5:acl:relcl	_
 9	to	to	PART	TO	_	10	mark	10:mark	_
 10	do	do	VERB	VB	VerbForm=Inf	8	xcomp	8:xcomp	_
 11	what	what	PRON	WP	PronType=Rel	10	obj	10:obj|14:obj	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	14	nsubj	14:nsubj	_
 13	really	really	ADV	RB	_	14	advmod	14:advmod	_
-14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	Cxn=rc-free-obj|SpaceAfter=No
+14	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	acl:relcl	11:acl:relcl	SpaceAfter=No
 15	.	.	PUNCT	.	_	4	punct	4:punct	_
 
 # newdoc id = reviews-024306
@@ -29369,7 +29369,7 @@
 8	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	11:nsubj	_
 9	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	11	aux	11:aux	_
 10	ever	ever	ADV	RB	PronType=Ind	11	advmod	11:advmod	_
-11	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	Cxn=rc-red-obj
+11	tasted	taste	VERB	VBN	Tense=Past|VerbForm=Part	7	acl:relcl	7:acl:relcl	_
 12	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	17	nsubj	17:nsubj	_
 13	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	cop	17:cop	_
 14	possible	possibly	ADV	RB	Typo=Yes	17	advmod	17:advmod	CorrectForm=possibly
@@ -29380,7 +29380,7 @@
 18	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
 19	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	aux	21:aux	_
 20	ever	ever	ADV	RB	PronType=Ind	21	advmod	21:advmod	_
-21	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+21	eaten	eat	VERB	VBN	Tense=Past|VerbForm=Part	17	acl:relcl	17:acl:relcl	SpaceAfter=No
 22	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-024306-0003
@@ -29429,7 +29429,7 @@
 # sent_id = reviews-341750-0004
 # text = I felt as if I was in an over priced Olive Garden.
 1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	2:nsubj	_
-2	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	_
+2	felt	feel	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 3	as	as	SCONJ	IN	_	12	mark	12:mark	_
 4	if	if	SCONJ	IN	_	12	mark	12:mark	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
@@ -29439,7 +29439,7 @@
 9	over	overpriced	ADJ	AFX	Degree=Pos|Typo=Yes	12	amod	12:amod	_
 10	priced	_	X	JJ	_	9	goeswith	9:goeswith	_
 11	Olive	Olive	PROPN	NNP	Number=Sing	12	compound	12:compound	_
-12	Garden	Garden	PROPN	NNP	Number=Sing	2	advcl	2:advcl:in	SpaceAfter=No
+12	Garden	Garden	PROPN	NNP	Number=Sing	2	advcl	2:advcl:in	CxnElt=2:Conditional-UnspecifiedEpistemic-NoInversion.Protasis|SpaceAfter=No
 13	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-341750-0005
@@ -29838,7 +29838,7 @@
 14	that	that	PRON	WDT	PronType=Rel	17	obj	13:ref	_
 15	Farrell	Farrell	PROPN	NNP	Number=Sing	16	compound	16:compound	_
 16	Electric	Electric	PROPN	NNP	Number=Sing	17	nsubj	17:nsubj	_
-17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-that-obj|SpaceAfter=No
+17	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	SpaceAfter=No
 18	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # newdoc id = reviews-335490
@@ -29850,7 +29850,7 @@
 3	i	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	6:nsubj	_
 4	have	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	6:aux	_
 5	been	be	AUX	VBN	Tense=Past|VerbForm=Part	6	cop	6:cop	_
-6	to	to	ADP	IN	_	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl-pstrand|Promoted=Yes
+6	to	to	ADP	IN	_	2	acl:relcl	2:acl:relcl	Promoted=Yes
 
 # sent_id = reviews-335490-0002
 # newpar id = reviews-335490-p0002
@@ -29989,13 +29989,13 @@
 15	where	where	ADV	WRB	PronType=Rel	18	advmod	11:ref	_
 16	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	18:nsubj	_
 17	can	can	AUX	MD	VerbForm=Fin	18	aux	18:aux	_
-18	delete	delete	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	Cxn=rc-wh-obl
+18	delete	delete	VERB	VB	VerbForm=Inf	11	acl:relcl	11:acl:relcl	_
 19	songs	song	NOUN	NNS	Number=Plur	18	obj	18:obj|23:obj	_
 20	he	he	PRON	PRP	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	23:nsubj	_
 21-22	doesn't	_	_	_	_	_	_	_	_
 21	does	do	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	n't	not	PART	RB	Polarity=Neg	23	advmod	23:advmod	_
-23	like	like	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+23	like	like	VERB	VB	VerbForm=Inf	19	acl:relcl	19:acl:relcl	SpaceAfter=No
 24	,	,	PUNCT	,	_	27	punct	27:punct	_
 25	and	and	CCONJ	CC	_	27	cc	27:cc	_
 26	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	27	nsubj	27:nsubj|29:nsubj:xsubj	_
@@ -30034,7 +30034,7 @@
 8	undergone	undergo	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	7	acl	7:acl	_
 9	here	here	ADV	RB	PronType=Dem	8	advmod	8:advmod	_
 10	which	which	PRON	WDT	PronType=Rel	11	nsubj	7:ref	_
-11	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+11	made	make	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	acl:relcl	7:acl:relcl	_
 12	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
 13	life	life	NOUN	NN	Number=Sing	11	obj	11:obj|14:nsubj:xsubj	_
 14	step	step	VERB	VB	VerbForm=Inf	11	xcomp	11:xcomp	_
@@ -30244,7 +30244,7 @@
 7	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	10	nsubj	10:nsubj	_
 8	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	10	aux	10:aux	_
 9	ever	ever	ADV	RB	PronType=Ind	10	advmod	10:advmod	_
-10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obj
+10	had	have	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 11	and	and	CCONJ	CC	_	15	cc	15:cc	_
 12	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	15	nsubj	15:nsubj	_
 13	would	would	AUX	MD	VerbForm=Fin	15	aux	15:aux	_
@@ -30288,7 +30288,7 @@
 5	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	8	nsubj	8:nsubj	_
 6	even	even	ADV	RB	_	8	advmod	8:advmod	_
 7	never	never	ADV	RB	PronType=Neg	8	advmod	8:advmod	_
-8	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obj
+8	seen	see	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 9	before	before	ADV	RB	_	8	advmod	8:advmod	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
 
@@ -30620,7 +30620,7 @@
 2	the	the	DET	DT	Definite=Def|PronType=Art	3	det	3:det	_
 3	lady	lady	NOUN	NN	Number=Sing	0	root	0:root|5:nsubj	_
 4	who	who	PRON	WP	PronType=Rel	5	nsubj	3:ref	_
-5	operates	operate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	Cxn=rc-wh-nsubj
+5	operates	operate	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	acl:relcl	3:acl:relcl	_
 6	the	the	DET	DT	Definite=Def|PronType=Art	8	det	8:det	_
 7	front	front	ADJ	JJ	Degree=Pos	8	amod	8:amod	_
 8	register	register	NOUN	NN	Number=Sing	5	obj	5:obj	SpaceAfter=No
@@ -30662,13 +30662,13 @@
 # text = If you enjoy amazing things, you must go to World's Finest Donair.
 1	If	if	SCONJ	IN	_	3	mark	3:mark	_
 2	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	3	nsubj	3:nsubj	_
-3	enjoy	enjoy	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	_
+3	enjoy	enjoy	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	9	advcl	9:advcl:if	CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 4	amazing	amazing	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
 5	things	thing	NOUN	NNS	Number=Plur	3	obj	3:obj	SpaceAfter=No
 6	,	,	PUNCT	,	_	3	punct	3:punct	_
 7	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	9	nsubj	9:nsubj	_
 8	must	must	AUX	MD	VerbForm=Fin	9	aux	9:aux	_
-9	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	_
+9	go	go	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=9:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 10	to	to	ADP	IN	_	14	case	14:case	_
 11-12	World's	_	_	_	_	_	_	_	_
 11	World	World	PROPN	NNP	Number=Sing	14	nmod:poss	14:nmod:poss	_
@@ -30803,14 +30803,14 @@
 19	business	business	NOUN	NN	Number=Sing	17	iobj	17:iobj	_
 20	something	something	PRON	NN	Number=Sing|PronType=Ind	17	obj	17:obj|22:nsubj	_
 21	that	that	PRON	WDT	PronType=Rel	22	nsubj	20:ref	_
-22	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	acl:relcl	20:acl:relcl	Cxn=rc-that-nsubj
+22	has	have	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	acl:relcl	20:acl:relcl	_
 23	the	the	DET	DT	Definite=Def|PronType=Art	24	det	24:det	_
 24	initials	initial	NOUN	NNS	Number=Plur	22	obj	22:obj	_
 25	KKK	KKK	PROPN	NNP	Number=Sing	24	appos	24:appos	SpaceAfter=No
 26	....	....	PUNCT	,	_	27	punct	27:punct	SpaceAfter=No
-27	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	_
+27	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	6:parataxis	Cxn=Existential-CopPred-ThereExpl
 28	there	there	PRON	EX	_	27	expl	27:expl	_
-29	something	something	PRON	NN	Number=Sing|PronType=Ind	27	nsubj	27:nsubj	_
+29	something	something	PRON	NN	Number=Sing|PronType=Ind	27	nsubj	27:nsubj	CxnElt=27:Existential-CopPred-ThereExpl.Pivot
 30	behind	behind	ADP	IN	_	32	case	32:case	_
 31	the	the	DET	DT	Definite=Def|PronType=Art	32	det	32:det	_
 32	scenes	scene	NOUN	NNS	Number=Plur	29	nmod	29:nmod:behind	_
@@ -30890,7 +30890,7 @@
 14	exactly	exactly	ADV	RB	_	15	advmod	15:advmod	_
 15	what	what	PRON	WP	PronType=Rel	12	obj	12:obj|17:obj	_
 16	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	17	nsubj	17:nsubj	_
-17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	Cxn=rc-free-obj
+17	want	want	VERB	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	15	acl:relcl	15:acl:relcl	_
 18	and	and	CCONJ	CC	_	22	cc	22:cc	_
 19	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	22:nsubj	_
 20	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	cop	22:cop	_
@@ -30955,7 +30955,7 @@
 9	what	what	PRON	WP	PronType=Rel	8	obj	8:obj|12:obj	_
 10	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
 11	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
-12	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	9	acl:relcl	9:acl:relcl	Cxn=rc-free-obj
+12	doing	do	VERB	VBG	Tense=Pres|VerbForm=Part	9	acl:relcl	9:acl:relcl	_
 13	and	and	CCONJ	CC	_	15	cc	15:cc	_
 14	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	15:nsubj	_
 15	shows	show	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	conj	6:conj:and	SpaceAfter=No
@@ -31051,7 +31051,7 @@
 13	extra	extra	ADJ	JJ	Degree=Pos	14	amod	14:amod	_
 14	mile	mile	NOUN	NN	Number=Sing	10	conj	7:obl:with|10:conj:and|16:obj	_
 15	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	16	nsubj	16:nsubj	_
-16	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	Cxn=rc-red-obj
+16	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=2|Tense=Past|VerbForm=Fin	14	acl:relcl	14:acl:relcl	_
 17	to	to	PART	TO	_	18	mark	18:mark	_
 18	get	get	VERB	VB	VerbForm=Inf	16	advcl	16:advcl:to	_
 19	out	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs|Typo=Yes	20	nmod:poss	20:nmod:poss	CorrectForm=our
@@ -31064,10 +31064,10 @@
 26	be	be	AUX	VB	VerbForm=Inf	29	cop	29:cop	_
 27	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	29	nmod:poss	29:nmod:poss	_
 28	first	first	ADJ	JJ	Degree=Pos|NumForm=Word|NumType=Ord	29	amod	29:amod	_
-29	call	call	NOUN	NN	Number=Sing	7	parataxis	7:parataxis	_
+29	call	call	NOUN	NN	Number=Sing	7	parataxis	7:parataxis	Cxn=Conditional-UnspecifiedEpistemic-NoInversion|CxnElt=29:Conditional-UnspecifiedEpistemic-NoInversion.Apodosis
 30	if	if	SCONJ	IN	_	32	mark	32:mark	_
 31	anything	anything	PRON	NN	Number=Sing|PronType=Ind	32	nsubj	32:nsubj	_
-32	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	advcl	29:advcl:if	_
+32	happens	happen	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	advcl	29:advcl:if	CxnElt=29:Conditional-UnspecifiedEpistemic-NoInversion.Protasis
 33	again	again	ADV	RB	_	32	advmod	32:advmod	_
 34	and	and	CCONJ	CC	_	37	cc	37:cc	_
 35	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	37	nsubj	37:nsubj	_
@@ -31201,9 +31201,9 @@
 14	so	so	SCONJ	IN	ExtPos=SCONJ	17	mark	17:mark	_
 15	that	that	SCONJ	IN	_	14	fixed	14:fixed	_
 16	there	there	PRON	EX	_	17	expl	17:expl	_
-17	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so_that	_
+17	were	be	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	advcl	2:advcl:so_that	Cxn=Existential-CopPred-ThereExpl
 18	no	no	DET	DT	PronType=Neg	19	det	19:det	_
-19	surprises	surprise	NOUN	NNS	Number=Plur	17	nsubj	17:nsubj	SpaceAfter=No
+19	surprises	surprise	NOUN	NNS	Number=Plur	17	nsubj	17:nsubj	CxnElt=17:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 20	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-354474-0004
@@ -31265,10 +31265,10 @@
 4	to	to	ADP	IN	_	5	case	5:case	_
 5	what	what	PRON	WP	PronType=Rel	3	obl	3:obl:to|12:obj	_
 6	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	expl	7:expl	_
-7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Cxn=rc-free-pred-auxstrand|Promoted=Yes
+7	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	acl:relcl	5:acl:relcl	Promoted=Yes
 8	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	10	nsubj	10:nsubj|12:nsubj:xsubj	_
 9	would	would	AUX	MD	VerbForm=Fin	10	aux	10:aux	_
-10	like	like	VERB	VB	VerbForm=Inf	5	advcl:relcl	5:advcl:relcl	Cxn=rc-free-obj_xcomp
+10	like	like	VERB	VB	VerbForm=Inf	5	advcl:relcl	5:advcl:relcl	_
 11	to	to	PART	TO	_	12	mark	12:mark	_
 12	achieve	achieve	VERB	VB	VerbForm=Inf	10	xcomp	10:xcomp	SpaceAfter=No
 13	,	,	PUNCT	,	_	18	punct	18:punct	_
@@ -31342,7 +31342,7 @@
 38	sometimes	sometimes	ADV	RB	PronType=Ind	41	advmod	41:advmod	_
 39	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	41	aux:pass	41:aux:pass	_
 40	not	not	PART	RB	Polarity=Neg	41	advmod	41:advmod	_
-41	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	35	acl:relcl	35:acl:relcl	Cxn=rc-wh-nsubj:pass|SpaceAfter=No
+41	needed	need	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	35	acl:relcl	35:acl:relcl	SpaceAfter=No
 42	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = reviews-309258-0003
@@ -31416,7 +31416,7 @@
 5-6	I've	_	_	_	_	_	_	_	_
 5	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	7	nsubj	7:nsubj	_
 6	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	aux	7:aux	_
-7	come	come	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	Cxn=rc-red-obl-pstrand
+7	come	come	VERB	VBN	Tense=Past|VerbForm=Part	4	acl:relcl	4:acl:relcl	_
 8	across	across	ADP	IN	_	7	obl	7:obl	Promoted=Yes
 9	for	for	ADP	IN	_	11	case	11:case	_
 10	long	long	ADJ	JJ	Degree=Pos	11	amod	11:amod	_
@@ -31447,7 +31447,7 @@
 9	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	12:nsubj	_
 10	've	have	AUX	VBP	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	aux	12:aux	_
 11	ever	ever	ADV	RB	PronType=Ind	12	advmod	12:advmod	_
-12	come	come	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	Cxn=rc-red-obl-pstrand
+12	come	come	VERB	VBN	Tense=Past|VerbForm=Part	6	acl:relcl	6:acl:relcl	_
 13	across	across	ADP	IN	_	12	obl	12:obl	Promoted=Yes
 14	in	in	ADP	IN	_	17	case	17:case	_
 15	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	17	nmod:poss	17:nmod:poss	_
@@ -31480,7 +31480,7 @@
 10	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	13:cop	_
 11	a	a	DET	DT	Definite=Ind|PronType=Art	13	det	13:det	_
 12	good	good	ADJ	JJ	Degree=Pos	13	amod	13:amod	_
-13	indication	indication	NOUN	NN	Number=Sing	5	advcl:relcl	5:advcl:relcl	Cxn=rc-wh-csubj
+13	indication	indication	NOUN	NN	Number=Sing	5	advcl:relcl	5:advcl:relcl	_
 14	of	of	ADP	IN	_	16	case	16:case	_
 15	her	her	PRON	PRP$	Case=Gen|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	16	nmod:poss	16:nmod:poss	_
 16	talent	talent	NOUN	NN	Number=Sing	13	nmod	13:nmod:of	SpaceAfter=No
@@ -31580,7 +31580,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	price	price	NOUN	NN	Number=Sing	6	nsubj	4:obj|6:nsubj	_
 3	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	4:nsubj	_
-4	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obj
+4	gave	give	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 6	good	good	ADJ	JJ	Degree=Pos	0	root	0:root	_
 7	so	so	ADV	RB	_	9	mark	9:mark	_
@@ -31599,10 +31599,10 @@
 3	showed	show	VERB	VBD	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	advcl	6:advcl:after	_
 4	up	up	ADP	RP	_	3	compound:prt	3:compound:prt	_
 5	there	there	PRON	EX	_	6	expl	6:expl	_
-6	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
+6	was	be	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 7	a	a	DET	DT	Definite=Ind|PronType=Art	9	det	9:det	_
 8	little	little	ADJ	JJ	Degree=Pos	9	amod	9:amod	_
-9	trouble	trouble	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	_
+9	trouble	trouble	NOUN	NN	Number=Sing	6	nsubj	6:nsubj	CxnElt=6:Existential-CopPred-ThereExpl.Pivot
 10	to	to	PART	TO	_	11	mark	11:mark	_
 11	get	get	VERB	VB	VerbForm=Inf	9	acl	9:acl:to	_
 12	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	13	nmod:poss	13:nmod:poss	_
@@ -31663,8 +31663,8 @@
 2	seemed	seem	VERB	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	0:root	_
 3	to	to	PART	TO	_	4	mark	4:mark	_
 4	understand	understand	VERB	VB	VerbForm=Inf	2	xcomp	2:xcomp	_
-5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	_
-6	important	important	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	_
+5	how	how	ADV	WRB	PronType=Int	6	advmod	6:advmod	CxnElt=6:Interrogative-WHInfo-Indirect.WHWord
+6	important	important	ADJ	JJ	Degree=Pos	4	ccomp	4:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=6:Interrogative-WHInfo-Indirect.Clause
 7	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	expl	6:expl	_
 8	was	be	AUX	VBD	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	6:cop	_
 9	for	for	SCONJ	IN	_	12	mark	12:mark	_
@@ -31960,7 +31960,7 @@
 1	The	the	DET	DT	Definite=Def|PronType=Art	2	det	2:det	_
 2	team	team	NOUN	NN	Number=Sing	7	nsubj	4:nsubj|7:nsubj|9:nsubj|12:nsubj|15:nsubj	_
 3	who	who	PRON	WP	PronType=Rel	4	nsubj	2:ref	_
-4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-wh-nsubj
+4	work	work	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	there	there	ADV	RB	PronType=Dem	4	advmod	4:advmod	_
 6	are	be	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	7:cop	_
 7	helpfull	helpful	ADJ	JJ	Degree=Pos|Typo=Yes	0	root	0:root	CorrectForm=helpful|SpaceAfter=No
@@ -32110,7 +32110,7 @@
 11	clueless	clueless	ADJ	JJ	Degree=Pos	3	conj	3:conj:but	_
 12	about	about	ADP	IN	_	13	case	13:case	_
 13	what	what	PRON	WP	PronType=Rel	11	obl	11:obl:about|14:nsubj	_
-14	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	Cxn=rc-free-nsubj
+14	makes	make	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	acl:relcl	13:acl:relcl	_
 15	a	a	DET	DT	Definite=Ind|PronType=Art	20	det	20:det	_
 16	good	good	ADJ	JJ	Degree=Pos	20	amod	20:amod	_
 17	dining	dining	NOUN	NN	Number=Sing	20	compound	20:compound	_
@@ -32192,7 +32192,7 @@
 8	who	who	PRON	WP	PronType=Rel	11	nsubj	7:ref	_
 9	is	be	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	11:cop	_
 10	in	in	ADP	IN	_	11	case	11:case	_
-11	need	need	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	Cxn=rc-wh-nsubj
+11	need	need	NOUN	NN	Number=Sing	7	acl:relcl	7:acl:relcl	_
 12	of	of	ADP	IN	_	15	case	15:case	_
 13	a	a	DET	DT	Definite=Ind|PronType=Art	15	det	15:det	_
 14	regular	regular	ADJ	JJ	Degree=Pos	15	amod	15:amod	_
@@ -32234,15 +32234,15 @@
 16	family	family	NOUN	NN	Number=Sing	17	compound	17:compound	_
 17	members	member	NOUN	NNS	Number=Plur	13	obl	13:obl:to|19:nsubj|23:nsubj	_
 18	that	that	PRON	WDT	PronType=Rel	19	nsubj	17:ref	_
-19	visit	visit	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-that-nsubj
+19	visit	visit	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 20	and	and	CCONJ	CC	_	23	cc	23:cc	_
 21-22	don't	_	_	_	_	_	_	_	_
 21	do	do	AUX	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	aux	23:aux	_
 22	n't	not	PART	RB	Polarity=Neg	23	advmod	23:advmod	_
 23	know	know	VERB	VB	VerbForm=Inf	19	conj	17:acl:relcl|19:conj:and	_
-24	where	where	ADV	WRB	PronType=Int	26	advmod	26:advmod	_
+24	where	where	ADV	WRB	PronType=Int	26	advmod	26:advmod	CxnElt=26:Interrogative-WHInfo-Indirect.WHWord
 25	to	to	PART	TO	_	26	mark	26:mark	_
-26	start	start	VERB	VB	VerbForm=Inf	23	ccomp	23:ccomp	_
+26	start	start	VERB	VB	VerbForm=Inf	23	ccomp	23:ccomp	Cxn=Interrogative-WHInfo-Indirect|CxnElt=26:Interrogative-WHInfo-Indirect.Clause
 27	when	when	ADV	WRB	PronType=Int	29	advmod	29:advmod	_
 28	it	it	PRON	PRP	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	29	nsubj	29:nsubj	_
 29	comes	come	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	advcl	26:advcl:when	_
@@ -32265,7 +32265,7 @@
 9	find	find	VERB	VB	VerbForm=Inf	3	conj	3:conj:and	_
 10	anything	anything	PRON	NN	Number=Sing|PronType=Ind	9	obj	9:obj|12:obj	_
 11	they	they	PRON	PRP	Case=Nom|Number=Plur|Person=3|PronType=Prs	12	nsubj	12:nsubj	_
-12	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	Cxn=rc-red-obj|SpaceAfter=No
+12	need	need	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	acl:relcl	10:acl:relcl	SpaceAfter=No
 13	.	.	PUNCT	.	_	3	punct	3:punct	_
 
 # sent_id = reviews-235190-0004
@@ -32314,14 +32314,14 @@
 10	photographers	photographer	NOUN	NNS	Number=Plur	7	obj	7:obj|13:nsubj	_
 11	that	that	PRON	WDT	PronType=Rel	13	nsubj	10:ref	_
 12	would	would	AUX	MD	VerbForm=Fin	13	aux	13:aux	_
-13	represent	represent	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	Cxn=rc-that-nsubj-auxstrand
+13	represent	represent	VERB	VB	VerbForm=Inf	10	acl:relcl	10:acl:relcl	_
 14	our	our	PRON	PRP$	Case=Gen|Number=Plur|Person=1|Poss=Yes|PronType=Prs	15	nmod:poss	15:nmod:poss	_
 15	firm	firm	NOUN	NN	Number=Sing	13	obj	13:obj	_
 16	in	in	ADP	IN	_	18	case	18:case	_
 17	the	the	DET	DT	Definite=Def|PronType=Art	18	det	18:det	_
 18	light	light	NOUN	NN	Number=Sing	13	obl	13:obl:in|20:obl	_
 19	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	20:nsubj	_
-20	wished	wish	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	Cxn=rc-red-obl-auxstrand
+20	wished	wish	VERB	VBD	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	18	acl:relcl	18:acl:relcl	_
 21	to	to	PART	TO	_	20	xcomp	20:xcomp	Promoted=Yes
 22	and	and	CCONJ	CC	_	27	cc	27:cc	_
 23	Michael	Michael	PROPN	NNP	Number=Sing	27	nsubj	27:nsubj	_
@@ -32408,11 +32408,11 @@
 # text = There must be a better mexican place in Rockland.
 1	There	there	PRON	EX	_	3	expl	3:expl	_
 2	must	must	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	a	a	DET	DT	Definite=Ind|PronType=Art	7	det	7:det	_
 5	better	good	ADJ	JJR	Degree=Cmp	7	amod	7:amod	_
 6	mexican	Mexican	ADJ	JJ	Degree=Pos	7	amod	7:amod	_
-7	place	place	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	_
+7	place	place	NOUN	NN	Number=Sing	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 8	in	in	ADP	IN	_	9	case	9:case	_
 9	Rockland	Rockland	PROPN	NNP	Number=Sing	3	obl	3:obl:in	SpaceAfter=No
 10	.	.	PUNCT	.	_	3	punct	3:punct	_
@@ -32438,7 +32438,7 @@
 1	Last	last	ADJ	JJ	Degree=Pos	2	amod	2:amod	_
 2	time	time	NOUN	NN	Number=Sing	10	obl:unmarked	4:obl|10:obl:unmarked	TemporalNPAdjunct=Yes
 3	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	4:nsubj	_
-4	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	Cxn=rc-red-obl
+4	went	go	VERB	VBD	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	2	acl:relcl	2:acl:relcl	_
 5	however	however	ADV	RB	_	10	advmod	10:advmod	SpaceAfter=No
 6	,	,	PUNCT	,	_	5	punct	5:punct	_
 7	my	my	PRON	PRP$	Case=Gen|Number=Sing|Person=1|Poss=Yes|PronType=Prs	8	nmod:poss	8:nmod:poss	_
@@ -32499,14 +32499,14 @@
 # text = there might be bigger and more well known bagel places in the area but Family Bagels are nice people, small shop and incredibly friendly.
 1	there	there	PRON	EX	_	3	expl	3:expl	_
 2	might	might	AUX	MD	VerbForm=Fin	3	aux	3:aux	_
-3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	_
+3	be	be	VERB	VB	VerbForm=Inf	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
 4	bigger	big	ADJ	JJR	Degree=Cmp	10	amod	10:amod	_
 5	and	and	CCONJ	CC	_	8	cc	8:cc	_
 6	more	more	ADV	RBR	Degree=Cmp	8	advmod	8:advmod	_
 7	well	well	ADV	RB	Degree=Pos	8	advmod	8:advmod	_
 8	known	know	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	4	conj	4:conj:and|10:amod	_
 9	bagel	bagel	NOUN	NN	Number=Sing	10	compound	10:compound	_
-10	places	place	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	_
+10	places	place	NOUN	NNS	Number=Plur	3	nsubj	3:nsubj	CxnElt=3:Existential-CopPred-ThereExpl.Pivot
 11	in	in	ADP	IN	_	13	case	13:case	_
 12	the	the	DET	DT	Definite=Def|PronType=Art	13	det	13:det	_
 13	area	area	NOUN	NN	Number=Sing	10	nmod	10:nmod:in	_
@@ -32546,7 +32546,7 @@
 18	and	and	CCONJ	CC	_	19	cc	19:cc	_
 19	service	service	NOUN	NN	Number=Sing	17	conj	14:obl:with|17:conj:and	_
 20	we	we	PRON	PRP	Case=Nom|Number=Plur|Person=1|PronType=Prs	21	nsubj	21:nsubj	_
-21	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	Cxn=rc-red-obj
+21	get	get	VERB	VBP	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	17	acl:relcl	17:acl:relcl	_
 22	at	at	ADP	IN	_	24	case	24:case	_
 23	Family	Family	PROPN	NNP	Number=Sing	24	compound	24:compound	_
 24	Bagels	Bagel	PROPN	NNPS	Number=Plur	21	obl	21:obl:at	_
@@ -32807,7 +32807,7 @@
 6	which	which	PRON	WDT	PronType=Rel	9	nsubj	5:ref	_
 7	has	have	AUX	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	9:aux	_
 8	significantly	significantly	ADV	RB	_	9	advmod	9:advmod	_
-9	reduced	reduce	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	Cxn=rc-wh-nsubj
+9	reduced	reduce	VERB	VBN	Tense=Past|VerbForm=Part	5	acl:relcl	5:acl:relcl	_
 10	the	the	DET	DT	Definite=Def|PronType=Art	11	det	11:det	_
 11	pain	pain	NOUN	NN	Number=Sing	9	obj	9:obj	_
 12	in	in	ADP	IN	_	14	case	14:case	_

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -9678,7 +9678,7 @@
 22	Street	Street	PROPN	NNP	Number=Sing	20	obj	20:obj	SpaceAfter=No
 23	,	,	PUNCT	,	_	20	punct	20:punct	CheckAttachment=22
 24	many	many	ADJ	JJ	Degree=Pos	6	parataxis	6:parataxis|24.1:nsubj	CheckAttachment=22|CheckReln=appos
-24.1	left	left	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	_	_	6:parataxis	CopyOf=6|wordform=__EMPTY__
+24.1	left	left	VERB	VBN	Tense=Past|VerbForm=Part|Voice=Pass	_	_	6:parataxis	CopyOf=6
 25	for	for	ADP	IN	_	26	case	26:case	_
 26	good	good	ADJ	JJ	Degree=Pos	24	orphan	24.1:obl:for	CheckReln=nmod|SpaceAfter=No
 27	.	.	PUNCT	.	_	6	punct	6:punct	_
@@ -23416,7 +23416,7 @@
 21	which	which	DET	WDT	PronType=Int	22	det	22:det	ManuallyChecked=PronType
 22	one	one	NOUN	NN	Number=Sing	24	obj	24:obj	_
 23	do	do	AUX	VBP	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	24	aux	24:aux	_
-23.1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	_	_	24:nsubj	wordform=__EMPTY__
+23.1	you	you	PRON	PRP	Case=Nom|Person=2|PronType=Prs	_	_	24:nsubj	
 24	like	like	VERB	VB	VerbForm=Inf	1	parataxis	1:parataxis	_
 25	the	the	DET	DT	Definite=Def|PronType=Art	26	det	26:det	_
 26	best	well	ADV	RBS	Degree=Sup	24	obl:unmarked	24:obl:unmarked	SpaceAfter=No

--- a/en_ewt-ud-test.conllu
+++ b/en_ewt-ud-test.conllu
@@ -7074,7 +7074,7 @@
 1	In	in	ADP	IN	_	2	case	2:case	_
 2	addition	addition	NOUN	NN	Number=Sing	4	obl	4:obl:in	SpaceAfter=No
 3	,	,	PUNCT	,	_	2	punct	2:punct	_
-4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+4	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=4:Interrogative-Polar-Direct.Clause
 5	there	there	PRON	EX	_	4	expl	4:expl	_
 6	someone	someone	PRON	NN	Number=Sing|PronType=Ind	4	nsubj	4:nsubj|9:nsubj	CxnElt=4:Existential-CopPred-ThereExpl.Pivot
 7	who	who	PRON	WP	PronType=Rel	9	nsubj	6:ref	_
@@ -12565,7 +12565,7 @@
 # sent_id = email-enronsent21_02-0006
 # newpar id = email-enronsent21_02-p0004
 # text = Are there any new developments in the trader world?
-1	Are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+1	Are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 4	new	new	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -19545,7 +19545,7 @@
 16	painting	painting	NOUN	NN	Number=Sing	19	nsubj	19:nsubj	CxnElt=19:Existential-CopPred-ThereExpl.Pivot|SpaceAfter=No
 17	/	/	SYM	,	_	18	cc	18:cc	SpaceAfter=No
 18	scupltures	sculpture	NOUN	NNS	Number=Plur|Typo=Yes	16	conj	16:conj|19:nsubj	CorrectForm=sculptures
-19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-WHInfo-Direct,Interrogative-WHInfo-Direct#2|CxnElt=19:Interrogative-WHInfo-Direct.Clause,19:Interrogative-WHInfo-Direct#2.Clause
+19	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct,Interrogative-WHInfo-Direct,Interrogative-WHInfo-Direct#2|CxnElt=19:Interrogative-Polar-Direct.Clause,19:Interrogative-WHInfo-Direct.Clause,19:Interrogative-WHInfo-Direct#2.Clause
 20	their	there	PRON	EX	Typo=Yes	19	expl	19:expl	CorrectForm=there
 21	and	and	CCONJ	CC	_	22	cc	22:cc	_
 22	who	who	PRON	WP	PronType=Int	19	conj	19:conj:and	CxnElt=19:Interrogative-WHInfo-Direct.WHWord
@@ -23212,7 +23212,7 @@
 # sent_id = answers-20111106015552AAj6rCu_ans-0001
 # newpar id = answers-20111106015552AAj6rCu_ans-p0001
 # text = is there any good places to get an ice-cream sundae from in Invercargill New Zealand?
-1	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl
+1	is	be	VERB	VBZ	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct|CxnElt=1:Interrogative-Polar-Direct.Clause
 2	there	there	PRON	EX	_	1	expl	1:expl	_
 3	any	any	DET	DT	PronType=Ind	5	det	5:det	_
 4	good	good	ADJ	JJ	Degree=Pos	5	amod	5:amod	_
@@ -23770,7 +23770,7 @@
 # newpar id = answers-20111107200249AAIyCy5_ans-p0001
 # text = why are there two statues of David?
 1	why	why	ADV	WRB	PronType=Int	2	advmod	2:advmod	CxnElt=2:Interrogative-WHInfo-Direct.WHWord
-2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-WHInfo-Direct.Clause
+2	are	be	VERB	VBP	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	0:root	Cxn=Existential-CopPred-ThereExpl,Interrogative-Polar-Direct,Interrogative-WHInfo-Direct|CxnElt=2:Interrogative-Polar-Direct.Clause,2:Interrogative-WHInfo-Direct.Clause
 3	there	there	PRON	EX	_	2	expl	2:expl	_
 4	two	two	NUM	CD	NumForm=Word|NumType=Card	5	nummod	5:nummod	_
 5	statues	statue	NOUN	NNS	Number=Plur	2	nsubj	2:nsubj	CxnElt=2:Existential-CopPred-ThereExpl.Pivot


### PR DESCRIPTION
Adds construction annotation in the MISC column, as described in https://aclanthology.org/2024.lrec-main.1471.pdf

Annotates NPN, Interrogatives, Conditionals, and Existentials, on the head of the respective phrase, plus construction elements.

For full specification and a subset of the treebank with only cxn-annotated sentences see here: https://github.com/LeonieWeissweiler/UCxn